### PR TITLE
#17 Fix Start Time for Cuy Arts & Culture

### DIFF
--- a/city_scrapers/spiders/cuya_arts_culture.py
+++ b/city_scrapers/spiders/cuya_arts_culture.py
@@ -112,7 +112,9 @@ class CuyaArtsCultureSpider(CityScrapersSpider):
             r"[a-zA-Z]{3,10} \d{1,2}, \d{4} at \d{1,2} [ap].m.", description
         )
         if dt_match:
-            return datetime.strptime(dt_match.group().replace(".",""), "%B %d, %Y at %I %p")
+            return datetime.strptime(
+                dt_match.group().replace(".", ""), "%B %d, %Y at %I %p"
+            )
         return
 
     def _parse_location(self, response):


### PR DESCRIPTION
## Fix Start Time for Cuyahoga County Arts & Culture Spider

Description in newer events are missing the full date & time. If not pulled from the description, attempt to pull from the heading in the page which is a slightly different format ("p.m." is used instead of "pm")

**Issue:** #17 

## Checklist

All checks are run in [GitHub Actions](https://github.com/features/actions). You'll be able to see the results of the checks at the bottom of the pull request page after it's been opened, and you can click on any of the specific checks listed to see the output of each step and debug failures.

- [ ] Tests are implemented
- [x] All tests are passing
- [x] Style checks run (see [documentation](https://cityscrapers.org/docs/development/) for more details)
- [x] Style checks are passing
- [x] Code comments from template removed

## Questions

* Existing tests pass. Happy to add one for the backup extract of date/time if needed. Saw this was marked urgent, and this is my first PR into this project, so wanted to get any other feedback as well.
