### PR TITLE
🕷️ Fix spider: Cayuga Board of Elections

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,15 @@ jobs:
       - name: Install Pipenv
         uses: dschep/install-pipenv-action@v1
 
+      - name: Cache Python dependencies
+        uses: actions/cache@v1
+        with:
+          path: .venv
+          key: pip-${{ matrix.python-version }}-${{ hashFiles('**/Pipfile.lock') }}
+          restore-keys: |
+            pip-${{ matrix.python-version }}-
+            pip-
+
       - name: Install dependencies
         run: pipenv sync --dev
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,15 +28,6 @@ jobs:
       - name: Install Pipenv
         uses: dschep/install-pipenv-action@v1
 
-      - name: Cache Python dependencies
-        uses: actions/cache@v1
-        with:
-          path: .venv
-          key: pip-${{ matrix.python-version }}-${{ hashFiles('**/Pipfile.lock') }}
-          restore-keys: |
-            pip-${{ matrix.python-version }}-
-            pip-
-
       - name: Install dependencies
         run: pipenv sync --dev
         env:

--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,6 @@ name = "pypi"
 
 [packages]
 scrapy = "*"
-scrapy-sentry = {ref = "v1", git = "https://github.com/City-Bureau/scrapy-sentry.git"}
 city-scrapers-core = {ref = "main", git = "https://github.com/City-Bureau/city-scrapers-core.git", extras = ["azure"]}
 scrapy-wayback-middleware = "*"
 python-dateutil = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8a20589388ef97f63e274771549b397f6605cd798779f0a7b7725897408717a4"
+            "sha256": "1e157fd63eb465196c0bb3d3bde6f6855830207b8ce66f83e203202595c0eb34"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -530,13 +530,6 @@
             "markers": "python_version >= '3.5'",
             "version": "==1.6.2"
         },
-        "raven": {
-            "hashes": [
-                "sha256:3fa6de6efa2493a7c827472e984ce9b020797d0da16f1db67197bcc23c8fae54",
-                "sha256:44a13f87670836e153951af9a3c80405d36b43097db869a36e92809673692ce4"
-            ],
-            "version": "==6.10.0"
-        },
         "referencing": {
             "hashes": [
                 "sha256:3c57da0513e9563eb7e203ebe9bb3a1b509b042016433bd1e45a2853466c3dd3",
@@ -673,10 +666,6 @@
             "index": "pypi",
             "markers": "python_version >= '3.8'",
             "version": "==2.11.0"
-        },
-        "scrapy-sentry": {
-            "git": "https://github.com/City-Bureau/scrapy-sentry.git",
-            "ref": "5da919f716d981e5c7926994f27676a285da39a3"
         },
         "scrapy-wayback-middleware": {
             "hashes": [

--- a/city_scrapers/settings/prod.py
+++ b/city_scrapers/settings/prod.py
@@ -18,7 +18,6 @@ SENTRY_DSN = os.getenv("SENTRY_DSN")
 
 EXTENSIONS = {
     "city_scrapers_core.extensions.AzureBlobStatusExtension": 100,
-    "scrapy_sentry.extensions.Errors": 10,
     "scrapy.extensions.closespider.CloseSpider": None,
 }
 

--- a/city_scrapers/spiders/cuya_elections.py
+++ b/city_scrapers/spiders/cuya_elections.py
@@ -52,7 +52,7 @@ class CuyaElectionsSpider(CityScrapersSpider):
 
     def _parse_title(self, item) -> str:
         """Parse or generate meeting title."""
-        title = item.css("h3.sf-event-title span::text").get()
+        title = item.css("h1.sf-event-title span::text").get()
         if title is None:
             return ""
         return title.strip()

--- a/city_scrapers/spiders/cuya_elections.py
+++ b/city_scrapers/spiders/cuya_elections.py
@@ -28,16 +28,10 @@ class CuyaElectionsSpider(CityScrapersSpider):
     }
 
     def parse(self, response):
-        """
-        `parse` should always `yield` Meeting items.
-
-        Change the `_parse_title`, `_parse_start`, etc methods to fit your scraping
-        needs.
-        """
-        # Go through each of the links from the calendar landing page and add them
-        #   to callbacks.
         for link in response.css("a.item-link::attr(href)"):
-            yield response.follow(link.get(), callback=self._parse_detail)
+            # The link path is incorrect, so we need to update it
+            correct_link = link.get().replace("boe-events/", "calendar/event-details/")
+            yield response.follow(correct_link, callback=self._parse_detail)
 
     def _parse_detail(self, item):
         meeting = Meeting(

--- a/city_scrapers/spiders/cuya_elections.py
+++ b/city_scrapers/spiders/cuya_elections.py
@@ -11,7 +11,7 @@ class CuyaElectionsSpider(CityScrapersSpider):
     name = "cuya_elections"
     agency = "Cuyahoga County Board of Elections"
     timezone = "America/Detroit"
-    start_urls = ["https://boe.cuyahogacounty.gov/calendar?it=Current%20Events&mpp=96"]
+    start_urls = ["https://boe.cuyahogacounty.gov/calendar?it=Current%20Events&categories=1%7CBoard%20Meeting"]
     _month_dict = {
         "January": 1,
         "February": 2,

--- a/city_scrapers/spiders/cuya_elections.py
+++ b/city_scrapers/spiders/cuya_elections.py
@@ -11,7 +11,7 @@ class CuyaElectionsSpider(CityScrapersSpider):
     agency = "Cuyahoga County Board of Elections"
     timezone = "America/Detroit"
     start_urls = [
-        "https://boe.cuyahogacounty.gov/calendar?it=Current%20Events&categories=1%7CBoard%20Meeting"  #noqa
+        "https://boe.cuyahogacounty.gov/calendar?it=Current%20Events&categories=1%7CBoard%20Meeting"  # noqa
     ]
     _month_dict = {
         "January": 1,

--- a/city_scrapers/spiders/cuya_elections.py
+++ b/city_scrapers/spiders/cuya_elections.py
@@ -1,6 +1,5 @@
 from datetime import datetime
-from typing import List, Tuple
-from urllib.parse import urljoin
+from typing import Tuple
 
 from city_scrapers_core.constants import BOARD
 from city_scrapers_core.items import Meeting
@@ -11,7 +10,9 @@ class CuyaElectionsSpider(CityScrapersSpider):
     name = "cuya_elections"
     agency = "Cuyahoga County Board of Elections"
     timezone = "America/Detroit"
-    start_urls = ["https://boe.cuyahogacounty.gov/calendar?it=Current%20Events&categories=1%7CBoard%20Meeting"]
+    start_urls = [
+        "https://boe.cuyahogacounty.gov/calendar?it=Current%20Events&categories=1%7CBoard%20Meeting"  #noqa
+    ]
     _month_dict = {
         "January": 1,
         "February": 2,

--- a/city_scrapers/spiders/cuya_elections.py
+++ b/city_scrapers/spiders/cuya_elections.py
@@ -26,6 +26,10 @@ class CuyaElectionsSpider(CityScrapersSpider):
         "November": 11,
         "December": 12,
     }
+    attachments_page = {
+        "title": "Board meeting documents",
+        "href": "https://boe.cuyahogacounty.gov/about-us/board-meeting-documents",
+    }
 
     def parse(self, response):
         for link in response.css("a.item-link::attr(href)"):
@@ -43,7 +47,7 @@ class CuyaElectionsSpider(CityScrapersSpider):
             all_day=self._parse_all_day(item),
             time_notes=self._parse_time_notes(item),
             location=self._parse_location(item),
-            links=self._parse_links(item),
+            links=[self.attachments_page],
             source=self._parse_source(item),
         )
         meeting["status"] = self._get_status(meeting)
@@ -122,19 +126,6 @@ class CuyaElectionsSpider(CityScrapersSpider):
             location["address"] = "see links and/or source"
 
         return location
-
-    def _parse_links(self, item) -> List:
-        """Parse or generate links."""
-        _parsed_links_titles = item.css(".sf_colsIn.col-lg-12 a::text")[9:]
-        _parsed_links_hrefs = item.css(".sf_colsIn.col-lg-12 a::attr(href)")[9:]
-        links: list = []
-        for i in range(len(_parsed_links_hrefs)):
-            temp = {
-                "title": _parsed_links_titles[i].get(),
-                "href": urljoin(item.url, _parsed_links_hrefs[i].get()),
-            }
-            links.append(temp)
-        return links
 
     def _parse_source(self, item):
         """Parse or generate source."""


### PR DESCRIPTION
## What's this PR do?

Fixes our Cuyahoga County Board of Elections spider (aka. `cuya_elections`), which broke due to page structure and URL changes.

## Why are we doing this? 

We want working scrapers, of course 🤖  The changes in this PR include changes to URLs and certain parsing methods. 

## Steps to manually test

After installing the project using `pipenv` (see Readme):

1. Activate the virtual environment:
```
pipenv shell
```
2. Run the spider:
```
scrapy crawl cuya_elections -O test_output.csv
```
3. Monitor the stdout and ensure that the crawl proceeds without raising any errors. Pay attention to the final status report from scrapy.

4. Inspect `test_output.csv` to ensure the data looks valid. I suggest opening a few of the URLs under the source column of test_output.csv and comparing the data for that row with what you see.

## Are there any smells or added technical debt to note?
- This scraper is now using a hardcoded link for the "links" field for each meeting. This agency has a special page where they locate all the attachments for every meeting. If we want to get fancy, we could scrape this page and combine the data with the final data. At present, given the number of broken scrapers that we need to fix, I think it's better to take this approach for now and move on. We can come back to this when time permits.