### PR TITLE
Fix spider: cuya_board_control

### DIFF
--- a/city_scrapers/spiders/cuya_board_control.py
+++ b/city_scrapers/spiders/cuya_board_control.py
@@ -1,21 +1,13 @@
 from city_scrapers_core.constants import BOARD
 from city_scrapers_core.spiders import CityScrapersSpider
 
-from city_scrapers.mixins import CuyaCountyMixin
+from city_scrapers.mixins import CuyaCountyMixin2
 
 
-class CuyaBoardControlSpider(CuyaCountyMixin, CityScrapersSpider):
+class CuyaBoardControlSpider(CuyaCountyMixin2, CityScrapersSpider):
     name = "cuya_board_control"
     agency = "Cuyahoga County Board of Control"
-    start_urls = ["http://bc.cuyahogacounty.us/en-US/Board-of-Control.aspx"]
+    start_urls = [
+        "https://cuyahogacounty.gov/boards-and-commissions/board-details/internal/board-of-control"  # noqa
+    ]
     classification = BOARD
-
-    def _parse_location(self, response):
-        loc_str = super()._parse_location(response)
-        if not loc_str:
-            return self.location
-        # Add conference room info to location name
-        loc = {**self.location}
-        loc_details = loc_str.split(", ")[-1]
-        loc["name"] += " " + loc_details
-        return loc

--- a/tests/files/cuya_board_control.html
+++ b/tests/files/cuya_board_control.html
@@ -1,384 +1,621 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head id="ctl00_Head2"><title>
-	Cuyahoga County Boards &amp; Commissions
-</title>
+<!DOCTYPE html> <html lang="en"> <head> <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" /> <meta name="viewport" content="width=device-width, initial-scale=1"> <meta charset="utf-8" /> <title>
+	Board of Control
+</title> <link rel="apple-touch-icon-precomposed" sizes="57x57" href="/assets/icons/apple-touch-icon-57x57.png" /> <link rel="apple-touch-icon-precomposed" sizes="114x114" href="/assets/icons/apple-touch-icon-114x114.png" /> <link rel="apple-touch-icon-precomposed" sizes="72x72" href="/assets/icons/apple-touch-icon-72x72.png" /> <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/assets/icons/apple-touch-icon-144x144.png" /> <link rel="apple-touch-icon-precomposed" sizes="60x60" href="/assets/icons/apple-touch-icon-60x60.png" /> <link rel="apple-touch-icon-precomposed" sizes="120x120" href="/assets/icons/apple-touch-icon-120x120.png" /> <link rel="apple-touch-icon-precomposed" sizes="76x76" href="/assets/icons/apple-touch-icon-76x76.png" /> <link rel="apple-touch-icon-precomposed" sizes="152x152" href="/assets/icons/apple-touch-icon-152x152.png" /> <link rel="icon" type="image/png" href="/assets/icons/favicon-196x196.png" sizes="196x196" /> <link rel="icon" type="image/png" href="/assets/icons/favicon-96x96.png" sizes="96x96" /> <link rel="icon" type="image/png" href="/assets/icons/favicon-32x32.png" sizes="32x32" /> <link rel="icon" type="image/png" href="/assets/icons/favicon-16x16.png" sizes="16x16" /> <link rel="icon" type="image/png" href="/assets/icons/favicon-128.png" sizes="128x128" /> <meta name="application-name" content="&nbsp;" /> <meta name="msapplication-TileColor" content="#FFFFFF" /> <meta name="msapplication-TileImage" content="mstile-144x144.png" /> <meta name="msapplication-square70x70logo" content="mstile-70x70.png" /> <meta name="msapplication-square150x150logo" content="mstile-150x150.png" /> <meta name="msapplication-wide310x150logo" content="mstile-310x150.png" /> <meta name="msapplication-square310x310logo" content="mstile-310x310.png" /> <!-- Google Fonts --> <link href="//fonts.googleapis.com/css?family=Oswald:300,500,700%7COpen+Sans:400,600,700" rel="stylesheet"> <!-- BootstrapCDN for FontsAwsome --> <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.2/css/all.min.css" /> <link href="/ResourcePackages/Bootstrap/assets/dist/css/main.min.css" rel="stylesheet" type="text/css" /><link href="/ResourcePackages/Bootstrap/assets/dist/css/CustomStyles.css" rel="stylesheet" type="text/css" /> <script type="text/javascript" src="https://www.googletagmanager.com/gtag/js?id=G-8C3KCV9D47"></script><script type="text/javascript">
 
-    <script type="text/javascript" src="/JavaScript/fader.js"></script>
-
-    <link id="ctl00_ResetCSS" rel="stylesheet" href="http://cdn.cuyahogacounty.us/CSS/Reset.css" type="text/css" /><link id="ctl00_AdaptersInvariantImportCSS" rel="stylesheet" href="/App_Themes/Default/CSS/Import.css" type="text/css" /><link id="ctl00_FeatureStylesCSS" rel="stylesheet" href="http://cdn.cuyahogacounty.us/CSS/FeatureStyles.css" type="text/css" /><link id="ctl00_TreeViewCSS" rel="stylesheet" href="http://cdn.cuyahogacounty.us/CSS/SimpleTreeView.css" type="text/css" /><link rel="stylesheet" href="/RadMenuMasterNav/Menu.RadMenuMasterNav.css" type="text/css" media="screen" /><link rel="stylesheet" href="/RadMenuSiteSpecificNav/Menu.RadMenuSiteSpecificNav.css" type="text/css" media="screen" />
-    <!--[if lt IE 7]>
-    <link id="ctl00_IEMenu6CSS" rel="stylesheet" href="/App_Themes/Default/CSS/BrowserSpecific/IEMenu6.css" type="text/css" />
-    <![endif]-->
-    <link rel="shortcut icon" href="/App_Themes/Default/img/icon.gif" type="image/png" /><link rel="icon" href="/App_Themes/Default/img/icon.gif" type="image/png" />
-    <script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-  ga('create', 'UA-11952497-44', 'auto');
-  ga('send', 'pageview');
-
-</script>
-<meta name="keywords" content="cuyahoga, county, boards, commissions, board, control" /><meta name="description" content="Board of Control" /><link href="/css/UserStyles.css" type="text/css" rel="Stylesheet" /><link href="/WebResource.axd?d=nVe01Lcjs-hTs9TECIlH3DmKzGRC2Gkm3S79rG6Rxqzz5YdiOfHWb5tceVj5-I2P38NOsRkGWpKfGW_HrZJF-XcVlxnVDy5MmmJt8YW5ylk6E4ZZHSzDRkQICbltUvzPq93jkA2&amp;t=634516086000000000" type="text/css" rel="stylesheet" class="Telerik_stylesheet" /></head>
-<body>
-    <form name="aspnetForm" method="post" action="BoardMeetingArchive.aspx?LanguageCD=en-US&amp;ItemKey=40905&amp;pb=y" id="aspnetForm">
-<div>
-<input type="hidden" name="__EVENTTARGET" id="__EVENTTARGET" value="" />
-<input type="hidden" name="__EVENTARGUMENT" id="__EVENTARGUMENT" value="" />
-<input type="hidden" name="__VIEWSTATE" id="__VIEWSTATE" value="/wEPDwULLTEzODY4NjQ3ODkPZBYCZg9kFgICAw9kFgoCBw8PFgQeCEltYWdlVXJsBRwvaW1nX2JjL2VuLVVTL3NpdGVfdGl0bGUuanBnHg1BbHRlcm5hdGVUZXh0BQ9DdXlhaG9nYSBDb3VudHlkZAIJD2QWAmYPZBYGAgEPDxYGHghDc3NDbGFzc2UeBVdpZHRoGwAAAAAA4GVAAQAAAB4EXyFTQgKCAhYEHgdvbkNsaWNrBTZnZXRFbGVtZW50QnlJZCgnY3RsMDBfU2l0ZVNlYXJjaDFfdHh0VGVybXMnKS52YWx1ZT0nJzseA2FsdGVkAgMPDxYIHgRUZXh0BQZTZWFyY2geDU9uQ2xpZW50Q2xpY2sFYGlmKGN0bDAwX1NpdGVTZWFyY2gxX3R4dFRlcm1zLnZhbHVlID09JycgfHwgY3RsMDBfU2l0ZVNlYXJjaDFfdHh0VGVybXMudmFsdWUgPT0nJykgcmV0dXJuIGZhbHNlOx8CBQxzZWFyY2hCdXR0b24fBAICZGQCBQ8PFgIfCAVgaWYoY3RsMDBfU2l0ZVNlYXJjaDFfdHh0VGVybXMudmFsdWUgPT0nJyB8fCBjdGwwMF9TaXRlU2VhcmNoMV90eHRUZXJtcy52YWx1ZSA9PScnKSByZXR1cm4gZmFsc2U7ZGQCDw9kFgJmDw8WAh8HBe4CPGEgY2xhc3M9J0JyZWFkQ3J1bWJMaW5rJyBocmVmPSdodHRwOi8vYmMuY3V5YWhvZ2Fjb3VudHkudXMvZW4tVVMvaG9tZS5hc3B4Jz5Ib21lPC9hPiZuYnNwOzxzcGFuIGNsYXNzPSdCcmVhZENydW1iU2VwYXJhdG9yJz4mZ3Q7PC9zcGFuPiZuYnNwOzxhIGNsYXNzPSdCcmVhZENydW1iTGluaycgaHJlZj0naHR0cDovL2JjLmN1eWFob2dhY291bnR5LnVzL2VuLVVTL0ludGVybmFsLUJvYXJkcy5hc3B4Jz5JbnRlcm5hbCBCb2FyZHM8L2E+Jm5ic3A7PHNwYW4gY2xhc3M9J0JyZWFkQ3J1bWJTZXBhcmF0b3InPiZndDs8L3NwYW4+Jm5ic3A7PHNwYW4gY2xhc3M9J0JyZWFkQ3J1bWJDdXJyZW50UGFnZSAnPkJvYXJkIG9mIENvbnRyb2w8L3NwYW4+ZGQCEQ9kFgYCAQ8WAh8HZWQCAw8WAh8HBcsTPGgyPkJvYXJkIG9mIENvbnRyb2w8L2gyPgo8YnIgLz4KPHN0cm9uZz4KQ09OVEFDVCBJTkZPUk1BVElPTjo8L3N0cm9uZz48YnIgLz4KQW5kcmlhIFJpY2hhcmRzb248YnIgLz4KMjA3OSBFLiA5dGggU3QsIENsZXZlbGFuZCwgT2hpbyA0NDExNQo8YnIgLz4KMjE2LTQ0My02ODUzCjxiciAvPgo8YSBocmVmPSJtYWlsdG86YXJpY2hhcmRzb25AY3V5YWhvZ2Fjb3VudHkudXMiPmFyaWNoYXJkc29uQGN1eWFob2dhY291bnR5LnVzPC9hPgo8YnIgLz4KPGJyIC8+CjxiciAvPgo8c3Ryb25nPldFQlNJVEU6PC9zdHJvbmc+PGJyIC8+CjxhIGhyZWY9Imh0dHA6Ly9iYy5jdXlhaG9nYWNvdW50eS51cy9lbi1VUy9Db3VuY2lsLUNvbW1pdHRlZS1Sb29tLUItTGl2ZS1TdHJlYW0uYXNweCIgdGFyZ2V0PSJfYmxhbmsiPmh0dHA6Ly9iYy5jdXlhaG9nYWNvdW50eS51cy9lbi1VUy9Db3VuY2lsLUNvbW1pdHRlZS1Sb29tLUItTGl2ZS1TdHJlYW0uYXNweDwvYT48YnIgLz4KPGJyIC8+CjxiciAvPgo8c3Ryb25nPgpERVNDUklQVElPTiBPRiBCT0FSRCBBTkQgUkVTUE9OU0lCSUxJVElFUzo8L3N0cm9uZz48YnIgLz4KVGhlIEJvYXJkIG9mIENvbnRyb2wgaGFzIGFwcHJvdmFsIGF1dGhvcml0eSBvdmVyIGFsbCBDb3VudHkgY29udHJhY3RzIGFuZCBwdXJjaGFzZXMgdmFsdWVkIGZyb20gJDUwMSB0byAkNTAwLDAwMCAoPGEgaHJlZj0iaHR0cDovL2NvZGUuY3V5YWhvZ2Fjb3VudHkudXMvZW4tVVMvQ0NSQy1UMkMyMDUtQm9hcmRzLmFzcHgiIHRhcmdldD0iX2JsYW5rIj5DdXlhaG9nYSBDb3VudHkgQ29kZSBUaXRsZSAyLCBTZWN0aW9uIDIwNS4wMTsgQ3V5YWhvZ2EgQ291bnR5IENvZGUgVGl0bGUgNSwgU2VjdGlvbiA1MDEuMDRCPC9hPikuIE1lbWJlcnNoaXAgaXMgY29tcHJpc2VkIG9mIHRoZSBDb3VudHkgRXhlY3V0aXZlLCBGaXNjYWwgT2ZmaWNlciwgRGlyZWN0b3Igb2YgUHVibGljIFdvcmtzLCBEaXJlY3RvciB0aGUgT2ZmaWNlIG9mIFByb2N1cmVtZW50IGFuZCBEaXZlcnNpdHksIGFuZCB0aHJlZSBtZW1iZXJzIG9mIENvdW50eSBDb3VuY2lsIGFwcG9pbnRlZCBieSB0aGUgQ291bmNpbCBQcmVzaWRlbnQuIFRoZSBCb2FyZCBvZiBDb250cm9sIG1lZXRzIHdlZWtseSB0byByZXZpZXcsIGRlbGliZXJhdGUsIGFuZCB2b3RlIG9uIHZhcmlvdXMgY29udHJhY3RzLCBhZ3JlZW1lbnRzLCBwdXJjaGFzZXMgYW5kIG90aGVyIGNvbnRyYWN0aW5nIGFuZCBwdXJjaGFzaW5nIG1hdHRlcnMgdW5kZXIgaXRzIGF1dGhvcml0eS4gQWxsIG1lZXRpbmdzIGFyZSBvcGVuIHRvIHRoZSBwdWJsaWMuCjxiciAvPgo8YnIgLz4KPGJyIC8+CjxzdHJvbmc+ClFVQUxJRklDQVRJT05TOjwvc3Ryb25nPjxiciAvPgpNZW1iZXJzaGlwIGlzIGNvbXByaXNlZCBvZiB0aGUgQ291bnR5IEV4ZWN1dGl2ZSwgRmlzY2FsIE9mZmljZXIsIERpcmVjdG9yIG9mIFB1YmxpYyBXb3JrcywgRGlyZWN0b3IgdGhlIE9mZmljZSBvZiBQcm9jdXJlbWVudCBhbmQgRGl2ZXJzaXR5LCBhbmQgdGhyZWUgbWVtYmVycyBvZiBDb3VudHkgQ291bmNpbCBhcHBvaW50ZWQgYnkgdGhlIENvdW5jaWwgUHJlc2lkZW50LiBNZW1iZXJzIHNlcnZlIGF0IHRoZSB2aXJ0dWUgb2YgdGhlaXIgcG9zaXRpb25zIHdpdGggQ3V5YWhvZ2EgQ291bnR5LjxiciAvPgo8YnIgLz4KPGJyIC8+CjxzdHJvbmc+TUVNQkVSU0hJUDo8L3N0cm9uZz48YnIgLz4KTi9BPGJyIC8+CjxiciAvPgo8YnIgLz4KPHN0cm9uZz5NRUVUSU5HIFNDSEVEVUxFL0FHRU5EQVM6PC9zdHJvbmc+PGJyIC8+Ck1lZXRpbmcgc2NoZWR1bGUgYW5kIGFnZW5kYXMgYmVsb3cuIDxhIGhyZWY9Ii9lbi1VUy9Db3VuY2lsLUNvbW1pdHRlZS1Sb29tLUItTGl2ZS1TdHJlYW0uYXNweCI+TWVldGluZ3MgY2FuIGJlIHZpZXdlZCBsaXZlIG9uIE1vbmRheXMgYXQgMTE6MDAgYW0uPC9hPjxiciAvPgo8YnIgLz4KPGJyIC8+CjxzdHJvbmc+CkJZTEFXUzo8L3N0cm9uZz48YnIgLz4KPGEgaHJlZj0iL3BkZl9iYy9lbi1VUy9SdWxlcyBfIEJvYXJkX29mX0NvbnRyb2wtdjAyMjkxNi5wZGYiPlZpZXcgcnVsZXM8L2E+PGJyIC8+CjxiciAvPgo8YnIgLz4KPHN0cm9uZz4KRU5BQkxJTkcgTEVHSVNMQVRJT046PC9zdHJvbmc+PGJyIC8+Cjx1bD4KICAgIDxsaT48YSBocmVmPSJodHRwOi8vY29kZS5jdXlhaG9nYWNvdW50eS51cy9wZGZfY29kZS9lbi1VUy9PMjAxNS0wMDA2LnBkZiIgdGFyZ2V0PSJfYmxhbmsiPkNvdW5jaWwgT3JkaW5hbmNlIE8yMDE1LTAwMDY8L2E+PC9saT4KICAgIDxsaT48YSBocmVmPSJodHRwOi8vY29kZS5jdXlhaG9nYWNvdW50eS51cy9lbi1VUy9DQ1JDLVQyQzIwNS1Cb2FyZHMuYXNweCIgdGFyZ2V0PSJfYmxhbmsiPkN1eWFob2dhIENvdW50eSBDb2RlIDIwNS4wMTwvYT48L2xpPgo8L3VsPgo8YnIgLz4KPHN0cm9uZz5PVEhFUiBVU0VGVUwgTElOS1M6PC9zdHJvbmc+PGJyIC8+Ck4vQQo8YnIgLz4KPGJyIC8+CjxiciAvPgo8c3Ryb25nPk1FRVRJTkcgU0NIRURVTEU6PC9zdHJvbmc+CjxiciAvPgo8YnIgLz5kAgUPZBYEAgEPDxYEHwIFDWdyaWRWaWV3U3R5bGUfBAICZBZKAgEPDxYEHwIFCG5ld3NJdGVtHwQCAmQWAmYPDxYCHwcFCTkvMTYvMjAxOWRkAgIPDxYEHwIFC25ld3NJdGVtQWx0HwQCAmQWAmYPDxYCHwcFCDkvOS8yMDE5ZGQCAw8PFgQfAgUIbmV3c0l0ZW0fBAICZBYCZg8PFgIfBwUIOS8zLzIwMTlkZAIEDw8WBB8CBQtuZXdzSXRlbUFsdB8EAgJkFgJmDw8WAh8HBQk4LzI2LzIwMTlkZAIFDw8WBB8CBQhuZXdzSXRlbR8EAgJkFgJmDw8WAh8HBQk4LzE5LzIwMTlkZAIGDw8WBB8CBQtuZXdzSXRlbUFsdB8EAgJkFgJmDw8WAh8HBQk4LzEyLzIwMTlkZAIHDw8WBB8CBQhuZXdzSXRlbR8EAgJkFgJmDw8WAh8HBQg4LzUvMjAxOWRkAggPDxYEHwIFC25ld3NJdGVtQWx0HwQCAmQWAmYPDxYCHwcFCTcvMjkvMjAxOWRkAgkPDxYEHwIFCG5ld3NJdGVtHwQCAmQWAmYPDxYCHwcFCTcvMjIvMjAxOWRkAgoPDxYEHwIFC25ld3NJdGVtQWx0HwQCAmQWAmYPDxYCHwcFCTcvMTUvMjAxOWRkAgsPDxYEHwIFCG5ld3NJdGVtHwQCAmQWAmYPDxYCHwcFCDcvOC8yMDE5ZGQCDA8PFgQfAgULbmV3c0l0ZW1BbHQfBAICZBYCZg8PFgIfBwUINy8xLzIwMTlkZAINDw8WBB8CBQhuZXdzSXRlbR8EAgJkFgJmDw8WAh8HBQk2LzI0LzIwMTlkZAIODw8WBB8CBQtuZXdzSXRlbUFsdB8EAgJkFgJmDw8WAh8HBQk2LzE3LzIwMTlkZAIPDw8WBB8CBQhuZXdzSXRlbR8EAgJkFgJmDw8WAh8HBQk2LzEwLzIwMTlkZAIQDw8WBB8CBQtuZXdzSXRlbUFsdB8EAgJkFgJmDw8WAh8HBQg2LzMvMjAxOWRkAhEPDxYEHwIFCG5ld3NJdGVtHwQCAmQWAmYPDxYCHwcFCTUvMjgvMjAxOWRkAhIPDxYEHwIFC25ld3NJdGVtQWx0HwQCAmQWAmYPDxYCHwcFCTUvMjAvMjAxOWRkAhMPDxYEHwIFCG5ld3NJdGVtHwQCAmQWAmYPDxYCHwcFCTUvMTMvMjAxOWRkAhQPDxYEHwIFC25ld3NJdGVtQWx0HwQCAmQWAmYPDxYCHwcFCDUvNi8yMDE5ZGQCFQ8PFgQfAgUIbmV3c0l0ZW0fBAICZBYCZg8PFgIfBwUJNC8yOS8yMDE5ZGQCFg8PFgQfAgULbmV3c0l0ZW1BbHQfBAICZBYCZg8PFgIfBwUJNC8yMi8yMDE5ZGQCFw8PFgQfAgUIbmV3c0l0ZW0fBAICZBYCZg8PFgIfBwUJNC8xNS8yMDE5ZGQCGA8PFgQfAgULbmV3c0l0ZW1BbHQfBAICZBYCZg8PFgIfBwUINC84LzIwMTlkZAIZDw8WBB8CBQhuZXdzSXRlbR8EAgJkFgJmDw8WAh8HBQg0LzEvMjAxOWRkAhoPDxYEHwIFC25ld3NJdGVtQWx0HwQCAmQWAmYPDxYCHwcFCTMvMjUvMjAxOWRkAhsPDxYEHwIFCG5ld3NJdGVtHwQCAmQWAmYPDxYCHwcFCTMvMTgvMjAxOWRkAhwPDxYEHwIFC25ld3NJdGVtQWx0HwQCAmQWAmYPDxYCHwcFCTMvMTEvMjAxOWRkAh0PDxYEHwIFCG5ld3NJdGVtHwQCAmQWAmYPDxYCHwcFCDMvNC8yMDE5ZGQCHg8PFgQfAgULbmV3c0l0ZW1BbHQfBAICZBYCZg8PFgIfBwUJMi8yNS8yMDE5ZGQCHw8PFgQfAgUIbmV3c0l0ZW0fBAICZBYCZg8PFgIfBwUJMi8xOS8yMDE5ZGQCIA8PFgQfAgULbmV3c0l0ZW1BbHQfBAICZBYCZg8PFgIfBwUJMi8xMS8yMDE5ZGQCIQ8PFgQfAgUIbmV3c0l0ZW0fBAICZBYCZg8PFgIfBwUIMi80LzIwMTlkZAIiDw8WBB8CBQtuZXdzSXRlbUFsdB8EAgJkFgJmDw8WAh8HBQkxLzI4LzIwMTlkZAIjDw8WBB8CBQhuZXdzSXRlbR8EAgJkFgJmDw8WAh8HBQkxLzIyLzIwMTlkZAIkDw8WBB8CBQtuZXdzSXRlbUFsdB8EAgJkFgJmDw8WAh8HBQkxLzE0LzIwMTlkZAIlDw8WBB8CBQhuZXdzSXRlbR8EAgJkFgJmDw8WAh8HBQgxLzcvMjAxOWRkAgMPZBYEAgEPFgIfBwUVPGgzPlZpZXcgYnkgWWVhcjwvaDM+ZAIDDxYCHwcFqgY8YSBocmVmPSdodHRwOi8vYmMuY3V5YWhvZ2Fjb3VudHkudXMvZW4tVVMvQm9hcmQtb2YtQ29udHJvbC5hc3B4P1llYXI9MjAxOSc+MjAxOTwvYT48YnIgLz48YSBocmVmPSdodHRwOi8vYmMuY3V5YWhvZ2Fjb3VudHkudXMvZW4tVVMvQm9hcmQtb2YtQ29udHJvbC5hc3B4P1llYXI9MjAxOCc+MjAxODwvYT48YnIgLz48YSBocmVmPSdodHRwOi8vYmMuY3V5YWhvZ2Fjb3VudHkudXMvZW4tVVMvQm9hcmQtb2YtQ29udHJvbC5hc3B4P1llYXI9MjAxNyc+MjAxNzwvYT48YnIgLz48YSBocmVmPSdodHRwOi8vYmMuY3V5YWhvZ2Fjb3VudHkudXMvZW4tVVMvQm9hcmQtb2YtQ29udHJvbC5hc3B4P1llYXI9MjAxNic+MjAxNjwvYT48YnIgLz48YSBocmVmPSdodHRwOi8vYmMuY3V5YWhvZ2Fjb3VudHkudXMvZW4tVVMvQm9hcmQtb2YtQ29udHJvbC5hc3B4P1llYXI9MjAxNSc+MjAxNTwvYT48YnIgLz48YSBocmVmPSdodHRwOi8vYmMuY3V5YWhvZ2Fjb3VudHkudXMvZW4tVVMvQm9hcmQtb2YtQ29udHJvbC5hc3B4P1llYXI9MjAxNCc+MjAxNDwvYT48YnIgLz48YSBocmVmPSdodHRwOi8vYmMuY3V5YWhvZ2Fjb3VudHkudXMvZW4tVVMvQm9hcmQtb2YtQ29udHJvbC5hc3B4P1llYXI9MjAxMyc+MjAxMzwvYT48YnIgLz48YSBocmVmPSdodHRwOi8vYmMuY3V5YWhvZ2Fjb3VudHkudXMvZW4tVVMvQm9hcmQtb2YtQ29udHJvbC5hc3B4P1llYXI9MjAxMic+MjAxMjwvYT48YnIgLz48YSBocmVmPSdodHRwOi8vYmMuY3V5YWhvZ2Fjb3VudHkudXMvZW4tVVMvQm9hcmQtb2YtQ29udHJvbC5hc3B4P1llYXI9MjAxMSc+MjAxMTwvYT48YnIgLz5kAhMPFgIfBwXTAsKgPGJyIC8+ClRoZSBtYWpvcml0eSBvZiB0aGUgQm9hcmRzIGFuZCBDb21taXNzaW9ucyBpbiBDdXlhaG9nYSBDb3VudHkgYXJlIENpdGl6ZW4gUG9saWN5IE1ha2luZyBhbmQgQWR2aXNvcnkgQm9hcmRzIGFuZCBDb21taXNzaW9ucy4gQWxsIG9mIHRoZXNlIGJvYXJkcyBhbmQgY29tbWlzc2lvbnMgYXJlIGdvdmVybmVkIGJ5IHRoZSBsYXdzIGFuZCByZWd1bGF0aW9ucyB0aGF0IGhhdmUgYXV0aG9yaXplZCB0aGVtLiBNZW1iZXJzIHJlcHJlc2VudCB0aGUgc3BlY2lmaWMgbWlzc2lvbiBvZiB0aGUgYm9hcmRzIG9yIGNvbW1pc3Npb24gdG8gd2hpY2ggdGhleSBoYXZlIGJlZW4gYXBwb2ludGVkLmQYAQUeX19Db250cm9sc1JlcXVpcmVQb3N0QmFja0tleV9fFgIFFWN0bDAwJG1hc3Rlck5hdiRNZW51MQUbY3RsMDAkc2l0ZVNwZWNpZmljTmF2JE1lbnUx6RCBNdNsb99i4xHdDLnQiYHsMmA=" />
-</div>
-
-<script type="text/javascript">
-//<![CDATA[
-var theForm = document.forms['aspnetForm'];
-if (!theForm) {
-    theForm = document.aspnetForm;
-}
-function __doPostBack(eventTarget, eventArgument) {
-    if (!theForm.onsubmit || (theForm.onsubmit() != false)) {
-        theForm.__EVENTTARGET.value = eventTarget;
-        theForm.__EVENTARGUMENT.value = eventArgument;
-        theForm.submit();
-    }
-}
-//]]>
-</script>
-
-
-<script src="/WebResource.axd?d=zWWBpfJyzWl84Im7r9ggFv1pQmVVjsOetwYQoXq0onX3sSBaCavhUFiFP1KcICrMua-IpULuR_cdOEmz67DcAEY_BO81&amp;t=636041134940000000" type="text/javascript"></script>
-
-
-<script src="/ScriptResource.axd?d=70o7s6VfGMPTvcyNimmlxMd9BNzPzJWBp0wBCHTjuElU_S7OL-ufG56IzeAmyXVX98Xpj3ufZo1r9JkA2RroN_ADkDj-MRsgM0sLigOIrvlv_bfE73yQGEqgI7aPgdGy0FzElyN95tmQN32rfnUYtGdrHDI1&amp;t=3f4a792d" type="text/javascript"></script>
-<script src="/ScriptResource.axd?d=aOVJixh57R0pbe_iTicF-VFP9ezdmfkAZoFg7uNKtXjM4rkPPd6FI3NH8NGc-v7kWeApL2RGvKwEykNb_z5wgkfA_pRBTR5g8bNVTq1FhbPZFFjw3e1fGN0URhpW4sTkmRpz6WGywIxKRMy4ma42b9-evFZltPnbugPznrRm_9fEsaI90&amp;t=3f4a792d" type="text/javascript"></script>
-<script src="/ScriptResource.axd?d=VSzDDgxALnjUIIInLUb0vub2G3JdH08OZ94QwF8E5wNYJRvRJbf6XHo_9mK55Idlp9KJlDgYRUNvkDsr7Ez2A9xyPvaDo3Z3GrNSFF29_TyNK-9P-eXSbUoY0Uujldx7HXBATA2&amp;t=ffffffffbb8f054a" type="text/javascript"></script>
-<script src="/ScriptResource.axd?d=nAHGX4RoGMgGUFZm_eQOqntHlc4m6p3SakNkP7h6k3uQA41M0orZruxEbq9zYAW8L53QbFvxSwSpnv3mRTYA6-20R3xgTEYsZSV1Zy-wMvYWFjtEOY6_ajdJt_f-ZfU9lLTqsg2&amp;t=ffffffffbb8f054a" type="text/javascript"></script>
-<script src="/ScriptResource.axd?d=X8w59HevH0SHmQ0LICf9OIk17jBAAwc0NcxZWYn6IEic-O0wsi7F9S1Okc_IoTSjhm1kBi7rFO4_OsYdqxLQarhy4HcLPvkVw93M2wvic0d58RJcvIwlndW6MELxCgNCHrwLoA2&amp;t=ffffffffbb8f054a" type="text/javascript"></script>
-<script src="/ScriptResource.axd?d=MRUjTepfWFL_Cr4DOP80Wrf6qDl95DTyGZOWBqUx40P-6MoSh9u14_fVfmu3vSCV-fMg5yc0Mo5_fYtZpTRFpOFEpgwi5yjqT0bQBdbzTZw-b3HnbQIfvnbe8cweqIy0Z8FJg4gAf7j54R9QBU5zcz11g741&amp;t=ffffffffbb8f054a" type="text/javascript"></script>
-<script src="/ScriptResource.axd?d=PDKm36tqtPSGw-UYNvJaIs9IoFNqjQvj2-yPLyj5q13oy6J-YZpYD5rkfnUA2y1NQerJEyxZrkndjbBWY9eYwP9Fq1KXXhMLBVqzcJ9DCGzvWDxaSmo8VkPbxJz_WR6AJYJT1g8kYgaZZSq_iyM3QR3Kx2k1&amp;t=ffffffffbb8f054a" type="text/javascript"></script>
-<script src="/ScriptResource.axd?d=CnoSDlBrP2UDEPNB0lczwSOsmLp8J1Nvmc5l1XeqOTUpRtagALjtu-ICB098EudNcA-Cee2bKiH2YZbFGGDMY4fXOhkGg235mM2CBtoxhhtR4DVa1HGrx1Crz_I0T8h0wb90MQ2&amp;t=ffffffffbb8f054a" type="text/javascript"></script>
-<div>
-
-	<input type="hidden" name="__VIEWSTATEGENERATOR" id="__VIEWSTATEGENERATOR" value="F816232F" />
-	<input type="hidden" name="__EVENTVALIDATION" id="__EVENTVALIDATION" value="/wEWAwKGoezFBwLwiv6LDwK6yJ3fDV+5yVerOMDXkoXaUhRxs/CpRHoQ" />
-</div>
-        <script type="text/javascript">
-//<![CDATA[
-Sys.WebForms.PageRequestManager._initialize('ctl00$ScriptManager1', document.getElementById('aspnetForm'));
-Sys.WebForms.PageRequestManager.getInstance()._updateControls([], [], [], 90);
-//]]>
-</script>
-
-<div id="masterBar">
-    <span id="ctl00_MasterBar"><!--div id="alert">DO NOT EDIT. COPY THIS LINE BELOW, CHANGE THE TEXT, AND REMOVE THE COMMENT MARKUP. DELETE SECOND LINE WHEN DONE.</div-->
-
-
-<!--
-.redAlert {
-    color: #FFFFFF;
-    font-weight: bold;
-    background-color:red;
-}
-
-</style>
--->
-
-<!--<div id="alert" class="redAlert"></div>-->
-<!--
+<!-- Google tag (gtag.js) EH 2023-07-17-->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-8C3KCV9D47"></script>
 <script>
-// Set the date we're counting down to
-//var countDownDate = new Date("Oct 10, 2018 12:59:59").getTime();
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
 
-// Update the count down every 1 second
-var x = setInterval(function() {
-
-    // Get todays date and time
-//    var now = new Date().getTime();
-
-    // Find the distance between now and the count down date
-  //  var distance = countDownDate - now;
-
-    // Time calculations for days, hours, minutes and seconds
-    //var days = Math.floor(distance / (1000 * 60 * 60 * 24));
-    //var hours = Math.floor((distance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
-    //var minutes = Math.floor((distance % (1000 * 60 * 60)) / (1000 * 60));
-    //var seconds = Math.floor((distance % (1000 * 60)) / 1000);
-
-    // Output the result in an element with id="demo"
-    document.getElementById("alert").innerHTML = "Make your voice heard!  There are  " + days + " days left to <a href='https://boe.cuyahogacounty.us/en-US/voter-registration.aspx' target='_blank'> register to vote </a> for the November 6th election.";
-
-    // If the count down is over, write some text
-   // if (distance < 0) {
-        //clearInterval(x);
-        document.getElementById("alert").style.display = "none";
-        //document.getElementById("alertR").innerHTML = "EXPIRED";
-    }
-}, 1000);
-//</script> -->
-</span>
-     <!--
-        '+-----------------------------------------------------------------------------+
-        '| This menu is for the county homepage shared navigation. To make it work,    |
-        '| set the Web site description in the code behind file to the site name for   |
-        '| the county homepage.                                                        |
-        '|                                                                             |
-        '| Note: The URLS for ALL menus are built based on the SiteMapUseDynamicURLs   |
-        '| Web.Config setting.  When developing, this should be set to false so that   |
-        '| the main site navigation points to the local machine.  This will cause      |
-        '| the shared navigation to also point to the local machine rather than the    |
-        '| county homepage URL.  Setting SiteMapUseDynamicURLs = False when the site   |
-        '| is deployed to the server will fix this and make everything work fine.      | 
-        '+-----------------------------------------------------------------------------+
-     -->
-     <div id="ctl00_masterNav_Menu1" class="RadMenu RadMenu_RadMenuMasterNav" UseEmbeddedScripts="false">
-	<!-- 2011.2.915.35 --><ul class="rmRootGroup rmHorizontal">
-		<li class="rmItem rmFirst"><a href="http://www.cuyahogacounty.us/en-US/home.aspx" class="rmLink rmRootLink MainItem"><span class="rmText"></span></a></li><li class="rmItem "><a href="http://www.cuyahogacounty.us/en-US/government.aspx" class="rmLink rmRootLink MainItem"><span class="rmText">Government</span></a><div class="rmSlide">
-			<ul class="rmVertical rmGroup rmLevel1">
-				<li class="rmItem rmFirst"><a href="http://www.cuyahogacounty.us/en-US/Organizational-Chart.aspx" class="rmLink MenuItem"><span class="rmText">Organizational Chart</span></a></li><li class="rmItem rmLast"><a href="http://www.cuyahogacounty.us/en-US/history.aspx" class="rmLink MenuItem"><span class="rmText">History</span></a></li>
-			</ul>
-		</div></li><li class="rmItem "><a href="http://www.cuyahogacounty.us/en-US/resident-services.aspx" class="rmLink rmRootLink MainItem"><span class="rmText">Residents</span></a><div class="rmSlide">
-			<ul class="rmVertical rmGroup rmLevel1">
-				<li class="rmItem rmFirst rmLast"><a href="http://www.cuyahogacounty.us/en-US/Communities.aspx" class="rmLink MenuItem"><span class="rmText">Communities</span></a></li>
-			</ul>
-		</div></li><li class="rmItem "><a href="http://www.cuyahogacounty.us/en-US/visitors.aspx" class="rmLink rmRootLink MainItem"><span class="rmText">Visitors</span></a></li><li class="rmItem "><a href="http://www.cuyahogacounty.us/en-US/business.aspx" class="rmLink rmRootLink MainItem"><span class="rmText">Business</span></a></li><li class="rmItem "><a href="http://www.cuyahogacounty.us/en-US/contact-list.aspx" class="rmLink rmRootLink MainItem"><span class="rmText">A-Z Directory</span></a></li><li class="rmItem rmLast"><a href="http://www.cuyahogacounty.us/en-US/online-services.aspx" class="rmLink rmRootLink MainItem"><span class="rmText">Online Services</span></a></li>
-	</ul><input id="ctl00_masterNav_Menu1_ClientState" name="ctl00_masterNav_Menu1_ClientState" type="hidden" />
-</div>
-    
-    </div><!--end #masterBar-->
-<div id="container">
-    <div id="header">
-    <map name="BannerMap" id="BannerMap">
-        <area shape="circle" coords="60,50,44" href="http://www.cuyahogacounty.us/" />
-        <area shape="rect" coords="110,0,1024,99" href="http://bc.cuyahogacounty.us/" />
-    </map>
-    <img id="ctl00_imgLogoTitle" border="0" usemap="#BannerMap" src="/img_bc/en-US/site_title.jpg" alt="Cuyahoga County" style="height:99px;width:1024px;border-width:0px;" />
-    </div><!--end #header-->
-    
-    <div id="searchBox">
-    <div id="ctl00_SiteSearch1_pnlSearch" onkeypress="javascript:return WebForm_FireDefaultButton(event, 'ctl00_SiteSearch1_btnGo')">
-	
-    <input name="ctl00$SiteSearch1$txtTerms" type="text" id="ctl00_SiteSearch1_txtTerms" onClick="getElementById('ctl00_SiteSearch1_txtTerms').value='';" alt="" style="width:175px;" />
-	<input type="submit" name="ctl00$SiteSearch1$btnGo" value="Search" onclick="if(ctl00_SiteSearch1_txtTerms.value =='' || ctl00_SiteSearch1_txtTerms.value =='') return false;" id="ctl00_SiteSearch1_btnGo" class="searchButton" />
-	
-
-</div><br />
-    </div>    
-
-            <!--Treeview Navigation-->
-        <div id="navigation">
-            <div class="centerNav">
-            <div id="ctl00_siteSpecificNav_Menu1" class="RadMenu RadMenu_RadMenuSiteSpecificNav" UseEmbeddedScripts="false">
-	<ul class="rmRootGroup rmHorizontal">
-		<li class="rmItem rmFirst"><a href="http://bc.cuyahogacounty.us/en-US/home.aspx" class="rmLink rmRootLink MainItem"><span class="rmText">Home</span></a></li><li class="rmItem "><a href="http://bc.cuyahogacounty.us/en-US/boards-commissions-form.aspx" class="rmLink rmRootLink MainItem"><span class="rmText">Boards and Commissions Form</span></a></li><li class="rmItem "><a href="http://bc.cuyahogacounty.us/en-US/Internal-Boards.aspx" class="rmLink rmRootLink MainItem rmSelected"><span class="rmText">Internal Boards</span></a></li><li class="rmItem "><a href="http://bc.cuyahogacounty.us/en-US/External-Boards.aspx" class="rmLink rmRootLink MainItem"><span class="rmText">External Boards</span></a></li><li class="rmItem "><a href="http://bc.cuyahogacounty.us/en-US/Other-Boards.aspx" class="rmLink rmRootLink MainItem"><span class="rmText">Other Boards</span></a></li><li class="rmItem "><a href="http://bc.cuyahogacounty.us/en-US/SiteMap.aspx" class="rmLink rmRootLink MainItem"><span class="rmText">Sitemap</span></a></li><li class="rmItem rmLast"><a href="http://bc.cuyahogacounty.us/en-US/MyAccount.aspx" class="rmLink rmRootLink MainItem"><span class="rmText">My Account</span></a></li>
-	</ul><input id="ctl00_siteSpecificNav_Menu1_ClientState" name="ctl00_siteSpecificNav_Menu1_ClientState" type="hidden" />
-</div>
-
-            </div>
-        </div>
-        <!--End Treeview Navigation-->
-
-    <div id="contentColumn">
-    <p id="top">
-        You are here:
-        
-<link href=http://bc.cuyahogacounty.us/Style/BreadCrumbs.css type="text/css"
-	rel="stylesheet">
-<span id="ctl00_Bread_crumbs1_Label1"><a class='BreadCrumbLink' href='http://bc.cuyahogacounty.us/en-US/home.aspx'>Home</a>&nbsp;<span class='BreadCrumbSeparator'>&gt;</span>&nbsp;<a class='BreadCrumbLink' href='http://bc.cuyahogacounty.us/en-US/Internal-Boards.aspx'>Internal Boards</a>&nbsp;<span class='BreadCrumbSeparator'>&gt;</span>&nbsp;<span class='BreadCrumbCurrentPage '>Board of Control</span></span>
-
-
-    </p>
-    
-    <h1>
-        </h1>
-        <h2>Board of Control</h2>
-<br />
-<strong>
-CONTACT INFORMATION:</strong><br />
-Andria Richardson<br />
-2079 E. 9th St, Cleveland, Ohio 44115
-<br />
-216-443-6853
-<br />
-<a href="mailto:arichardson@cuyahogacounty.us">arichardson@cuyahogacounty.us</a>
-<br />
-<br />
-<br />
-<strong>WEBSITE:</strong><br />
-<a href="http://bc.cuyahogacounty.us/en-US/Council-Committee-Room-B-Live-Stream.aspx" target="_blank">http://bc.cuyahogacounty.us/en-US/Council-Committee-Room-B-Live-Stream.aspx</a><br />
-<br />
-<br />
-<strong>
-DESCRIPTION OF BOARD AND RESPONSIBILITIES:</strong><br />
-The Board of Control has approval authority over all County contracts and purchases valued from $501 to $500,000 (<a href="http://code.cuyahogacounty.us/en-US/CCRC-T2C205-Boards.aspx" target="_blank">Cuyahoga County Code Title 2, Section 205.01; Cuyahoga County Code Title 5, Section 501.04B</a>). Membership is comprised of the County Executive, Fiscal Officer, Director of Public Works, Director the Office of Procurement and Diversity, and three members of County Council appointed by the Council President. The Board of Control meets weekly to review, deliberate, and vote on various contracts, agreements, purchases and other contracting and purchasing matters under its authority. All meetings are open to the public.
-<br />
-<br />
-<br />
-<strong>
-QUALIFICATIONS:</strong><br />
-Membership is comprised of the County Executive, Fiscal Officer, Director of Public Works, Director the Office of Procurement and Diversity, and three members of County Council appointed by the Council President. Members serve at the virtue of their positions with Cuyahoga County.<br />
-<br />
-<br />
-<strong>MEMBERSHIP:</strong><br />
-N/A<br />
-<br />
-<br />
-<strong>MEETING SCHEDULE/AGENDAS:</strong><br />
-Meeting schedule and agendas below. <a href="/en-US/Council-Committee-Room-B-Live-Stream.aspx">Meetings can be viewed live on Mondays at 11:00 am.</a><br />
-<br />
-<br />
-<strong>
-BYLAWS:</strong><br />
-<a href="/pdf_bc/en-US/Rules _ Board_of_Control-v022916.pdf">View rules</a><br />
-<br />
-<br />
-<strong>
-ENABLING LEGISLATION:</strong><br />
-<ul>
-    <li><a href="http://code.cuyahogacounty.us/pdf_code/en-US/O2015-0006.pdf" target="_blank">Council Ordinance O2015-0006</a></li>
-    <li><a href="http://code.cuyahogacounty.us/en-US/CCRC-T2C205-Boards.aspx" target="_blank">Cuyahoga County Code 205.01</a></li>
-</ul>
-<br />
-<strong>OTHER USEFUL LINKS:</strong><br />
-N/A
-<br />
-<br />
-<br />
-<strong>MEETING SCHEDULE:</strong>
-<br />
-<br />
-    
-<div >
-    <ul>
-    <table id="ctl00_ContentPlaceHolder1_ArchiveControl1_tblRecentNews" class="gridViewStyle" border="0">
-	<tr id="ctl00_ContentPlaceHolder1_ArchiveControl1_thRecentNews">
-		<th>Date</th><th>Item</th><th>Files</th>
-	</tr><tr class="newsItem">
-		<td>9/16/2019</td><td><a href="http://bc.cuyahogacounty.us/en-US/091619-BOC-meeting.aspx">Board of Control Meeting</a></td><td><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=4WMJGeytOlN9QqRgnYKD%2fw%3d%3d" target="_blank">Agenda</a><br /></td>
-	</tr><tr class="newsItemAlt">
-		<td>9/9/2019</td><td><a href="http://bc.cuyahogacounty.us/en-US/090919BOCMeeting.aspx">Board of Control Meeting</a></td><td><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=YICdz%2bxQNqSXC%2bYvy8p5Sw%3d%3d" target="_blank">Agenda</a><br /></td>
-	</tr><tr class="newsItem">
-		<td>9/3/2019</td><td><a href="http://bc.cuyahogacounty.us/en-US/090319-BOC-meeting.aspx">Board of Control Meeting</a></td><td><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=ItAmWexRAtkvZMENqysomw%3d%3d" target="_blank">Agenda</a><br /><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=4WMJGeytOlPc09gwkgQOWA%3d%3d" target="_blank">Minutes</a><br /></td>
-	</tr><tr class="newsItemAlt">
-		<td>8/26/2019</td><td><a href="http://bc.cuyahogacounty.us/en-US/082619-BOC-Meeting.aspx">Board of Control Meeting</a></td><td><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=RLOyp0viy4bKOfv%2fWVxITA%3d%3d" target="_blank">Agenda</a><br /><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=YICdz%2bxQNqQ2Tjd8wWE6LQ%3d%3d" target="_blank">Minutes</a><br /></td>
-	</tr><tr class="newsItem">
-		<td>8/19/2019</td><td><a href="http://bc.cuyahogacounty.us/en-US/081919-BOC-Meeting.aspx">Board of Control Meeting</a></td><td><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=faKCQJ7eFTInt1k2DVET2Q%3d%3d" target="_blank">Agenda</a><br /><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=Zlkzd8bZWjBfeH7%2b5rxiNw%3d%3d" target="_blank">Minutes</a><br /></td>
-	</tr><tr class="newsItemAlt">
-		<td>8/12/2019</td><td><a href="http://bc.cuyahogacounty.us/en-US/081219-BOC-Mtg.aspx">Board of Control Meeting</a></td><td><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=f3owOe0hgRYOGmQYzFCSUQ%3d%3d" target="_blank">Agenda</a><br /><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=RLOyp0viy4b7DGQpUi34tw%3d%3d" target="_blank">Minutes</a><br /></td>
-	</tr><tr class="newsItem">
-		<td>8/5/2019</td><td><a href="http://bc.cuyahogacounty.us/en-US/080519-BOC-meeting.aspx">Board of Control Meeting</a></td><td><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=qTtse7yiJsWFKSu7I3SVSw%3d%3d" target="_blank">Agenda</a><br /><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=faKCQJ7eFTJUMkGrtpkrow%3d%3d" target="_blank">Minutes</a><br /></td>
-	</tr><tr class="newsItemAlt">
-		<td>7/29/2019</td><td><a href="http://bc.cuyahogacounty.us/en-US/072919-BOCMtg.aspx">Board of Control Meeting</a></td><td><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=ecHwD1wg%2b4lU7ZLsIyxBRA%3d%3d" target="_blank">Agenda</a><br /><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=f3owOe0hgRbmHArJ%2fffa%2bw%3d%3d" target="_blank">Minutes</a><br /></td>
-	</tr><tr class="newsItem">
-		<td>7/22/2019</td><td><a href="http://bc.cuyahogacounty.us/en-US/072219BOC-Meeting.aspx">Board of Control Meeting</a></td><td><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=%2bldxIXFIZuLe%2byZNG67exA%3d%3d" target="_blank">Agenda</a><br /><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=qTtse7yiJsX0Nvj%2fZW1enA%3d%3d" target="_blank">Minutes</a><br /></td>
-	</tr><tr class="newsItemAlt">
-		<td>7/15/2019</td><td><a href="http://bc.cuyahogacounty.us/en-US/071519-BOC-meeting.aspx">Board of Control Meeting</a></td><td><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=IUMl1zTi1NzHqzFBenTtsg%3d%3d" target="_blank">Agenda</a><br /><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=MZyfIDwIo4P0eTNxNBoIMA%3d%3d" target="_blank">Minutes</a><br /></td>
-	</tr><tr class="newsItem">
-		<td>7/8/2019</td><td><a href="http://bc.cuyahogacounty.us/en-US/070819-BOCMtg.aspx">Board of Control Meeting</a></td><td><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=wGcsRsi3OYPSljeA4%2bPLVQ%3d%3d" target="_blank">Agenda</a><br /><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=%2bldxIXFIZuL85k%2fAmYe9bg%3d%3d" target="_blank">Minutes</a><br /></td>
-	</tr><tr class="newsItemAlt">
-		<td>7/1/2019</td><td><a href="http://bc.cuyahogacounty.us/en-US/070119-BOC-Meeting.aspx">Board of Control Meeting</a></td><td><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=2flwr4L1rmwZzioJ3V8eMw%3d%3d" target="_blank">Agenda</a><br /><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=IUMl1zTi1Ny2iGQZTgq3sw%3d%3d" target="_blank">Minutes</a><br /></td>
-	</tr><tr class="newsItem">
-		<td>6/24/2019</td><td><a href="http://bc.cuyahogacounty.us/en-US/062419-BOC-meeting.aspx">Board of Control Meeting</a></td><td><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=MJLzKI7J2Yc3Puyjvr6%2bBw%3d%3d" target="_blank">Agenda</a><br /><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=loG4Vksyj0FJEZkxQNgO6g%3d%3d" target="_blank">Minutes</a><br /></td>
-	</tr><tr class="newsItemAlt">
-		<td>6/17/2019</td><td><a href="http://bc.cuyahogacounty.us/en-US/061719-BOCMtg.aspx">Board of Control Meeting</a></td><td><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=R58JdHcqvdP424JLc2cmoQ%3d%3d" target="_blank">Agenda</a><br /><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=md9q4WKJ2%2fct5M19sv03nw%3d%3d" target="_blank">Minutes</a><br /></td>
-	</tr><tr class="newsItem">
-		<td>6/10/2019</td><td><a href="http://bc.cuyahogacounty.us/en-US/061019-BOCMtg.aspx">Board of Control Meeting</a></td><td><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=Kj1LziFyLcnEincNaA45Mg%3d%3d" target="_blank">Agenda</a><br /><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=MJLzKI7J2Yd%2fwoxFwd6Umg%3d%3d" target="_blank">Minutes</a><br /></td>
-	</tr><tr class="newsItemAlt">
-		<td>6/3/2019</td><td><a href="http://bc.cuyahogacounty.us/en-US/060319-BOC-meeting.aspx">Board of Control Meeting</a></td><td><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=INd%2btKb62guZRn9xF2r%2fSg%3d%3d" target="_blank">Agenda</a><br /><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=R58JdHcqvdNsV%2bLyB3RI4Q%3d%3d" target="_blank">Minutes</a><br /></td>
-	</tr><tr class="newsItem">
-		<td>5/28/2019</td><td><a href="http://bc.cuyahogacounty.us/en-US/052819-BOC-meeting.aspx">Board of Control Meeting</a></td><td><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=5wMfa40uLSrR6nOJOMKD0Q%3d%3d" target="_blank">Agenda</a><br /><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=Kj1LziFyLcnyWRQMcii0rQ%3d%3d" target="_blank">Minutes</a><br /></td>
-	</tr><tr class="newsItemAlt">
-		<td>5/20/2019</td><td><a href="http://bc.cuyahogacounty.us/en-US/052019-BOC-meeting.aspx">Board of Control Meeting</a></td><td><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=GutW27z8A3qlQy%2bxcUyb5Q%3d%3d" target="_blank">Agenda</a><br /><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=4me%2fqogm509k%2bNeZzD8RFA%3d%3d" target="_blank">Minutes</a><br /></td>
-	</tr><tr class="newsItem">
-		<td>5/13/2019</td><td><a href="http://bc.cuyahogacounty.us/en-US/051319-BOC-Meeting.aspx">Board of Control Meeting</a></td><td><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=gq3zlknHbT%2fC%2flQuQCzGNw%3d%3d" target="_blank">Agenda</a><br /><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=5wMfa40uLSrAiekFSLp8Ew%3d%3d" target="_blank">Minutes</a><br /></td>
-	</tr><tr class="newsItemAlt">
-		<td>5/6/2019</td><td><a href="http://bc.cuyahogacounty.us/en-US/050619-BOCMeeting.aspx">Board of Control Meeting</a></td><td><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=mMiotqg1fooM3ca7XE64uA%3d%3d" target="_blank">Agenda</a><br /><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=GutW27z8A3qMrOS8CQmxuA%3d%3d" target="_blank">Minutes</a><br /></td>
-	</tr><tr class="newsItem">
-		<td>4/29/2019</td><td><a href="http://bc.cuyahogacounty.us/en-US/042919-BOC-Meeting.aspx">Board of Control Meeting</a></td><td><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=XHX5YRzaEqFoVIDPxR0ZMQ%3d%3d" target="_blank">Agenda</a><br /><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=gq3zlknHbT%2fkrBT0Q%2fzG3w%3d%3d" target="_blank">Minutes</a><br /></td>
-	</tr><tr class="newsItemAlt">
-		<td>4/22/2019</td><td><a href="http://bc.cuyahogacounty.us/en-US/042219-BOC-Meeting.aspx">Board of Control Meeting</a></td><td><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=L3IdX%2bzR1UVIo9wJ2HIUUQ%3d%3d" target="_blank">Agenda</a><br /><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=mMiotqg1fopnKSjZKLJugg%3d%3d" target="_blank">Minutes</a><br /></td>
-	</tr><tr class="newsItem">
-		<td>4/15/2019</td><td><a href="http://bc.cuyahogacounty.us/en-US/041519-BOC-meeting.aspx">Board of Control Meeting</a></td><td><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=7xS43Dl1hFcxwEf4fLWAoA%3d%3d" target="_blank">Agenda</a><br /><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=XHX5YRzaEqF4ENRmCirtxg%3d%3d" target="_blank">Minutes</a><br /></td>
-	</tr><tr class="newsItemAlt">
-		<td>4/8/2019</td><td><a href="http://bc.cuyahogacounty.us/en-US/040819BOCMeeting.aspx">Board of Control Meeting</a></td><td><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=uH%2boBJv%2bJKyVOKVi%2brP5BQ%3d%3d" target="_blank">Agenda</a><br /><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=L3IdX%2bzR1UX12p5wfcgw%2bg%3d%3d" target="_blank">Minutes</a><br /></td>
-	</tr><tr class="newsItem">
-		<td>4/1/2019</td><td><a href="http://bc.cuyahogacounty.us/en-US/040119BOCMeeting.aspx">Board of Control Meeting</a></td><td><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=%2fE2teErBaeTDkuAO0allMw%3d%3d" target="_blank">Agenda</a><br /><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=7xS43Dl1hFcEhJ0WQFyL3g%3d%3d" target="_blank">Minutes</a><br /></td>
-	</tr><tr class="newsItemAlt">
-		<td>3/25/2019</td><td><a href="http://bc.cuyahogacounty.us/en-US/032519-BOC-Meeting.aspx">Board of Control Meeting</a></td><td><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=jrZSLATrHXJirotKEMFXmQ%3d%3d" target="_blank">Agenda</a><br /><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=uH%2boBJv%2bJKwljFwuHc1G0w%3d%3d" target="_blank">Minutes</a><br /></td>
-	</tr><tr class="newsItem">
-		<td>3/18/2019</td><td><a href="http://bc.cuyahogacounty.us/en-US/031819BOCMeeting.aspx">Board of Control Meeting</a></td><td><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=udGEHEncXpu1TVVOouNCNQ%3d%3d" target="_blank">Agenda</a><br /><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=%2fE2teErBaeSOXJD9vEHwTQ%3d%3d" target="_blank">Minutes</a><br /></td>
-	</tr><tr class="newsItemAlt">
-		<td>3/11/2019</td><td><a href="http://bc.cuyahogacounty.us/en-US/031119-BOC-Meeting.aspx">Board of Control Meeting</a></td><td><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=ZeOk3W1vwzYpnbLNSQv0YQ%3d%3d" target="_blank">Agenda</a><br /><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=jrZSLATrHXKm1WNZ2dBrTQ%3d%3d" target="_blank">Minutes</a><br /></td>
-	</tr><tr class="newsItem">
-		<td>3/4/2019</td><td><a href="http://bc.cuyahogacounty.us/en-US/030419-BOC-Meeting.aspx">Board of Control Meeting</a></td><td><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=bxVWHIUykktCYIQzh5ZSAg%3d%3d" target="_blank">Agenda</a><br /><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=udGEHEncXpsQ2HXH7pzW8w%3d%3d" target="_blank">Minutes</a><br /></td>
-	</tr><tr class="newsItemAlt">
-		<td>2/25/2019</td><td><a href="http://bc.cuyahogacounty.us/en-US/022519BOCMtg.aspx">Board of Control Meeting</a></td><td><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=HkFKsYiFBeoj4rUmvSmMsQ%3d%3d" target="_blank">Agenda</a><br /><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=HXiewqbb0xiPkAE45gjUhg%3d%3d" target="_blank">Minutes</a><br /></td>
-	</tr><tr class="newsItem">
-		<td>2/19/2019</td><td><a href="http://bc.cuyahogacounty.us/en-US/021919-BOC-Meeting.aspx">Board of Control Meeting</a></td><td><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=%2fX%2fWe3zURFeVb%2bRaovRw7g%3d%3d" target="_blank">Agenda</a><br /><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=bxVWHIUykksjAGeAC%2b001A%3d%3d" target="_blank">Minutes</a><br /></td>
-	</tr><tr class="newsItemAlt">
-		<td>2/11/2019</td><td><a href="http://bc.cuyahogacounty.us/en-US/021119-BOC-meeting.aspx">Board of Control Meeting</a></td><td><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=YQleo%2f%2bg3jp%2fUaesjlWkZA%3d%3d" target="_blank">Agenda</a><br /><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=WP4eFtcKnSKVAvMEEN9sSQ%3d%3d" target="_blank">Minutes</a><br /></td>
-	</tr><tr class="newsItem">
-		<td>2/4/2019</td><td><a href="http://bc.cuyahogacounty.us/en-US/020419-BOC-Meeting.aspx">Board of Control Meeting</a></td><td><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=Um12GmIO3tKIxG5krKpwRg%3d%3d" target="_blank">Agenda</a><br /><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=%2fX%2fWe3zURFeX%2bNqlKGGnBw%3d%3d" target="_blank">Minutes</a><br /></td>
-	</tr><tr class="newsItemAlt">
-		<td>1/28/2019</td><td><a href="http://bc.cuyahogacounty.us/en-US/012819BOCMtg.aspx">Board of Control Meeting</a></td><td><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=YfXKH9lmoTylzzUXaxJHzg%3d%3d" target="_blank">Agenda</a><br /><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=YQleo%2f%2bg3jrE2GonIB7cdA%3d%3d" target="_blank">Minutes</a><br /></td>
-	</tr><tr class="newsItem">
-		<td>1/22/2019</td><td><a href="http://bc.cuyahogacounty.us/en-US/012219-BOC-Meeting.aspx">Board of Control Meeting</a></td><td><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=a8B53uaC%2fUX39Sz7VUKgGQ%3d%3d" target="_blank">Agenda</a><br /><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=Um12GmIO3tKu4Dya4oGJ6w%3d%3d" target="_blank">Minutes</a><br /></td>
-	</tr><tr class="newsItemAlt">
-		<td>1/14/2019</td><td><a href="http://bc.cuyahogacounty.us/en-US/011419-BOC-Meeting.aspx">Board of Control Meeting</a></td><td><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=YfXKH9lmoTzCk%2f%2fNpWV13Q%3d%3d" target="_blank">Minutes</a><br /></td>
-	</tr><tr class="newsItem">
-		<td>1/7/2019</td><td><a href="http://bc.cuyahogacounty.us/en-US/010719BOCMeeting.aspx">Board of Control Meeting</a></td><td><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=djhyqaewiHoe%2bh8pJA4ZLw%3d%3d" target="_blank">Agenda</a><br /><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?File=a8B53uaC%2fUXzh2B16pN6qQ%3d%3d" target="_blank">Minutes</a><br /></td>
-	</tr>
-</table>
-    </ul>
-    <div id="ctl00_ContentPlaceHolder1_ArchiveControl1_pnlYears">
-	
-        <h3>View by Year</h3>
-        <blockquote>
-            <a href='http://bc.cuyahogacounty.us/en-US/Board-of-Control.aspx?Year=2019'>2019</a><br /><a href='http://bc.cuyahogacounty.us/en-US/Board-of-Control.aspx?Year=2018'>2018</a><br /><a href='http://bc.cuyahogacounty.us/en-US/Board-of-Control.aspx?Year=2017'>2017</a><br /><a href='http://bc.cuyahogacounty.us/en-US/Board-of-Control.aspx?Year=2016'>2016</a><br /><a href='http://bc.cuyahogacounty.us/en-US/Board-of-Control.aspx?Year=2015'>2015</a><br /><a href='http://bc.cuyahogacounty.us/en-US/Board-of-Control.aspx?Year=2014'>2014</a><br /><a href='http://bc.cuyahogacounty.us/en-US/Board-of-Control.aspx?Year=2013'>2013</a><br /><a href='http://bc.cuyahogacounty.us/en-US/Board-of-Control.aspx?Year=2012'>2012</a><br /><a href='http://bc.cuyahogacounty.us/en-US/Board-of-Control.aspx?Year=2011'>2011</a><br />
-        </blockquote>
-    
-</div>
-    
-</div>
-
-    </div><!--end #rightColumn-->
-    <div id="footer">
-    <div id="siteFooter">
-         <br />
-The majority of the Boards and Commissions in Cuyahoga County are Citizen Policy Making and Advisory Boards and Commissions. All of these boards and commissions are governed by the laws and regulations that have authorized them. Members represent the specific mission of the boards or commission to which they have been appointed.
-    </div>
-    <div id="masterFooter">
-        <span id="ctl00_FooterBar"><ul class="footerNav right">
-<li><a href="http://www.cuyahogacounty.us/">County Home Page</a></li>
-<li><a href="https://www.cuyahogacounty.us/i-want-to-contact">A-Z Service Directory</a></li>
-<li><a href="http://cuyahogacounty.us/en-US/contact-list.aspx">Contact Us</a></li>
-<li><a href="http://www.cuyahogacounty.us/en-us/faqs.aspx">FAQs</a></li>
-<li><a href="http://www.cuyahogacounty.us/en-us/Terms-of-Use.aspx">Terms of Use</a></li>
-</ul>
-<ul class="footerNav">
-<li><a href="http://code.cuyahogacounty.us/en-US/CCRC-T1C106-Public-Records.aspx">Public Records Policy</a></li>
-<li><a href="http://www.cuyahogacounty.us/en-US/privacy-policy.aspx">Privacy Policy</a></li>
-<li><a href="http://www.cuyahogacounty.us/en-US/social-media-policy.aspx">Social Media Policy</a></li>
-<li><a href="https://cuyahogacounty.us/accessibility-statement-general">Accessibility Statement</a></li>
-<li><a href="http://www.cuyahogacounty.us/en-US/disclaimer.aspx">Disclaimer</a></li>
-</ul>
-<p><a href="http://isc.cuyahogacounty.us/">Powered by the Department of Information Technology</a></p></span>
-    </div>
-    </div><!--end #footer-->
-</div><!--end #container-->
-    
-
-<script type="text/javascript">
-//<![CDATA[
-Sys.Application.initialize();
-Sys.Application.add_init(function() {
-    $create(Telerik.Web.UI.RadMenu, {"_childListElementCssClass":null,"_skin":"RadMenuMasterNav","attributes":{"UseEmbeddedScripts":"false"},"clientStateFieldID":"ctl00_masterNav_Menu1_ClientState","collapseAnimation":"{\"duration\":450}","expandAnimation":"{\"duration\":450}","itemData":[{"navigateUrl":"http://www.cuyahogacounty.us/en-US/home.aspx","cssClass":"MainItem"},{"items":[{"navigateUrl":"http://www.cuyahogacounty.us/en-US/Organizational-Chart.aspx","cssClass":"MenuItem"},{"navigateUrl":"http://www.cuyahogacounty.us/en-US/history.aspx","cssClass":"MenuItem"}],"navigateUrl":"http://www.cuyahogacounty.us/en-US/government.aspx","cssClass":"MainItem"},{"items":[{"navigateUrl":"http://www.cuyahogacounty.us/en-US/Communities.aspx","cssClass":"MenuItem"}],"navigateUrl":"http://www.cuyahogacounty.us/en-US/resident-services.aspx","cssClass":"MainItem"},{"navigateUrl":"http://www.cuyahogacounty.us/en-US/visitors.aspx","cssClass":"MainItem"},{"navigateUrl":"http://www.cuyahogacounty.us/en-US/business.aspx","cssClass":"MainItem"},{"navigateUrl":"http://www.cuyahogacounty.us/en-US/contact-list.aspx","cssClass":"MainItem"},{"navigateUrl":"http://www.cuyahogacounty.us/en-US/online-services.aspx","cssClass":"MainItem"}]}, null, null, $get("ctl00_masterNav_Menu1"));
-});
-Sys.Application.add_init(function() {
-    $create(Telerik.Web.UI.RadMenu, {"_childListElementCssClass":null,"_skin":"RadMenuSiteSpecificNav","attributes":{"UseEmbeddedScripts":"false"},"clientStateFieldID":"ctl00_siteSpecificNav_Menu1_ClientState","collapseAnimation":"{\"duration\":450}","expandAnimation":"{\"duration\":450}","itemData":[{"navigateUrl":"http://bc.cuyahogacounty.us/en-US/home.aspx","cssClass":"MainItem"},{"navigateUrl":"http://bc.cuyahogacounty.us/en-US/boards-commissions-form.aspx","cssClass":"MainItem"},{"navigateUrl":"http://bc.cuyahogacounty.us/en-US/Internal-Boards.aspx","cssClass":"MainItem rmSelected"},{"navigateUrl":"http://bc.cuyahogacounty.us/en-US/External-Boards.aspx","cssClass":"MainItem"},{"navigateUrl":"http://bc.cuyahogacounty.us/en-US/Other-Boards.aspx","cssClass":"MainItem"},{"navigateUrl":"http://bc.cuyahogacounty.us/en-US/SiteMap.aspx","cssClass":"MainItem"},{"navigateUrl":"http://bc.cuyahogacounty.us/en-US/MyAccount.aspx","cssClass":"MainItem"}]}, null, null, $get("ctl00_siteSpecificNav_Menu1"));
-});
-//]]>
+  gtag('config', 'G-8C3KCV9D47');
 </script>
-</form>
-</body>
-</html>
+</script><script type="text/javascript" src="https://app-script.monsido.com/v2/monsido-script.js"></script><script type="text/javascript">
+<script type="text/javascript">
+
+    window._monsido = window._monsido || {
+
+        token: "G98XI9WyVuNOTjDxOORC8g",
+
+        statistics: {
+
+            enabled: true,
+
+            documentTracking: {
+
+                enabled: true,
+
+                documentCls: "monsido_download",
+
+                documentIgnoreCls: "monsido_ignore_download",
+
+                documentExt: ["pdf","doc","ppt","docx","pptx"],
+
+            },
+
+        },
+
+        heatmap: {
+
+            enabled: true,
+
+        },
+
+    };
+
+</script>
+
+<script type="text/javascript" async src=https://app-script.monsido.com/v2/monsido-script.js></script>
+</script><meta name="Generator" content="Sitefinity 14.2.7900.0 DX" /><link rel="canonical" href="https://cuyahogacounty.gov/boards-and-commissions/board-details" /></head> <body> <div class="sfPublicWrapper" id="PublicWrapper"> <!-- Header --> <header class="site-header navbar-fixed-top" role="banner" aria-label="Site Header" style="background:#e5f6fe;"> <a id="skippy" class="sr-only-focusable fixed-top official-site full-size-official-site" data-toggle="collapse" href="#collapseContainer" aria-expanded="false"
+      aria-controls="collapseContainer"> <div class="container-fluid center official-blue-bar"> <span class="skiplink-text"> <img src="/ResourcePackages/Bootstrap/assets/dist/images/us_flag_small.png" alt="Image of the State of Ohio flag"> An official website of the Cuyahoga County government. Here’s how you know
+       </span> </div> </a> <div class="row collapse top-ribbon" id="collapseContainer"> <div class="card shadow border parent justify-content-center align-items-center officialWebSite" style="z-index: 6000000!important;"> <div class="card-body" style="padding:0px;"> <div class="row  container"> <div class="col-lg-1"> <img src="/ResourcePackages/Bootstrap/assets/dist/images/icon-dott-gov.png" alt="" /> </div> <div class="col-lg-5 x-small-text"> <strong>The .gov means it&#39;s official.</strong> <br /> A .gov website belongs to an official government organization in the United States.
+        </div> <div class="col-lg-1"> <img src="/ResourcePackages/Bootstrap/assets/dist/images/icon-https.png" alt="" /> </div> <div class="col-lg-5 x-small-text"> <strong>The site is secure.</strong><br /> A lock or https:// means you’ve safely connected to the .gov website. Share sensitive information only on official, secure websites.
+          
+        </div> </div> </div> </div> </div> <a class="skip-link" href="#main"><h1>Skip to Main Content</h1></a> <script src="/ScriptResource.axd?d=okuX3IVIBwfJlfEQK32K3gsjCNmXHz3Ps0ekJj_lJW6grU8z7sDn5c1SO0Q7O_P2C6QozfOyMcSH-VuHV5kqd4jkwQBtjd3Y1zeJ3MgvRCas-0-_K9iboUvPq9VF9WWCU5qbFBXusaawqZGl2tMiN2a58saD4bplygm5bWH-KZAm1CqGCf-EluYhR8BPhSVf0&amp;t=4e1c7b51" type="text/javascript"></script><script src="/ScriptResource.axd?d=EydukmxBmDstn7gSYzQESNmFydCbazOPXX7jPXGKatBMaujCe6TlGaN2thRd9gsQOqsMOK9q7sa1LF5uYBun3bVs5dW6fRbh2veIhlU8FkrvFVx9p17ftwF0OBn9QTsQ02e0vCekC_e8XNyHoMsSgKT5VxjIHc521_CttxbRanDwgMc6tZB24FEczHHnBqMY0&amp;t=4e1c7b51" type="text/javascript"></script><script src="/ScriptResource.axd?d=2z9h4-hKx8Yk1hygmet7puwDjZws3DhD-ASRIY5bp0qCCGiaOmEenIHwp1E0KB_rvsCbF-1F2BSAelnzWqUBdpRtNsHu4X2-Fi3rChdYOEatrQmAF6uPAJMP-QfQueWGta8Aa491C-NUopffEih39wo5sS1nvAHaoHjPy7JjfdFQw-qXB-0tmphFDY2hiXC20&amp;t=4e1c7b51" type="text/javascript"></script> <!--googleoff: all --> <div class="top-section" aria-hidden="true"> 
+
+<div >
+    <div class="sf-Long-text" ><button class="to-top" type="button"><span class="sr-only">To Top</span></button></div>    
+</div>
+
+ </div> <div class="svg-legend" aria-hidden="true"> 
+
+<div >
+    <div class="sf-Long-text" ><svg focusable="false" style="position:absolute;width:0;height:0;overflow:hidden;" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<symbol id="icon-circle-left" viewbox="0 0 32 32">
+<title>circle-left</title>
+<path d="M20 15v-2c0-0.547-0.453-1-1-1h-7.844l2.953-2.953c0.187-0.187 0.297-0.438 0.297-0.703s-0.109-0.516-0.297-0.703l-1.422-1.422c-0.187-0.187-0.438-0.281-0.703-0.281s-0.516 0.094-0.703 0.281l-7.078 7.078c-0.187 0.187-0.281 0.438-0.281 0.703s0.094 0.516 0.281 0.703l7.078 7.078c0.187 0.187 0.438 0.281 0.703 0.281s0.516-0.094 0.703-0.281l1.422-1.422c0.187-0.187 0.281-0.438 0.281-0.703s-0.094-0.516-0.281-0.703l-2.953-2.953h7.844c0.547 0 1-0.453 1-1zM24 14c0 6.625-5.375 12-12 12s-12-5.375-12-12 5.375-12 12-12 12 5.375 12 12z"></path>
+</symbol>
+<symbol id="icon-circle-right" viewbox="0 0 32 32">
+<title>circle-right</title>
+<path d="M20.078 14c0-0.266-0.094-0.516-0.281-0.703l-7.078-7.078c-0.187-0.187-0.438-0.281-0.703-0.281s-0.516 0.094-0.703 0.281l-1.422 1.422c-0.187 0.187-0.281 0.438-0.281 0.703s0.094 0.516 0.281 0.703l2.953 2.953h-7.844c-0.547 0-1 0.453-1 1v2c0 0.547 0.453 1 1 1h7.844l-2.953 2.953c-0.187 0.187-0.297 0.438-0.297 0.703s0.109 0.516 0.297 0.703l1.422 1.422c0.187 0.187 0.438 0.281 0.703 0.281s0.516-0.094 0.703-0.281l7.078-7.078c0.187-0.187 0.281-0.438 0.281-0.703zM24 14c0 6.625-5.375 12-12 12s-12-5.375-12-12 5.375-12 12-12 12 5.375 12 12z"></path>
+</symbol>
+<symbol id="icon-search" viewbox="0 0 16 16">
+<title>search</title>
+<path d="M15.56 15.56c-0.587 0.587-1.538 0.587-2.125 0l-2.652-2.652c-1.090 0.699-2.379 1.116-3.771 1.116-3.872 0-7.012-3.139-7.012-7.012s3.14-7.012 7.012-7.012c3.873 0 7.012 3.139 7.012 7.012 0 1.391-0.417 2.68-1.116 3.771l2.652 2.652c0.587 0.587 0.587 1.538 0 2.125zM7.012 2.003c-2.766 0-5.009 2.242-5.009 5.009s2.243 5.009 5.009 5.009c2.766 0 5.009-2.242 5.009-5.009s-2.242-5.009-5.009-5.009z"></path>
+</symbol>
+<symbol id="icon-youtube-play" viewbox="0 0 28 28">
+<title>youtube-play</title>
+<path d="M11.109 17.625l7.562-3.906-7.562-3.953v7.859zM14 4.156c5.891 0 9.797 0.281 9.797 0.281 0.547 0.063 1.75 0.063 2.812 1.188 0 0 0.859 0.844 1.109 2.781 0.297 2.266 0.281 4.531 0.281 4.531v2.125s0.016 2.266-0.281 4.531c-0.25 1.922-1.109 2.781-1.109 2.781-1.062 1.109-2.266 1.109-2.812 1.172 0 0-3.906 0.297-9.797 0.297v0c-7.281-0.063-9.516-0.281-9.516-0.281-0.625-0.109-2.031-0.078-3.094-1.188 0 0-0.859-0.859-1.109-2.781-0.297-2.266-0.281-4.531-0.281-4.531v-2.125s-0.016-2.266 0.281-4.531c0.25-1.937 1.109-2.781 1.109-2.781 1.062-1.125 2.266-1.125 2.812-1.188 0 0 3.906-0.281 9.797-0.281v0z"></path>
+</symbol>
+<symbol id="icon-twitter-square" viewbox="0 0 24 28">
+<title>twitter-square</title>
+<path d="M20 9.531c-0.594 0.266-1.219 0.438-1.891 0.531 0.688-0.406 1.203-1.062 1.453-1.828-0.641 0.375-1.344 0.656-2.094 0.797-0.594-0.641-1.453-1.031-2.391-1.031-1.813 0-3.281 1.469-3.281 3.281 0 0.25 0.016 0.516 0.078 0.75-2.734-0.141-5.156-1.437-6.781-3.437-0.281 0.484-0.453 1.062-0.453 1.656 0 1.141 0.531 2.141 1.422 2.734-0.547-0.016-1.062-0.172-1.563-0.406v0.031c0 1.594 1.203 2.922 2.703 3.219-0.281 0.078-0.5 0.125-0.797 0.125-0.203 0-0.406-0.031-0.609-0.063 0.422 1.297 1.625 2.25 3.063 2.281-1.125 0.875-2.531 1.406-4.078 1.406-0.266 0-0.531-0.016-0.781-0.047 1.453 0.922 3.172 1.469 5.031 1.469 6.031 0 9.344-5 9.344-9.344 0-0.141 0-0.281-0.016-0.422 0.641-0.453 1.203-1.031 1.641-1.703zM24 6.5v15c0 2.484-2.016 4.5-4.5 4.5h-15c-2.484 0-4.5-2.016-4.5-4.5v-15c0-2.484 2.016-4.5 4.5-4.5h15c2.484 0 4.5 2.016 4.5 4.5z"></path>
+</symbol>
+<symbol id="icon-facebook-square" viewbox="0 0 24 28">
+<title>facebook-square</title>
+<path d="M19.5 2c2.484 0 4.5 2.016 4.5 4.5v15c0 2.484-2.016 4.5-4.5 4.5h-2.938v-9.297h3.109l0.469-3.625h-3.578v-2.312c0-1.047 0.281-1.75 1.797-1.75l1.906-0.016v-3.234c-0.328-0.047-1.469-0.141-2.781-0.141-2.766 0-4.672 1.687-4.672 4.781v2.672h-3.125v3.625h3.125v9.297h-8.313c-2.484 0-4.5-2.016-4.5-4.5v-15c0-2.484 2.016-4.5 4.5-4.5h15z"></path>
+</symbol>
+<symbol id="icon-group" viewbox="0 0 30 28">
+<title>group</title>
+<path d="M9.266 14c-1.625 0.047-3.094 0.75-4.141 2h-2.094c-1.563 0-3.031-0.75-3.031-2.484 0-1.266-0.047-5.516 1.937-5.516 0.328 0 1.953 1.328 4.062 1.328 0.719 0 1.406-0.125 2.078-0.359-0.047 0.344-0.078 0.688-0.078 1.031 0 1.422 0.453 2.828 1.266 4zM26 23.953c0 2.531-1.672 4.047-4.172 4.047h-13.656c-2.5 0-4.172-1.516-4.172-4.047 0-3.531 0.828-8.953 5.406-8.953 0.531 0 2.469 2.172 5.594 2.172s5.063-2.172 5.594-2.172c4.578 0 5.406 5.422 5.406 8.953zM10 4c0 2.203-1.797 4-4 4s-4-1.797-4-4 1.797-4 4-4 4 1.797 4 4zM21 10c0 3.313-2.688 6-6 6s-6-2.688-6-6 2.688-6 6-6 6 2.688 6 6zM30 13.516c0 1.734-1.469 2.484-3.031 2.484h-2.094c-1.047-1.25-2.516-1.953-4.141-2 0.812-1.172 1.266-2.578 1.266-4 0-0.344-0.031-0.688-0.078-1.031 0.672 0.234 1.359 0.359 2.078 0.359 2.109 0 3.734-1.328 4.062-1.328 1.984 0 1.937 4.25 1.937 5.516zM28 4c0 2.203-1.797 4-4 4s-4-1.797-4-4 1.797-4 4-4 4 1.797 4 4z"></path>
+</symbol>
+<symbol id="icon-flag-o" viewbox="0 0 29 28">
+<title>flag-o</title>
+<path d="M26 16.328v-9.625c-1.25 0.672-3 1.422-4.781 1.422v0c-0.828 0-1.594-0.156-2.266-0.5-1.672-0.828-3.484-1.625-5.656-1.625-2.016 0-4.484 0.984-6.297 1.984v9.359c2.063-0.953 4.688-1.766 6.766-1.766 2.406 0 3.969 0.797 5.641 1.625l0.438 0.219c0.438 0.219 0.969 0.344 1.578 0.344 1.734 0 3.609-0.922 4.578-1.437zM5 4c0 0.734-0.406 1.375-1 1.719v19.781c0 0.281-0.219 0.5-0.5 0.5h-1c-0.281 0-0.5-0.219-0.5-0.5v-19.781c-0.594-0.344-1-0.984-1-1.719 0-1.109 0.891-2 2-2s2 0.891 2 2zM28 5v11.922c0 0.375-0.219 0.719-0.547 0.891-0.063 0.031-0.156 0.078-0.266 0.141-1 0.531-3.359 1.813-5.766 1.813-0.922 0-1.75-0.187-2.469-0.547l-0.438-0.219c-1.578-0.797-2.828-1.422-4.75-1.422-2.25 0-5.422 1.172-7.25 2.281-0.156 0.094-0.344 0.141-0.516 0.141s-0.344-0.047-0.5-0.125c-0.313-0.187-0.5-0.516-0.5-0.875v-11.594c0-0.344 0.187-0.672 0.484-0.859 1-0.594 4.531-2.547 7.812-2.547 2.609 0 4.734 0.953 6.531 1.828 0.406 0.203 0.875 0.297 1.391 0.297 1.844 0 3.875-1.172 4.844-1.75 0.203-0.109 0.375-0.203 0.484-0.266 0.313-0.156 0.672-0.141 0.969 0.031 0.297 0.187 0.484 0.516 0.484 0.859z"></path>
+</symbol>
+<symbol id="icon-newspaper-o" viewbox="0 0 32 28">
+<title>newspaper-o</title>
+<path d="M16 8h-6v6h6v-6zM18 18v2h-10v-2h10zM18 6v10h-10v-10h10zM28 18v2h-8v-2h8zM28 14v2h-8v-2h8zM28 10v2h-8v-2h8zM28 6v2h-8v-2h8zM4 21v-15h-2v15c0 0.547 0.453 1 1 1s1-0.453 1-1zM30 21v-17h-24v17c0 0.344-0.063 0.688-0.172 1h23.172c0.547 0 1-0.453 1-1zM32 2v19c0 1.656-1.344 3-3 3h-26c-1.656 0-3-1.344-3-3v-17h4v-2h28z"></path>
+</symbol>
+<symbol id="icon-star-o" viewbox="0 0 26 28">
+<title>star-o</title>
+<path d="M17.766 15.687l4.781-4.641-6.594-0.969-2.953-5.969-2.953 5.969-6.594 0.969 4.781 4.641-1.141 6.578 5.906-3.109 5.891 3.109zM26 10.109c0 0.281-0.203 0.547-0.406 0.75l-5.672 5.531 1.344 7.812c0.016 0.109 0.016 0.203 0.016 0.313 0 0.422-0.187 0.781-0.641 0.781-0.219 0-0.438-0.078-0.625-0.187l-7.016-3.687-7.016 3.687c-0.203 0.109-0.406 0.187-0.625 0.187-0.453 0-0.656-0.375-0.656-0.781 0-0.109 0.016-0.203 0.031-0.313l1.344-7.812-5.688-5.531c-0.187-0.203-0.391-0.469-0.391-0.75 0-0.469 0.484-0.656 0.875-0.719l7.844-1.141 3.516-7.109c0.141-0.297 0.406-0.641 0.766-0.641s0.625 0.344 0.766 0.641l3.516 7.109 7.844 1.141c0.375 0.063 0.875 0.25 0.875 0.719z"></path>
+</symbol>
+<symbol id="icon-desktop" viewbox="0 0 30 28">
+<title>desktop</title>
+<path d="M28 15.5v-13c0-0.266-0.234-0.5-0.5-0.5h-25c-0.266 0-0.5 0.234-0.5 0.5v13c0 0.266 0.234 0.5 0.5 0.5h25c0.266 0 0.5-0.234 0.5-0.5zM30 2.5v17c0 1.375-1.125 2.5-2.5 2.5h-8.5c0 1.328 1 2.453 1 3s-0.453 1-1 1h-8c-0.547 0-1-0.453-1-1 0-0.578 1-1.641 1-3h-8.5c-1.375 0-2.5-1.125-2.5-2.5v-17c0-1.375 1.125-2.5 2.5-2.5h25c1.375 0 2.5 1.125 2.5 2.5z"></path>
+</symbol>
+<symbol id="icon-certificate" viewbox="0 0 24 28">
+<title>certificate</title>
+<path d="M21.5 14l2.156 2.109c0.297 0.281 0.406 0.703 0.313 1.094-0.109 0.391-0.422 0.703-0.812 0.797l-2.938 0.75 0.828 2.906c0.109 0.391 0 0.812-0.297 1.094-0.281 0.297-0.703 0.406-1.094 0.297l-2.906-0.828-0.75 2.938c-0.094 0.391-0.406 0.703-0.797 0.812-0.094 0.016-0.203 0.031-0.297 0.031-0.297 0-0.594-0.125-0.797-0.344l-2.109-2.156-2.109 2.156c-0.281 0.297-0.703 0.406-1.094 0.313-0.406-0.109-0.703-0.422-0.797-0.812l-0.75-2.938-2.906 0.828c-0.391 0.109-0.812 0-1.094-0.297-0.297-0.281-0.406-0.703-0.297-1.094l0.828-2.906-2.938-0.75c-0.391-0.094-0.703-0.406-0.812-0.797-0.094-0.391 0.016-0.812 0.313-1.094l2.156-2.109-2.156-2.109c-0.297-0.281-0.406-0.703-0.313-1.094 0.109-0.391 0.422-0.703 0.812-0.797l2.938-0.75-0.828-2.906c-0.109-0.391 0-0.812 0.297-1.094 0.281-0.297 0.703-0.406 1.094-0.297l2.906 0.828 0.75-2.938c0.094-0.391 0.406-0.703 0.797-0.797 0.391-0.109 0.812 0 1.094 0.297l2.109 2.172 2.109-2.172c0.281-0.297 0.688-0.406 1.094-0.297 0.391 0.094 0.703 0.406 0.797 0.797l0.75 2.938 2.906-0.828c0.391-0.109 0.812 0 1.094 0.297 0.297 0.281 0.406 0.703 0.297 1.094l-0.828 2.906 2.938 0.75c0.391 0.094 0.703 0.406 0.812 0.797 0.094 0.391-0.016 0.812-0.313 1.094z"></path>
+</symbol>
+<symbol id="icon-envelope-o" viewbox="0 0 28 28">
+<title>envelope-o</title>
+<path d="M26 23.5v-12c-0.328 0.375-0.688 0.719-1.078 1.031-2.234 1.719-4.484 3.469-6.656 5.281-1.172 0.984-2.625 2.188-4.25 2.188h-0.031c-1.625 0-3.078-1.203-4.25-2.188-2.172-1.813-4.422-3.563-6.656-5.281-0.391-0.313-0.75-0.656-1.078-1.031v12c0 0.266 0.234 0.5 0.5 0.5h23c0.266 0 0.5-0.234 0.5-0.5zM26 7.078c0-0.391 0.094-1.078-0.5-1.078h-23c-0.266 0-0.5 0.234-0.5 0.5 0 1.781 0.891 3.328 2.297 4.438 2.094 1.641 4.188 3.297 6.266 4.953 0.828 0.672 2.328 2.109 3.422 2.109h0.031c1.094 0 2.594-1.437 3.422-2.109 2.078-1.656 4.172-3.313 6.266-4.953 1.016-0.797 2.297-2.531 2.297-3.859zM28 6.5v17c0 1.375-1.125 2.5-2.5 2.5h-23c-1.375 0-2.5-1.125-2.5-2.5v-17c0-1.375 1.125-2.5 2.5-2.5h23c1.375 0 2.5 1.125 2.5 2.5z"></path>
+</symbol>
+<symbol id="icon-share-alt" viewbox="0 0 24 28">
+<title>share-alt</title>
+<path d="M19 16c2.766 0 5 2.234 5 5s-2.234 5-5 5-5-2.234-5-5c0-0.172 0.016-0.359 0.031-0.531l-5.625-2.812c-0.891 0.828-2.094 1.344-3.406 1.344-2.766 0-5-2.234-5-5s2.234-5 5-5c1.313 0 2.516 0.516 3.406 1.344l5.625-2.812c-0.016-0.172-0.031-0.359-0.031-0.531 0-2.766 2.234-5 5-5s5 2.234 5 5-2.234 5-5 5c-1.313 0-2.516-0.516-3.406-1.344l-5.625 2.812c0.016 0.172 0.031 0.359 0.031 0.531s-0.016 0.359-0.031 0.531l5.625 2.812c0.891-0.828 2.094-1.344 3.406-1.344z"></path>
+</symbol>
+<symbol id="icon-print" viewbox="0 0 26 28">
+<title>print</title>
+<path d="M6 24h14v-4h-14v4zM6 14h14v-6h-2.5c-0.828 0-1.5-0.672-1.5-1.5v-2.5h-10v10zM24 15c0-0.547-0.453-1-1-1s-1 0.453-1 1 0.453 1 1 1 1-0.453 1-1zM26 15v6.5c0 0.266-0.234 0.5-0.5 0.5h-3.5v2.5c0 0.828-0.672 1.5-1.5 1.5h-15c-0.828 0-1.5-0.672-1.5-1.5v-2.5h-3.5c-0.266 0-0.5-0.234-0.5-0.5v-6.5c0-1.641 1.359-3 3-3h1v-8.5c0-0.828 0.672-1.5 1.5-1.5h10.5c0.828 0 1.969 0.469 2.562 1.062l2.375 2.375c0.594 0.594 1.062 1.734 1.062 2.562v4h1c1.641 0 3 1.359 3 3z"></path>
+</symbol>
+<symbol id="icon-notebook-list" viewbox="0 0 32 32">
+<title>notebook-list</title>
+<path d="M22.769 1.231v-1.231h1.231v1.231h1.234c1.362 0 2.458 1.104 2.458 2.466v25.837c0 1.371-1.101 2.466-2.458 2.466h-18.468c-1.362 0-2.458-1.104-2.458-2.466v-25.837c0-1.371 1.101-2.466 2.458-2.466h1.234v-1.231h1.231v1.231h3.692v-1.231h1.231v1.231h3.692v-1.231h1.231v1.231h3.692zM22.769 2.462h-3.692v1.231h-1.231v-1.231h-3.692v1.231h-1.231v-1.231h-3.692v1.231h-1.231v-1.231h-1.231c-0.68 0-1.231 0.54-1.231 1.235v25.839c0 0.682 0.56 1.235 1.231 1.235h18.462c0.68 0 1.231-0.54 1.231-1.235v-25.839c0-0.682-0.56-1.235-1.231-1.235h-1.231v1.231h-1.231v-1.231zM14.154 11.077v1.231h9.846v-1.231h-9.846zM8 9.846h3.692v3.692h-3.692v-3.692zM9.231 11.077v1.231h1.231v-1.231h-1.231zM8 16h3.692v3.692h-3.692v-3.692zM9.231 17.231v1.231h1.231v-1.231h-1.231zM14.154 17.231v1.231h9.846v-1.231h-9.846zM8 22.154h3.692v3.692h-3.692v-3.692zM9.231 23.385v1.231h1.231v-1.231h-1.231zM14.154 23.385v1.231h9.846v-1.231h-9.846z"></path>
+</symbol>
+<symbol id="icon-notebook-text" viewbox="0 0 32 32">
+<title>notebook-text</title>
+<path d="M22.154 1.231v-1.231h1.231v1.231h1.234c1.362 0 2.458 1.104 2.458 2.466v25.837c0 1.371-1.101 2.466-2.458 2.466h-18.468c-1.362 0-2.458-1.104-2.458-2.466v-25.837c0-1.371 1.101-2.466 2.458-2.466h1.234v-1.231h1.231v1.231h3.692v-1.231h1.231v1.231h3.692v-1.231h1.231v1.231h3.692zM22.154 2.462h-3.692v1.231h-1.231v-1.231h-3.692v1.231h-1.231v-1.231h-3.692v1.231h-1.231v-1.231h-1.231c-0.68 0-1.231 0.54-1.231 1.235v25.839c0 0.682 0.56 1.235 1.231 1.235h18.462c0.68 0 1.231-0.54 1.231-1.235v-25.839c0-0.682-0.56-1.235-1.231-1.235h-1.231v1.231h-1.231v-1.231zM7.385 7.385v1.231h16v-1.231h-16zM7.385 11.077v1.231h16v-1.231h-16zM7.385 14.769v1.231h16v-1.231h-16zM7.385 18.462v1.231h16v-1.231h-16zM7.385 22.154v1.231h16v-1.231h-16zM7.385 25.846v1.231h16v-1.231h-16z"></path>
+</symbol>
+<symbol id="icon-document-recording" viewbox="0 0 32 32">
+<title>document-recording</title>
+<path d="M19.556 0h0.593l7.111 8.296v21.344c0 1.295-1.060 2.359-2.367 2.359h-17.784c-1.311 0-2.367-1.065-2.367-2.379v-27.242c0-1.314 1.063-2.379 2.374-2.379h12.441zM18.963 1.185h-11.857c-0.652 0-1.18 0.54-1.18 1.18v27.27c0 0.652 0.539 1.18 1.185 1.18h17.778c0.655 0 1.185-0.527 1.185-1.177v-20.156h-4.743c-1.308 0-2.368-1.051-2.368-2.377v-5.919zM20.148 1.778v5.323c0 0.66 0.534 1.196 1.181 1.196h4.389l-5.57-6.519zM11.852 20.734v-1.771h1.185v1.769c0 1.641 1.315 2.972 2.963 2.972 1.636 0 2.963-1.333 2.963-2.972v-1.769h1.185v1.771c0 2.095-1.545 3.825-3.556 4.113v2.412h2.37v1.185h-5.926v-1.185h2.37v-2.413c-2.007-0.288-3.556-2.020-3.556-4.112v0zM14.222 16.002v0c0-0.984 0.796-1.78 1.778-1.78 0.989 0 1.778 0.797 1.778 1.78v4.737c0 0.984-0.796 1.78-1.778 1.78-0.989 0-1.778-0.797-1.778-1.78v-4.737zM16 15.407c-0.327 0-0.593 0.255-0.593 0.59v4.746c0 0.326 0.275 0.59 0.593 0.59 0.327 0 0.593-0.255 0.593-0.59v-4.746c0-0.326-0.275-0.59-0.593-0.59v0z"></path>
+</symbol>
+</defs>
+</svg></div>    
+</div> <!-- <FeatherSection name="SVGs"></FeatherSection> --> </div> <!--googleon: all --> 
+<div id="Header_T25F18B5E018_Col00" class="sf_colsIn header-start" data-sf-element="Div" data-placeholder-label="Header Start"><div id="Header_T25F18B5E024_Col00" class="sf_colsIn container flex-container" data-sf-element="Container" data-placeholder-label="Container"><div id="Header_T25F18B5E026_Col00" class="sf_colsIn branding" data-sf-element="Div" data-placeholder-label="Branding">
+<div class="site-logo" >
+    <div class="sf-Long-text" ><a href="/home"><img alt="Logo of Cuyahoga County" src="https://cuyahogacms.blob.core.windows.net/home/images/default-source/default-album/county_logo100.png?sfvrsn=89399372_2" /></a></div>    
+</div>
+<div class="site-name" >
+    <div class="sf-Long-text" ><a href="/home"><img src="https://cuyahogacms.blob.core.windows.net/home/images/default-source/default-album/cco.png?sfvrsn=6fb4683f_2" alt="Cuyahoga County. Ohio" /></a><br /><strong>Boards and Commissions</strong></div>    
+</div></div>
+<div >
+    <div class="sf-Long-text" ><div class="font-sizer"><button class="btn btn-default btn-sm hidden-xs" id="incfont" tabindex="-1">A +</button><button class="btn btn-default btn-xs hidden-xs" id="decfont" tabindex="-1">A -</button></div></div>    
+</div>
+
+
+<div class="search-box search-box--header form-inline">
+    <div class="form-inner">
+        <div class="form-group">
+            <input class="form-control" placeholder="I'm looking for..." type="text" id="8e4a6ea3-a57a-44e2-b0a2-33815a69a099">
+        </div>
+        <button type="button" class="btn btn-primary" id="d266ba69-040e-4092-b823-e9c3d9b45f20">
+            <span class="visually-hidden">Submit</span>
+            <svg class="icon icon-search"><use xlink:href="#icon-search" xmlns:xlink="http://www.w3.org/1999/xlink"></use></svg>
+        </button>
+    </div>
+
+    <input type="hidden" data-sf-role="resultsUrl" value="/boards-and-commissions/search-results" />
+    <input type="hidden" data-sf-role="indexCatalogue" value="bcindex" />
+    <input type="hidden" data-sf-role="wordsMode" value="AllWords" />
+    <input type="hidden" data-sf-role="disableSuggestions" value='false' />
+    <input type="hidden" data-sf-role="minSuggestionLength" value="3" />
+    <input type="hidden" data-sf-role="suggestionFields" value="Title,Content" />
+    <input type="hidden" data-sf-role="language" value="" />
+    <input type="hidden" data-sf-role="suggestionsRoute" value="/restapi/search/suggestions" />
+    <input type="hidden" data-sf-role="searchTextBoxId" value='#8e4a6ea3-a57a-44e2-b0a2-33815a69a099' />
+    <input type="hidden" data-sf-role="searchButtonId" value='#d266ba69-040e-4092-b823-e9c3d9b45f20' />
+
+    
+</div>
+
+
+
+
+
+
+
+
+<div class="social-links social-links--header" >
+    <div class="sf-Long-text" ><div class="social-links"><ul role="menubar"><li><a href="https://www.facebook.com/CuyahogaCounty" title="Facebook" target="_blank" data-sf-ec-immutable=""><em class="fab fa-facebook fa-lg"></em><span class="text-hide">Facebook</span></a></li><li><a href="https://twitter.com/CuyahogaCounty" title="Twitter" target="_blank" data-sf-ec-immutable=""><em class="fab fa-twitter fa-lg"></em><span class="text-hide">Twitter</span></a></li><li><a href="https://www.youtube.com/CuyahogaCounty" title="YouTube" target="_blank" data-sf-ec-immutable=""><em class="fab fa-youtube fa-lg"></em><span class="text-hide">Youtube</span></a></li><li><a href="/county-news/newsletter-registration" title="Newsletter Registration" target="_blank"><em class="fas fa-envelope fa-lg"></em><span class="text-hide">Newsletter Registration</span></a></li><li><a href="https://www.instagram.com/cuyahogacounty/" title="Instagram" target="_blank" data-sf-ec-immutable=""><em class="fab fa-instagram fa-lg"></em><span class="text-hide">Instagram</span></a></li><li><a href="/executive/news/lets-talk-cuyahoga-podcast" title="Podcast" target="_blank"><em class="fas fa-podcast fa-lg"></em><span class="text-hide">Podcast</span></a></li></ul></div></div>    
+</div>
+</div>
+</div><div id="Header_T25F18B5E019_Col00" class="sf_colsIn header-end" data-sf-element="Div" data-placeholder-label="Header End"><div id="Header_T25F18B5E025_Col00" class="sf_colsIn container flex-container" data-sf-element="Container" data-placeholder-label="Container">
+<div class="main-navigation ">
+    
+    <div class="navbar-header">
+        <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+        </button>
+    </div>
+
+    <div class="navbar-collapse js-navbar-collapse pull-left underButton phoneSizeMenuStyle collapse" id="bs-example-navbar-collapse-1">
+        <ul class="nav navbar-nav">
+        <li class=""><a href="/boards-and-commissions" target="_self">HOME</a></li>
+        <li class=""><a href="/boards-and-commissions/all-boards" target="_self">All Boards</a></li>
+        <li class=""><a href="/boards-and-commissions/calendar" target="_self">Calendar</a></li>
+        <li class=""><a href="/boards-and-commissions/about-us" target="_self">About Us</a></li>
+        </ul>
+    </div><!-- /.navbar-collapse -->
+</div>
+
+
+
+
+
+
+
+
+
+<div>
+    
+
+      <ul class=" list-unstyled btn btn-warning btn-sm warningButton text-white">
+     <li class="">
+        <a href="/boards-and-commissions/boards-and-commissions-application" target="_self">Apply Online</a>
+
+    </li>
+    </ul>
+</div>
+
+
+
+
+
+
+<div class="searchbox-toggle-button" >
+    <div class="sf-Long-text" ><button type="button"><span class="sr-only">search</span>
+<svg class="icon icon-search"><use xlink:href="#icon-search" xmlns:xlink="http://www.w3.org/1999/xlink"></use></svg>
+</button></div>    
+</div>
+</div>
+</div> </header> <!-- end Header --> <!-- Site Main --> <div class="site-main"> 
+
+<div class="site-alert">
+    </div> <!-- Main Content --> <main class="main-content" role="main" id="main" tabindex="-1">
+<div id="Contentplaceholder1_T04DEF6BE051_Col00" class="sf_colsIn container" data-sf-element="Container" data-placeholder-label="Container"><div>
+    <ul class="sf-breadscrumb breadcrumb">
+                <li><a href="/">Home </a></li>
+                <li><a href="/boards-and-commissions">Boards and Commissions </a></li>
+                <li class="active">Board Details</li>
+    </ul>
+</div>
+<div >
+    <div class="sf-Long-text" ></div>    
+</div><div class="row" data-sf-element="Row">
+    <div id="Contentplaceholder1_T04DEF6BE057_Col00" class="sf_colsIn col-md-12" data-sf-element="Column 1" data-placeholder-label="Column 1">
+
+
+<div >
+    <h1 >
+        Board of Control
+    </h1>
+
+    <br />
+
+
+
+        <h2>Contact Information:</h2>
+        <div class="sf-Long-text" ><p><a href="mailto:ckinzig@cuyahogacounty.us">Cheryl Kinzig</a><br />216-443-5852</p></div>
+        
+        <h2>Description of Board and Responsibilities:</h2>
+        <div class="sf-Long-text" ><p>The Board of Control has approval authority over all County contracts and purchases valued from $5,000 to $500,000 (<a target="_blank" href="/code/titles/title-2-county-organization/chapter-205-boards">Cuyahoga County Code Title 2, Section 205.01</a>; <a target="_blank" href="/code/titles/title-5-contracts-and-purchasing/chapter-501-contracts-and-purchasing-procedures">Cuyahoga County Code Title 5, Section 501.04B</a>). Membership is comprised of the County Executive, Fiscal Officer, Director of Public Works, Director the Office of Procurement and Diversity, and three members of County Council appointed by the Council President. The Board of Control meets weekly to review, deliberate, and vote on various contracts, agreements, purchases and other contracting and purchasing matters under its authority. All meetings are open to the public. </p></div>
+            
+<h2>Qualifications:</h2>
+        <div class="sf-Long-text" ><p>Membership is comprised of the County Executive, Fiscal Officer, Director of Public Works, Director the Office of Procurement and Diversity, and three members of County Council appointed by the Council President. Members serve at the virtue of their positions with Cuyahoga County.</p></div>
+    
+                <h2>ByLaws: </h2>
+            <a href='https://cuyahogacms.blob.core.windows.net/home/docs/default-source/boards-and-commissions/internal/boc/bocrules.pdf?sfvrsn=7e533eb3_3'>Board of Control Rules</a><br>
+
+        <h2>Enabling Legislation:</h2>
+        <div class="sf-Long-text" ><p><a href="http://council.cuyahogacounty.us/pdf_council/en-US/Legislation/Ordinances/2015/O2015-0006G%20Enacting%20the%20Board%20of%20Control%20Consolidation%20Act.pdf" target="_blank" data-sf-ec-immutable="">Council Ordinance O2015-0006</a></p><p><a target="_blank" href="/code/titles/title-2-county-organization/chapter-205-boards">Cuyahoga County Code 205.01</a>
+</p><p>&nbsp;</p></div>
+
+    
+
+
+
+
+    </div>
+
+<script>
+	
+	$( ".all" ).removeClass( "active" );
+
+
+	
+	
+	
+</script>
+
+
+
+<style>
+    .bcyeargrid {
+        width: 20%;
+        margin-left: 0px;
+    }
+
+    .bceventgrid {
+        margin-top: -20px;
+        margin-left: 0px;
+        margin-right: 0px;
+    }
+
+    .svgsize {
+        height: 25px;
+        width: 25px;
+    }
+
+    .bccalendarboard {
+        margin-top: -40px;
+    }
+</style>
+
+    <div class="row bceventgrid">
+        <h3>MEETING SCHEDULE:</h3>
+        <table class="table table-striped table-bordered">
+            <thead>
+                <tr>
+                    <th>Date</th>
+                    <th>Title</th>
+                    <th>Files</th>
+                </tr>
+            <tbody>
+                    <tr>
+
+                        <td>1/29/2024</td>
+                        
+                        <td><a href="/boards-and-commissions/bc-event-detail//2024/01/29/boards-and-commissions/01-29-24---board-of-control-meeting">01/29/24 - Board of Control Meeting</a></td>
+                        <td>
+                            <div class="related-content">
+                                    <a href="/docs/default-source/boards-and-commissions/internal/boc/2024/012924-bocagenda.pdf">
+                                        <svg class="icon icon-notebook-list svgsize"><use xlink:href="#icon-notebook-list"></use></svg>
+                                        <span>Agendas</span>
+                                    </a>
+                                                            </div>
+                        </td>
+                    </tr>
+                    <tr>
+
+                        <td>1/22/2024</td>
+                        
+                        <td><a href="/boards-and-commissions/bc-event-detail//2024/01/22/boards-and-commissions/01-22-24---board-of-control-meeting">01/22/24 - Board of Control Meeting</a></td>
+                        <td>
+                            <div class="related-content">
+                                    <a href="/docs/default-source/boards-and-commissions/internal/boc/2024/012224-bocagenda.pdf">
+                                        <svg class="icon icon-notebook-list svgsize"><use xlink:href="#icon-notebook-list"></use></svg>
+                                        <span>Agendas</span>
+                                    </a>
+                                                            </div>
+                        </td>
+                    </tr>
+                    <tr>
+
+                        <td>1/16/2024</td>
+                        
+                        <td><a href="/boards-and-commissions/bc-event-detail//2024/01/16/boards-and-commissions/01-16-24---board-of-control-meeting">01/16/24 - Board of Control Meeting</a></td>
+                        <td>
+                            <div class="related-content">
+                                    <a href="/docs/default-source/boards-and-commissions/internal/boc/2024/011624-bocagenda.pdf">
+                                        <svg class="icon icon-notebook-list svgsize"><use xlink:href="#icon-notebook-list"></use></svg>
+                                        <span>Agendas</span>
+                                    </a>
+                                                                    <a href="/docs/default-source/boards-and-commissions/internal/boc/2024/011624-bocminutes.pdf">
+                                        <svg class="icon icon-notebook-text" style="height:25px;width:25px;"><use xlink:href="#icon-notebook-text"></use></svg>
+                                        <span>Minutes</span>
+                                    </a>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr>
+
+                        <td>1/08/2024</td>
+                        
+                        <td><a href="/boards-and-commissions/bc-event-detail//2024/01/08/boards-and-commissions/01-08-24---board-of-control-meeting">01/08/24 - Board of Control Meeting</a></td>
+                        <td>
+                            <div class="related-content">
+                                    <a href="/docs/default-source/boards-and-commissions/internal/boc/2024/010824-bocagenda.pdf">
+                                        <svg class="icon icon-notebook-list svgsize"><use xlink:href="#icon-notebook-list"></use></svg>
+                                        <span>Agendas</span>
+                                    </a>
+                                                                    <a href="/docs/default-source/boards-and-commissions/internal/boc/2024/010824-bocminutes.pdf">
+                                        <svg class="icon icon-notebook-text" style="height:25px;width:25px;"><use xlink:href="#icon-notebook-text"></use></svg>
+                                        <span>Minutes</span>
+                                    </a>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr>
+
+                        <td>1/02/2024</td>
+                        
+                        <td><a href="/boards-and-commissions/bc-event-detail//2024/01/02/boards-and-commissions/01-02-24---board-of-control-meeting">01/02/24 - Board of Control Meeting</a></td>
+                        <td>
+                            <div class="related-content">
+                                    <a href="/docs/default-source/boards-and-commissions/internal/boc/2024/010224-bocagenda.pdf">
+                                        <svg class="icon icon-notebook-list svgsize"><use xlink:href="#icon-notebook-list"></use></svg>
+                                        <span>Agendas</span>
+                                    </a>
+                                                                    <a href="/docs/default-source/boards-and-commissions/internal/boc/2024/010224-bocminutes.pdf">
+                                        <svg class="icon icon-notebook-text" style="height:25px;width:25px;"><use xlink:href="#icon-notebook-text"></use></svg>
+                                        <span>Minutes</span>
+                                    </a>
+                            </div>
+                        </td>
+                    </tr>
+            </tbody>
+        </table>
+    </div>
+    <div class="row bcyeargrid">
+        <h3>View By Year</h3>
+
+        <table class="table table-striped table-bordered">
+            <thead>
+                <tr>
+                    <th>Years</th>
+                </tr>
+            </thead>
+            <tbody>
+                    <tr>
+                        <td>
+                            <a href="board-of-control?year=2024">2024</a>
+                            
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <a href="board-of-control?year=2023">2023</a>
+                            
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <a href="board-of-control?year=2022">2022</a>
+                            
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <a href="board-of-control?year=2021">2021</a>
+                            
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <a href="board-of-control?year=2020">2020</a>
+                            
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <a href="board-of-control?year=2019">2019</a>
+                            
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <a href="board-of-control?year=2018">2018</a>
+                            
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <a href="board-of-control?year=2017">2017</a>
+                            
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <a href="board-of-control?year=2016">2016</a>
+                            
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <a href="board-of-control?year=2015">2015</a>
+                            
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <a href="board-of-control?year=2014">2014</a>
+                            
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <a href="board-of-control?year=2013">2013</a>
+                            
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <a href="board-of-control?year=2012">2012</a>
+                            
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <a href="board-of-control?year=2011">2011</a>
+                            
+                        </td>
+                    </tr>
+            </tbody>
+        </table>
+    </div>
+
+
+<br />
+<br />
+<br />
+
+<div >
+    <div class="sf-Long-text" ></div>    
+</div>
+    </div>
+</div>
+
+</div>
+</main> <!-- end Main Content --> </div> <!-- end Site Main --> <!-- Footer --> <footer class="site-footer footer" role="contentinfo" aria-label="Site Footer">
+<div id="Footer_T25F18B5E001_Col00" class="sf_colsIn container" data-sf-element="Container" data-placeholder-label="Container"><div class="row" data-sf-element="Row">
+    <div id="Footer_T167E4FAD083_Col00" class="sf_colsIn col-md-4" data-sf-element="Column 1" data-placeholder-label="Column 1">
+<div >
+    <div class="sf-Long-text" > <p>The majority of the Boards and Commissions in Cuyahoga County are Citizen Policy Making and Advisory Boards and Commissions. All of these boards and commissions are governed by the laws and regulations that have authorized them. Members represent the specific mission of the boards or commission to which they have been appointed. </p></div>    
+</div>
+    </div>
+    <div id="Footer_T167E4FAD083_Col01" class="sf_colsIn col-md-4" data-sf-element="Column 2" data-placeholder-label="Column 2">
+<div >
+    <div class="sf-Long-text" ><h3>Useful Links</h3><ul><li><a href="https://codes.ohio.gov/ohio-revised-code" target="_blank" data-sf-ec-immutable="">Ohio Revised Codes</a> </li><li><a target="_blank" href="/code">Cuyahoga County Code</a> </li><li><a href="http://council.cuyahogacounty.us/en-US/Charter-CuyahogaCounty.aspx" target="_blank" data-sf-ec-immutable="">Cuyahoga County Charter</a>
+ </li></ul></div>    
+</div>
+    </div>
+    <div id="Footer_T167E4FAD083_Col02" class="sf_colsIn col-md-4" data-sf-element="Column 3" data-placeholder-label="Column 3">
+<div >
+    <div class="sf-Long-text" ><h3>Site Info</h3></div>    
+</div>
+
+
+<div>
+    
+    <ul class="list-unstyled">
+     <li class="">
+        <a href="/a-z-directory" target="_self">Departments</a>
+    </li>
+     <li class="">
+        <a href="/faqs" target="_self">FAQs</a>
+    </li>
+     <li class="">
+        <a href="/public-records-request" target="_self">Public Records Request</a>
+    </li>
+     <li class="">
+        <a href="/privacy-policy" target="_self">Privacy Policy</a>
+    </li>
+     <li class="">
+        <a href="/disclaimer" target="_self">Disclaimer</a>
+    </li>
+     <li class="">
+        <a href="/accessibility" target="_self">Accessibility</a>
+    </li>
+     <li class="">
+        <a href="/i-want-to-contact/county-social-media" target="_self">County Social Media</a>
+    </li>
+    </ul>
+</div>
+
+
+
+
+
+    </div>
+</div>
+<div class="row footer-bottom" data-sf-element="Row">
+    <div id="Footer_T25F18B5E036_Col00" class="sf_colsIn col-md-6" data-sf-element="Column 1" data-placeholder-label="Column 1">
+<div >
+    <div class="sf-Long-text" ><a target="_blank" href="/information-technology">Powered by the Department of Information Technology</a>
+<br /><br /><a href="https://www.sitefinity.com/customers/website-of-the-year/2017" target="_blank" data-sf-ec-immutable="">Progress Sitefinity 2017 Website of the Year - Government Category</a><br /></div>    
+</div>
+    </div>
+    <div id="Footer_T25F18B5E036_Col01" class="sf_colsIn col-md-6" data-sf-element="Column 2" data-placeholder-label="Column 2">
+<div >
+    <div class="sf-Long-text" ><p>The official government website of Cuyahoga County. <br />Quick facts about Cuyahoga County from the <a href="https://www.census.gov/quickfacts/fact/table/cuyahogacountyohio/PST045219">U.S. Census Bureau</a> <br />Cuyahoga County is a member of the <a href="https://www.naco.org/">National Association of Counties</a></p></div>    
+</div>
+    </div>
+</div>
+
+</div>
+
+
+
+
+
+
+
+
+</footer> <!-- end Footer --> </div> <script src="/Frontend-Assembly/Telerik.Sitefinity.Frontend/Mvc/Scripts/Bootstrap/js/bootstrap.min.js?package=Bootstrap&amp;v=MTQuMi43OTAwLjA%3d" type="text/javascript"></script> <script src="/ResourcePackages/Bootstrap/assets/dist/js/slick.min.js"></script> <script src="/ResourcePackages/Bootstrap/assets/dist/js/project.min.js"></script> <script src="/Frontend-Assembly/Telerik.Sitefinity.Frontend.Search/Mvc/Scripts/SearchBox/Search-box.min.js?package=Bootstrap&amp;v=MTQuMi43OTAwLjA%3d" type="text/javascript"></script><script type="application/json" id="PersonalizationTracker">
+	{"IsPagePersonalizationTarget":false,"IsUrlPersonalizationTarget":false,"PageId":"cb38f601-d9b3-4d37-977c-77c2447a07d2"}
+</script><script type="text/javascript" src="/WebResource.axd?d=Oiw5o8i74rDb2VpVaCaMSqM7nqpJ7y9OdepsWDIrAYMyxQaEl6SKqYBKfnuQhljNeS8ETgA7LZkl-qD6Zgl62djfgm2ytO4J-XoYuTm3QEXKf1E0g0uL-02gaUtRmWPN_dtbCNDV73tMqHSfelJH31cpRO-Fr6KCcp6rbXwsaJGsMQlQFVbBO4inQJKd9bPDWb_JGiXu0bk-Q2YYFfukA45QgfR0tXm1Ne33G3qHZag1&amp;t=637988280879082224">
+
+</script> <script src="/ResourcePackages/Bootstrap/assets/dist/js/sweetalert2.all.min.js"></script> <link href="/ResourcePackages/Bootstrap/assets/dist/css/sweetalert2.css" rel="stylesheet" /> <script type="text/javascript" src="https://app-script.monsido.com/v2/monsido-script.js"></script> <script type="text/javascript">
+  window._monsido = window._monsido || {
+        token: "kdx8gAyHUT8TGciNL_KoQw",
+        statistics: {
+            enabled: true,
+            documentTracking: {
+                enabled: true,
+                documentCls: "monsido_download",
+                documentIgnoreCls: "monsido_ignore_download",
+                documentExt: ["pdf","doc","ppt","docx","pptx"],
+            },
+        },
+    };
+</script> </body> </html>

--- a/tests/files/cuya_board_control_detail.html
+++ b/tests/files/cuya_board_control_detail.html
@@ -1,257 +1,403 @@
+<!DOCTYPE html> <html lang="en"> <head> <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" /> <meta name="viewport" content="width=device-width, initial-scale=1"> <meta charset="utf-8" /> <title>
+	01/29/24 - Board of Control Meeting
+</title> <link rel="apple-touch-icon-precomposed" sizes="57x57" href="/assets/icons/apple-touch-icon-57x57.png" /> <link rel="apple-touch-icon-precomposed" sizes="114x114" href="/assets/icons/apple-touch-icon-114x114.png" /> <link rel="apple-touch-icon-precomposed" sizes="72x72" href="/assets/icons/apple-touch-icon-72x72.png" /> <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/assets/icons/apple-touch-icon-144x144.png" /> <link rel="apple-touch-icon-precomposed" sizes="60x60" href="/assets/icons/apple-touch-icon-60x60.png" /> <link rel="apple-touch-icon-precomposed" sizes="120x120" href="/assets/icons/apple-touch-icon-120x120.png" /> <link rel="apple-touch-icon-precomposed" sizes="76x76" href="/assets/icons/apple-touch-icon-76x76.png" /> <link rel="apple-touch-icon-precomposed" sizes="152x152" href="/assets/icons/apple-touch-icon-152x152.png" /> <link rel="icon" type="image/png" href="/assets/icons/favicon-196x196.png" sizes="196x196" /> <link rel="icon" type="image/png" href="/assets/icons/favicon-96x96.png" sizes="96x96" /> <link rel="icon" type="image/png" href="/assets/icons/favicon-32x32.png" sizes="32x32" /> <link rel="icon" type="image/png" href="/assets/icons/favicon-16x16.png" sizes="16x16" /> <link rel="icon" type="image/png" href="/assets/icons/favicon-128.png" sizes="128x128" /> <meta name="application-name" content="&nbsp;" /> <meta name="msapplication-TileColor" content="#FFFFFF" /> <meta name="msapplication-TileImage" content="mstile-144x144.png" /> <meta name="msapplication-square70x70logo" content="mstile-70x70.png" /> <meta name="msapplication-square150x150logo" content="mstile-150x150.png" /> <meta name="msapplication-wide310x150logo" content="mstile-310x150.png" /> <meta name="msapplication-square310x310logo" content="mstile-310x310.png" /> <!-- Google Fonts --> <link href="//fonts.googleapis.com/css?family=Oswald:300,500,700%7COpen+Sans:400,600,700" rel="stylesheet"> <!-- BootstrapCDN for FontsAwsome --> <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.2/css/all.min.css" /> <link href="/ResourcePackages/Bootstrap/assets/dist/css/main.min.css" rel="stylesheet" type="text/css" /><link href="/ResourcePackages/Bootstrap/assets/dist/css/CustomStyles.css" rel="stylesheet" type="text/css" /> <script type="text/javascript" src="https://www.googletagmanager.com/gtag/js?id=G-8C3KCV9D47"></script><script type="text/javascript">
 
+<!-- Google tag (gtag.js) EH 2023-07-17-->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-8C3KCV9D47"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head id="ctl00_Head2"><title>
-	Board of Control Meeting - Cuyahoga County Boards &amp; Commissions
-</title>
+  gtag('config', 'G-8C3KCV9D47');
+</script>
+</script><script type="text/javascript" src="https://app-script.monsido.com/v2/monsido-script.js"></script><script type="text/javascript">
+<script type="text/javascript">
 
-    <script type="text/javascript" src="/JavaScript/fader.js"></script>
+    window._monsido = window._monsido || {
 
-    <link id="ctl00_ResetCSS" rel="stylesheet" href="http://cdn.cuyahogacounty.us/CSS/Reset.css" type="text/css" /><link id="ctl00_AdaptersInvariantImportCSS" rel="stylesheet" href="/App_Themes/Default/CSS/Import.css" type="text/css" /><link id="ctl00_FeatureStylesCSS" rel="stylesheet" href="http://cdn.cuyahogacounty.us/CSS/FeatureStyles.css" type="text/css" /><link id="ctl00_TreeViewCSS" rel="stylesheet" href="http://cdn.cuyahogacounty.us/CSS/SimpleTreeView.css" type="text/css" /><link rel="stylesheet" href="/RadMenuMasterNav/Menu.RadMenuMasterNav.css" type="text/css" media="screen" /><link rel="stylesheet" href="/RadMenuSiteSpecificNav/Menu.RadMenuSiteSpecificNav.css" type="text/css" media="screen" />
-    <!--[if lt IE 7]>
-    <link id="ctl00_IEMenu6CSS" rel="stylesheet" href="/App_Themes/Default/CSS/BrowserSpecific/IEMenu6.css" type="text/css" />
-    <![endif]-->
-    <link rel="shortcut icon" href="/App_Themes/Default/img/icon.gif" type="image/png" /><link rel="icon" href="/App_Themes/Default/img/icon.gif" type="image/png" />
-    <script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+        token: "G98XI9WyVuNOTjDxOORC8g",
 
-  ga('create', 'UA-11952497-44', 'auto');
-  ga('send', 'pageview');
+        statistics: {
+
+            enabled: true,
+
+            documentTracking: {
+
+                enabled: true,
+
+                documentCls: "monsido_download",
+
+                documentIgnoreCls: "monsido_ignore_download",
+
+                documentExt: ["pdf","doc","ppt","docx","pptx"],
+
+            },
+
+        },
+
+        heatmap: {
+
+            enabled: true,
+
+        },
+
+    };
 
 </script>
-<meta name="keywords" content="cuyahoga, county, boards, commissions" /><meta name="description" content="090319 BOC Meeting" /><link href="/css/UserStyles.css" type="text/css" rel="Stylesheet" /><link href="/WebResource.axd?d=nVe01Lcjs-hTs9TECIlH3DmKzGRC2Gkm3S79rG6Rxqzz5YdiOfHWb5tceVj5-I2P38NOsRkGWpKfGW_HrZJF-XcVlxnVDy5MmmJt8YW5ylk6E4ZZHSzDRkQICbltUvzPq93jkA2&amp;t=634516086000000000" type="text/css" rel="stylesheet" class="Telerik_stylesheet" /></head>
-<body>
-    <form name="aspnetForm" method="post" action="EventTemplate.aspx?LanguageCD=en-US&amp;ItemKey=92551&amp;pb=y" id="aspnetForm">
-<input type="hidden" name="__VIEWSTATE" id="__VIEWSTATE" value="/wEPDwUKMjA2MjM4MDM2Ng9kFgJmD2QWAgIDD2QWCgIHDw8WBB4ISW1hZ2VVcmwFHC9pbWdfYmMvZW4tVVMvc2l0ZV90aXRsZS5qcGceDUFsdGVybmF0ZVRleHQFD0N1eWFob2dhIENvdW50eWRkAgkPZBYCZg9kFgYCAQ8PFgYeCENzc0NsYXNzZR4FV2lkdGgbAAAAAADgZUABAAAAHgRfIVNCAoICFgQeB29uQ2xpY2sFNmdldEVsZW1lbnRCeUlkKCdjdGwwMF9TaXRlU2VhcmNoMV90eHRUZXJtcycpLnZhbHVlPScnOx4DYWx0ZWQCAw8PFggeBFRleHQFBlNlYXJjaB4NT25DbGllbnRDbGljawVgaWYoY3RsMDBfU2l0ZVNlYXJjaDFfdHh0VGVybXMudmFsdWUgPT0nJyB8fCBjdGwwMF9TaXRlU2VhcmNoMV90eHRUZXJtcy52YWx1ZSA9PScnKSByZXR1cm4gZmFsc2U7HwIFDHNlYXJjaEJ1dHRvbh8EAgJkZAIFDw8WAh8IBWBpZihjdGwwMF9TaXRlU2VhcmNoMV90eHRUZXJtcy52YWx1ZSA9PScnIHx8IGN0bDAwX1NpdGVTZWFyY2gxX3R4dFRlcm1zLnZhbHVlID09JycpIHJldHVybiBmYWxzZTtkZAIPD2QWAmYPDxYCHwcFpQM8YSBjbGFzcz0nQnJlYWRDcnVtYkxpbmsnIGhyZWY9J2h0dHA6Ly9iYy5jdXlhaG9nYWNvdW50eS51cy9lbi1VUy9ob21lLmFzcHgnPkhvbWU8L2E+Jm5ic3A7PHNwYW4gY2xhc3M9J0JyZWFkQ3J1bWJTZXBhcmF0b3InPiZndDs8L3NwYW4+Jm5ic3A7PGEgY2xhc3M9J0JyZWFkQ3J1bWJMaW5rJyBocmVmPSdodHRwOi8vYmMuY3V5YWhvZ2Fjb3VudHkudXMvZW4tVVMvSW50ZXJuYWwtQm9hcmRzLmFzcHgnPkludGVybmFsIEJvYXJkczwvYT4mbmJzcDs8c3BhbiBjbGFzcz0nQnJlYWRDcnVtYlNlcGFyYXRvcic+Jmd0Ozwvc3Bhbj4mbmJzcDs8YSBjbGFzcz0nQnJlYWRDcnVtYkxpbmsnIGhyZWY9J2h0dHA6Ly9iYy5jdXlhaG9nYWNvdW50eS51cy9lbi1VUy9Cb2FyZC1vZi1Db250cm9sLmFzcHgnPkJvYXJkIG9mIENvbnRyb2w8L2E+Jm5ic3A7ZGQCEQ9kFgICAQ9kFgYCAQ8WAh8HBRhCb2FyZCBvZiBDb250cm9sIE1lZXRpbmdkAgMPZBYMAgEPFgIfBwUYQm9hcmQgb2YgQ29udHJvbCBNZWV0aW5nZAIFDxYCHwcFETkvMy8yMDE5LTExOjAwIEFNZAIHD2QWAgIDDxYCHwcFETkvMy8yMDE5LTEyOjAwIFBNZAILDxYCHwcFQ0NvdW50eSBIZWFkcXVhcnRlcnMsIDIwNzkgRWFzdCBOaW50aCBTdHJlZXQsIDR0aCAtIENvbW1pdHRlZSBSb29tIEJkAg8PFgIfBwWGAzxzdHlsZT4KICAgIC5lbWJlZC1jb250YWluZXIgeyBwb3NpdGlvbjogcmVsYXRpdmU7IHBhZGRpbmctYm90dG9tOiA1Ni4yNSU7IGhlaWdodDogMDsgb3ZlcmZsb3c6IGhpZGRlbjsgbWF4LXdpZHRoOiAxMDAlOyB9IC5lbWJlZC1jb250YWluZXIgaWZyYW1lLCAuZW1iZWQtY29udGFpbmVyIG9iamVjdCwgLmVtYmVkLWNvbnRhaW5lciBlbWJlZCB7IHBvc2l0aW9uOiBhYnNvbHV0ZTsgdG9wOiAwOyBsZWZ0OiAwOyB3aWR0aDogMTAwJTsgaGVpZ2h0OiAxMDAlOyB9Cjwvc3R5bGU+CjxkaXYgY2xhc3M9ImVtYmVkLWNvbnRhaW5lciI+PGlmcmFtZSBzcmM9Imh0dHBzOi8vd3d3LnlvdXR1YmUuY29tL2VtYmVkLy95TWhVYWF4bGRJZyIgZnJhbWVib3JkZXI9IjAiPjwvaWZyYW1lPjwvZGl2PmQCEQ9kFgICAQ8PFgQfBwU0TG9naW4gb3IgcmVnaXN0ZXIgaW4gb3JkZXIgdG8gc2lnbiB1cCBmb3IgdGhpcyBldmVudB4HVmlzaWJsZWhkZAIFD2QWAgIBDw8WAh4cdXNlckxvZ2dlZEluQmVmb3JlRm9ybVN1Ym1pdGhkFgQCAQ9kFgYCAw8PFgYfB2UfAgUQRm9ybU1lc3NhZ2VDbGFzcx8EAgJkZAIJDw8WCB8HBQVMb2dpbh8CBQ5idXR0b25Ob01hcmdpbh8EAgIfCWhkZAILD2QWAmYPZBYGZg8QD2QWAh4Fc3R5bGUFDWRpc3BsYXk6bm9uZTtkFgBkAgEPFgIfCWhkAgIPEA8WAh8JaGRkZGQCAw8PFgIfCWhkFgICAw8PFgQfAgUOYnV0dG9uTm9NYXJnaW4fBAICZGQCEw8WAh8HBdMCwqA8YnIgLz4KVGhlIG1ham9yaXR5IG9mIHRoZSBCb2FyZHMgYW5kIENvbW1pc3Npb25zIGluIEN1eWFob2dhIENvdW50eSBhcmUgQ2l0aXplbiBQb2xpY3kgTWFraW5nIGFuZCBBZHZpc29yeSBCb2FyZHMgYW5kIENvbW1pc3Npb25zLiBBbGwgb2YgdGhlc2UgYm9hcmRzIGFuZCBjb21taXNzaW9ucyBhcmUgZ292ZXJuZWQgYnkgdGhlIGxhd3MgYW5kIHJlZ3VsYXRpb25zIHRoYXQgaGF2ZSBhdXRob3JpemVkIHRoZW0uIE1lbWJlcnMgcmVwcmVzZW50IHRoZSBzcGVjaWZpYyBtaXNzaW9uIG9mIHRoZSBib2FyZHMgb3IgY29tbWlzc2lvbiB0byB3aGljaCB0aGV5IGhhdmUgYmVlbiBhcHBvaW50ZWQuZBgBBR5fX0NvbnRyb2xzUmVxdWlyZVBvc3RCYWNrS2V5X18WAgUVY3RsMDAkbWFzdGVyTmF2JE1lbnUxBRtjdGwwMCRzaXRlU3BlY2lmaWNOYXYkTWVudTEr04BDC0JBb+4XcLJVy2x7t+zx1w==" />
 
+<script type="text/javascript" async src=https://app-script.monsido.com/v2/monsido-script.js></script>
+</script><meta name="Generator" content="Sitefinity 14.2.7900.0 DX" /><link rel="canonical" href="https://cuyahogacounty.gov/boards-and-commissions/bc-event-detail" /></head> <body> <div class="sfPublicWrapper" id="PublicWrapper"> <!-- Header --> <header class="site-header navbar-fixed-top" role="banner" aria-label="Site Header" style="background:#e5f6fe;"> <a id="skippy" class="sr-only-focusable fixed-top official-site full-size-official-site" data-toggle="collapse" href="#collapseContainer" aria-expanded="false"
+      aria-controls="collapseContainer"> <div class="container-fluid center official-blue-bar"> <span class="skiplink-text"> <img src="/ResourcePackages/Bootstrap/assets/dist/images/us_flag_small.png" alt="Image of the State of Ohio flag"> An official website of the Cuyahoga County government. Here’s how you know
+       </span> </div> </a> <div class="row collapse top-ribbon" id="collapseContainer"> <div class="card shadow border parent justify-content-center align-items-center officialWebSite" style="z-index: 6000000!important;"> <div class="card-body" style="padding:0px;"> <div class="row  container"> <div class="col-lg-1"> <img src="/ResourcePackages/Bootstrap/assets/dist/images/icon-dott-gov.png" alt="" /> </div> <div class="col-lg-5 x-small-text"> <strong>The .gov means it&#39;s official.</strong> <br /> A .gov website belongs to an official government organization in the United States.
+        </div> <div class="col-lg-1"> <img src="/ResourcePackages/Bootstrap/assets/dist/images/icon-https.png" alt="" /> </div> <div class="col-lg-5 x-small-text"> <strong>The site is secure.</strong><br /> A lock or https:// means you’ve safely connected to the .gov website. Share sensitive information only on official, secure websites.
+          
+        </div> </div> </div> </div> </div> <a class="skip-link" href="#main"><h1>Skip to Main Content</h1></a> <script src="/ScriptResource.axd?d=okuX3IVIBwfJlfEQK32K3gsjCNmXHz3Ps0ekJj_lJW6grU8z7sDn5c1SO0Q7O_P2C6QozfOyMcSH-VuHV5kqd4jkwQBtjd3Y1zeJ3MgvRCas-0-_K9iboUvPq9VF9WWCU5qbFBXusaawqZGl2tMiN2a58saD4bplygm5bWH-KZAm1CqGCf-EluYhR8BPhSVf0&amp;t=4e1c7b51" type="text/javascript"></script><script src="/ScriptResource.axd?d=EydukmxBmDstn7gSYzQESNmFydCbazOPXX7jPXGKatBMaujCe6TlGaN2thRd9gsQOqsMOK9q7sa1LF5uYBun3bVs5dW6fRbh2veIhlU8FkrvFVx9p17ftwF0OBn9QTsQ02e0vCekC_e8XNyHoMsSgKT5VxjIHc521_CttxbRanDwgMc6tZB24FEczHHnBqMY0&amp;t=4e1c7b51" type="text/javascript"></script><script src="/ScriptResource.axd?d=2z9h4-hKx8Yk1hygmet7puwDjZws3DhD-ASRIY5bp0qCCGiaOmEenIHwp1E0KB_rvsCbF-1F2BSAelnzWqUBdpRtNsHu4X2-Fi3rChdYOEatrQmAF6uPAJMP-QfQueWGta8Aa491C-NUopffEih39wo5sS1nvAHaoHjPy7JjfdFQw-qXB-0tmphFDY2hiXC20&amp;t=4e1c7b51" type="text/javascript"></script> <!--googleoff: all --> <div class="top-section" aria-hidden="true"> 
 
-<script src="/ScriptResource.axd?d=txTNptnyP-kHR71XaIv1YWY0CTS8PDEhEUsfAxmLvh1dyJrqsIr_OuqG1QO_OH3X5AtTT2Peylr8T4dTdkBspqH6FgnHT2mMff-84h3A0w0zZ_vcaDsrrvnM_k0bfcCmMauarpwJCPdBSt6Iz69LzVdiW641&amp;t=3f4a792d" type="text/javascript"></script>
-<script src="/ScriptResource.axd?d=rzhySJ1SHwY4sh4bDtqdE0i0voxa5KT4fEDjYApxF3kGmRwTrE5uB79HOORun9O51ZK3xAZVVD42Ki5uqczV1Q1afYcsSn77NSS2WHkPLTOdDYIWgrwjCGy_xT0EZKSPmUyMaA2&amp;t=ffffffffbb8f054a" type="text/javascript"></script>
-<script src="/ScriptResource.axd?d=IYA58t3LiJ2APF9dNyJCUbomUEsjbQNgvRw9FjaAVVLgGWoXpOv9W35l_-SS45pMcVnEfZbvFu4z0rwsbjXY5dPel5o1vBCEjcFpriOHZWA6XCbq_Zk44tj00F_nv95trafhbA2&amp;t=ffffffffbb8f054a" type="text/javascript"></script>
-<script src="/ScriptResource.axd?d=LQapxUMxMZ_daMNKoc5zVpcVHbGgj62DfGHYlOnA4vB89jscAGsic4rj3K3ux2Kv-iFO8JLgGwUIEFmw3WSTVRxElUNOVhKwB6K0E4-D7knKIzFGYvfpXvOyF4Nl3gstj6dZNA2&amp;t=ffffffffbb8f054a" type="text/javascript"></script>
-<script src="/ScriptResource.axd?d=qUudBYdLM9ZXG2lVgWhaA5OTcqb3c_aY69UW57inIgG6qU6btKAh0Nxbn94bAzilTX50dATpl-7r5-2UQ83lg9XwMvgdvs8IFs9wwtcbOFUIgrYfxv1roueQttxtKIFeN9Ci2E8wbWsQ6NVoOm_aw5hms2E1&amp;t=ffffffffbb8f054a" type="text/javascript"></script>
-<script src="/ScriptResource.axd?d=NEb9aeYk0mHCKOHTI_kX5maIMXWriaGwEFElMXP0jMtptXrlxMVuQ9QQb09ogP2Jc4PQjAF2j1fkXcWlUkp5904JrwukcN8zTMf4HPPfrG_OiwN7M08-L4t13Biso3GBETOAgMMmi2I_V20PejJnwpBi0Ig1&amp;t=ffffffffbb8f054a" type="text/javascript"></script>
-<script src="/ScriptResource.axd?d=VXobuBEQxbtDLaIU1KuvIl0E_kBkcYyIZJdiz7EkA1VJS3eKKVPk-1VABCU7vxs119u8LD1cXqyAzlYk3OIMXqXFIFYCZmuZMGowtwCEFzylJH60TjpWztBrwnebCaURMRKfSQ2&amp;t=ffffffffbb8f054a" type="text/javascript"></script>
-<input type="hidden" name="__VIEWSTATEGENERATOR" id="__VIEWSTATEGENERATOR" value="3EAED612" />
-<input type="hidden" name="__EVENTVALIDATION" id="__EVENTVALIDATION" value="/wEWAwLF6u/yAwLwiv6LDwK6yJ3fDQU2Ry4gtDxVLEFztfNdNrKNWywS" />
-        
-<div id="masterBar">
-    <span id="ctl00_MasterBar"><!--div id="alert">DO NOT EDIT. COPY THIS LINE BELOW, CHANGE THE TEXT, AND REMOVE THE COMMENT MARKUP. DELETE SECOND LINE WHEN DONE.</div-->
-
-
-<!--
-.redAlert {
-    color: #FFFFFF;
-    font-weight: bold;
-    background-color:red;
-}
-
-</style>
--->
-
-<!--<div id="alert" class="redAlert"></div>-->
-<!--
-<script>
-// Set the date we're counting down to
-//var countDownDate = new Date("Oct 10, 2018 12:59:59").getTime();
-
-// Update the count down every 1 second
-var x = setInterval(function() {
-
-    // Get todays date and time
-//    var now = new Date().getTime();
-
-    // Find the distance between now and the count down date
-  //  var distance = countDownDate - now;
-
-    // Time calculations for days, hours, minutes and seconds
-    //var days = Math.floor(distance / (1000 * 60 * 60 * 24));
-    //var hours = Math.floor((distance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
-    //var minutes = Math.floor((distance % (1000 * 60 * 60)) / (1000 * 60));
-    //var seconds = Math.floor((distance % (1000 * 60)) / 1000);
-
-    // Output the result in an element with id="demo"
-    document.getElementById("alert").innerHTML = "Make your voice heard!  There are  " + days + " days left to <a href='https://boe.cuyahogacounty.us/en-US/voter-registration.aspx' target='_blank'> register to vote </a> for the November 6th election.";
-
-    // If the count down is over, write some text
-   // if (distance < 0) {
-        //clearInterval(x);
-        document.getElementById("alert").style.display = "none";
-        //document.getElementById("alertR").innerHTML = "EXPIRED";
-    }
-}, 1000);
-//</script> -->
-</span>
-     <!--
-        '+-----------------------------------------------------------------------------+
-        '| This menu is for the county homepage shared navigation. To make it work,    |
-        '| set the Web site description in the code behind file to the site name for   |
-        '| the county homepage.                                                        |
-        '|                                                                             |
-        '| Note: The URLS for ALL menus are built based on the SiteMapUseDynamicURLs   |
-        '| Web.Config setting.  When developing, this should be set to false so that   |
-        '| the main site navigation points to the local machine.  This will cause      |
-        '| the shared navigation to also point to the local machine rather than the    |
-        '| county homepage URL.  Setting SiteMapUseDynamicURLs = False when the site   |
-        '| is deployed to the server will fix this and make everything work fine.      | 
-        '+-----------------------------------------------------------------------------+
-     -->
-     <div id="ctl00_masterNav_Menu1" class="RadMenu RadMenu_RadMenuMasterNav" UseEmbeddedScripts="false">
-	<!-- 2011.2.915.35 --><ul class="rmRootGroup rmHorizontal">
-		<li class="rmItem rmFirst"><a href="http://www.cuyahogacounty.us/en-US/home.aspx" class="rmLink rmRootLink MainItem"><span class="rmText"></span></a></li><li class="rmItem "><a href="http://www.cuyahogacounty.us/en-US/government.aspx" class="rmLink rmRootLink MainItem"><span class="rmText">Government</span></a><div class="rmSlide">
-			<ul class="rmVertical rmGroup rmLevel1">
-				<li class="rmItem rmFirst"><a href="http://www.cuyahogacounty.us/en-US/Organizational-Chart.aspx" class="rmLink MenuItem"><span class="rmText">Organizational Chart</span></a></li><li class="rmItem rmLast"><a href="http://www.cuyahogacounty.us/en-US/history.aspx" class="rmLink MenuItem"><span class="rmText">History</span></a></li>
-			</ul>
-		</div></li><li class="rmItem "><a href="http://www.cuyahogacounty.us/en-US/resident-services.aspx" class="rmLink rmRootLink MainItem"><span class="rmText">Residents</span></a><div class="rmSlide">
-			<ul class="rmVertical rmGroup rmLevel1">
-				<li class="rmItem rmFirst rmLast"><a href="http://www.cuyahogacounty.us/en-US/Communities.aspx" class="rmLink MenuItem"><span class="rmText">Communities</span></a></li>
-			</ul>
-		</div></li><li class="rmItem "><a href="http://www.cuyahogacounty.us/en-US/visitors.aspx" class="rmLink rmRootLink MainItem"><span class="rmText">Visitors</span></a></li><li class="rmItem "><a href="http://www.cuyahogacounty.us/en-US/business.aspx" class="rmLink rmRootLink MainItem"><span class="rmText">Business</span></a></li><li class="rmItem "><a href="http://www.cuyahogacounty.us/en-US/contact-list.aspx" class="rmLink rmRootLink MainItem"><span class="rmText">A-Z Directory</span></a></li><li class="rmItem rmLast"><a href="http://www.cuyahogacounty.us/en-US/online-services.aspx" class="rmLink rmRootLink MainItem"><span class="rmText">Online Services</span></a></li>
-	</ul><input id="ctl00_masterNav_Menu1_ClientState" name="ctl00_masterNav_Menu1_ClientState" type="hidden" />
-</div>
-    
-    </div><!--end #masterBar-->
-<div id="container">
-    <div id="header">
-    <map name="BannerMap" id="BannerMap">
-        <area shape="circle" coords="60,50,44" href="http://www.cuyahogacounty.us/" />
-        <area shape="rect" coords="110,0,1024,99" href="http://bc.cuyahogacounty.us/" />
-    </map>
-    <img id="ctl00_imgLogoTitle" border="0" usemap="#BannerMap" src="/img_bc/en-US/site_title.jpg" alt="Cuyahoga County" height="99" width="1024" border="0" />
-    </div><!--end #header-->
-    
-    <div id="searchBox">
-    <div id="ctl00_SiteSearch1_pnlSearch">
-	
-    <input name="ctl00$SiteSearch1$txtTerms" type="text" id="ctl00_SiteSearch1_txtTerms" onClick="getElementById('ctl00_SiteSearch1_txtTerms').value='';" alt="" />
-	<input type="submit" name="ctl00$SiteSearch1$btnGo" value="Search" onclick="if(ctl00_SiteSearch1_txtTerms.value =='' || ctl00_SiteSearch1_txtTerms.value =='') return false;" id="ctl00_SiteSearch1_btnGo" class="searchButton" />
-	
-
-</div><br />
-    </div>    
-
-            <!--Treeview Navigation-->
-        <div id="navigation">
-            <div class="centerNav">
-            <div id="ctl00_siteSpecificNav_Menu1" class="RadMenu RadMenu_RadMenuSiteSpecificNav" UseEmbeddedScripts="false">
-	<ul class="rmRootGroup rmHorizontal">
-		<li class="rmItem rmFirst"><a href="http://bc.cuyahogacounty.us/en-US/home.aspx" class="rmLink rmRootLink MainItem"><span class="rmText">Home</span></a></li><li class="rmItem "><a href="http://bc.cuyahogacounty.us/en-US/boards-commissions-form.aspx" class="rmLink rmRootLink MainItem"><span class="rmText">Boards and Commissions Form</span></a></li><li class="rmItem "><a href="http://bc.cuyahogacounty.us/en-US/Internal-Boards.aspx" class="rmLink rmRootLink MainItem rmSelected"><span class="rmText">Internal Boards</span></a></li><li class="rmItem "><a href="http://bc.cuyahogacounty.us/en-US/External-Boards.aspx" class="rmLink rmRootLink MainItem"><span class="rmText">External Boards</span></a></li><li class="rmItem "><a href="http://bc.cuyahogacounty.us/en-US/Other-Boards.aspx" class="rmLink rmRootLink MainItem"><span class="rmText">Other Boards</span></a></li><li class="rmItem "><a href="http://bc.cuyahogacounty.us/en-US/SiteMap.aspx" class="rmLink rmRootLink MainItem"><span class="rmText">Sitemap</span></a></li><li class="rmItem rmLast"><a href="http://bc.cuyahogacounty.us/en-US/MyAccount.aspx" class="rmLink rmRootLink MainItem"><span class="rmText">My Account</span></a></li>
-	</ul><input id="ctl00_siteSpecificNav_Menu1_ClientState" name="ctl00_siteSpecificNav_Menu1_ClientState" type="hidden" />
+<div >
+    <div class="sf-Long-text" ><button class="to-top" type="button"><span class="sr-only">To Top</span></button></div>    
 </div>
 
+ </div> <div class="svg-legend" aria-hidden="true"> 
+
+<div >
+    <div class="sf-Long-text" ><svg focusable="false" style="position:absolute;width:0;height:0;overflow:hidden;" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<symbol id="icon-circle-left" viewbox="0 0 32 32">
+<title>circle-left</title>
+<path d="M20 15v-2c0-0.547-0.453-1-1-1h-7.844l2.953-2.953c0.187-0.187 0.297-0.438 0.297-0.703s-0.109-0.516-0.297-0.703l-1.422-1.422c-0.187-0.187-0.438-0.281-0.703-0.281s-0.516 0.094-0.703 0.281l-7.078 7.078c-0.187 0.187-0.281 0.438-0.281 0.703s0.094 0.516 0.281 0.703l7.078 7.078c0.187 0.187 0.438 0.281 0.703 0.281s0.516-0.094 0.703-0.281l1.422-1.422c0.187-0.187 0.281-0.438 0.281-0.703s-0.094-0.516-0.281-0.703l-2.953-2.953h7.844c0.547 0 1-0.453 1-1zM24 14c0 6.625-5.375 12-12 12s-12-5.375-12-12 5.375-12 12-12 12 5.375 12 12z"></path>
+</symbol>
+<symbol id="icon-circle-right" viewbox="0 0 32 32">
+<title>circle-right</title>
+<path d="M20.078 14c0-0.266-0.094-0.516-0.281-0.703l-7.078-7.078c-0.187-0.187-0.438-0.281-0.703-0.281s-0.516 0.094-0.703 0.281l-1.422 1.422c-0.187 0.187-0.281 0.438-0.281 0.703s0.094 0.516 0.281 0.703l2.953 2.953h-7.844c-0.547 0-1 0.453-1 1v2c0 0.547 0.453 1 1 1h7.844l-2.953 2.953c-0.187 0.187-0.297 0.438-0.297 0.703s0.109 0.516 0.297 0.703l1.422 1.422c0.187 0.187 0.438 0.281 0.703 0.281s0.516-0.094 0.703-0.281l7.078-7.078c0.187-0.187 0.281-0.438 0.281-0.703zM24 14c0 6.625-5.375 12-12 12s-12-5.375-12-12 5.375-12 12-12 12 5.375 12 12z"></path>
+</symbol>
+<symbol id="icon-search" viewbox="0 0 16 16">
+<title>search</title>
+<path d="M15.56 15.56c-0.587 0.587-1.538 0.587-2.125 0l-2.652-2.652c-1.090 0.699-2.379 1.116-3.771 1.116-3.872 0-7.012-3.139-7.012-7.012s3.14-7.012 7.012-7.012c3.873 0 7.012 3.139 7.012 7.012 0 1.391-0.417 2.68-1.116 3.771l2.652 2.652c0.587 0.587 0.587 1.538 0 2.125zM7.012 2.003c-2.766 0-5.009 2.242-5.009 5.009s2.243 5.009 5.009 5.009c2.766 0 5.009-2.242 5.009-5.009s-2.242-5.009-5.009-5.009z"></path>
+</symbol>
+<symbol id="icon-youtube-play" viewbox="0 0 28 28">
+<title>youtube-play</title>
+<path d="M11.109 17.625l7.562-3.906-7.562-3.953v7.859zM14 4.156c5.891 0 9.797 0.281 9.797 0.281 0.547 0.063 1.75 0.063 2.812 1.188 0 0 0.859 0.844 1.109 2.781 0.297 2.266 0.281 4.531 0.281 4.531v2.125s0.016 2.266-0.281 4.531c-0.25 1.922-1.109 2.781-1.109 2.781-1.062 1.109-2.266 1.109-2.812 1.172 0 0-3.906 0.297-9.797 0.297v0c-7.281-0.063-9.516-0.281-9.516-0.281-0.625-0.109-2.031-0.078-3.094-1.188 0 0-0.859-0.859-1.109-2.781-0.297-2.266-0.281-4.531-0.281-4.531v-2.125s-0.016-2.266 0.281-4.531c0.25-1.937 1.109-2.781 1.109-2.781 1.062-1.125 2.266-1.125 2.812-1.188 0 0 3.906-0.281 9.797-0.281v0z"></path>
+</symbol>
+<symbol id="icon-twitter-square" viewbox="0 0 24 28">
+<title>twitter-square</title>
+<path d="M20 9.531c-0.594 0.266-1.219 0.438-1.891 0.531 0.688-0.406 1.203-1.062 1.453-1.828-0.641 0.375-1.344 0.656-2.094 0.797-0.594-0.641-1.453-1.031-2.391-1.031-1.813 0-3.281 1.469-3.281 3.281 0 0.25 0.016 0.516 0.078 0.75-2.734-0.141-5.156-1.437-6.781-3.437-0.281 0.484-0.453 1.062-0.453 1.656 0 1.141 0.531 2.141 1.422 2.734-0.547-0.016-1.062-0.172-1.563-0.406v0.031c0 1.594 1.203 2.922 2.703 3.219-0.281 0.078-0.5 0.125-0.797 0.125-0.203 0-0.406-0.031-0.609-0.063 0.422 1.297 1.625 2.25 3.063 2.281-1.125 0.875-2.531 1.406-4.078 1.406-0.266 0-0.531-0.016-0.781-0.047 1.453 0.922 3.172 1.469 5.031 1.469 6.031 0 9.344-5 9.344-9.344 0-0.141 0-0.281-0.016-0.422 0.641-0.453 1.203-1.031 1.641-1.703zM24 6.5v15c0 2.484-2.016 4.5-4.5 4.5h-15c-2.484 0-4.5-2.016-4.5-4.5v-15c0-2.484 2.016-4.5 4.5-4.5h15c2.484 0 4.5 2.016 4.5 4.5z"></path>
+</symbol>
+<symbol id="icon-facebook-square" viewbox="0 0 24 28">
+<title>facebook-square</title>
+<path d="M19.5 2c2.484 0 4.5 2.016 4.5 4.5v15c0 2.484-2.016 4.5-4.5 4.5h-2.938v-9.297h3.109l0.469-3.625h-3.578v-2.312c0-1.047 0.281-1.75 1.797-1.75l1.906-0.016v-3.234c-0.328-0.047-1.469-0.141-2.781-0.141-2.766 0-4.672 1.687-4.672 4.781v2.672h-3.125v3.625h3.125v9.297h-8.313c-2.484 0-4.5-2.016-4.5-4.5v-15c0-2.484 2.016-4.5 4.5-4.5h15z"></path>
+</symbol>
+<symbol id="icon-group" viewbox="0 0 30 28">
+<title>group</title>
+<path d="M9.266 14c-1.625 0.047-3.094 0.75-4.141 2h-2.094c-1.563 0-3.031-0.75-3.031-2.484 0-1.266-0.047-5.516 1.937-5.516 0.328 0 1.953 1.328 4.062 1.328 0.719 0 1.406-0.125 2.078-0.359-0.047 0.344-0.078 0.688-0.078 1.031 0 1.422 0.453 2.828 1.266 4zM26 23.953c0 2.531-1.672 4.047-4.172 4.047h-13.656c-2.5 0-4.172-1.516-4.172-4.047 0-3.531 0.828-8.953 5.406-8.953 0.531 0 2.469 2.172 5.594 2.172s5.063-2.172 5.594-2.172c4.578 0 5.406 5.422 5.406 8.953zM10 4c0 2.203-1.797 4-4 4s-4-1.797-4-4 1.797-4 4-4 4 1.797 4 4zM21 10c0 3.313-2.688 6-6 6s-6-2.688-6-6 2.688-6 6-6 6 2.688 6 6zM30 13.516c0 1.734-1.469 2.484-3.031 2.484h-2.094c-1.047-1.25-2.516-1.953-4.141-2 0.812-1.172 1.266-2.578 1.266-4 0-0.344-0.031-0.688-0.078-1.031 0.672 0.234 1.359 0.359 2.078 0.359 2.109 0 3.734-1.328 4.062-1.328 1.984 0 1.937 4.25 1.937 5.516zM28 4c0 2.203-1.797 4-4 4s-4-1.797-4-4 1.797-4 4-4 4 1.797 4 4z"></path>
+</symbol>
+<symbol id="icon-flag-o" viewbox="0 0 29 28">
+<title>flag-o</title>
+<path d="M26 16.328v-9.625c-1.25 0.672-3 1.422-4.781 1.422v0c-0.828 0-1.594-0.156-2.266-0.5-1.672-0.828-3.484-1.625-5.656-1.625-2.016 0-4.484 0.984-6.297 1.984v9.359c2.063-0.953 4.688-1.766 6.766-1.766 2.406 0 3.969 0.797 5.641 1.625l0.438 0.219c0.438 0.219 0.969 0.344 1.578 0.344 1.734 0 3.609-0.922 4.578-1.437zM5 4c0 0.734-0.406 1.375-1 1.719v19.781c0 0.281-0.219 0.5-0.5 0.5h-1c-0.281 0-0.5-0.219-0.5-0.5v-19.781c-0.594-0.344-1-0.984-1-1.719 0-1.109 0.891-2 2-2s2 0.891 2 2zM28 5v11.922c0 0.375-0.219 0.719-0.547 0.891-0.063 0.031-0.156 0.078-0.266 0.141-1 0.531-3.359 1.813-5.766 1.813-0.922 0-1.75-0.187-2.469-0.547l-0.438-0.219c-1.578-0.797-2.828-1.422-4.75-1.422-2.25 0-5.422 1.172-7.25 2.281-0.156 0.094-0.344 0.141-0.516 0.141s-0.344-0.047-0.5-0.125c-0.313-0.187-0.5-0.516-0.5-0.875v-11.594c0-0.344 0.187-0.672 0.484-0.859 1-0.594 4.531-2.547 7.812-2.547 2.609 0 4.734 0.953 6.531 1.828 0.406 0.203 0.875 0.297 1.391 0.297 1.844 0 3.875-1.172 4.844-1.75 0.203-0.109 0.375-0.203 0.484-0.266 0.313-0.156 0.672-0.141 0.969 0.031 0.297 0.187 0.484 0.516 0.484 0.859z"></path>
+</symbol>
+<symbol id="icon-newspaper-o" viewbox="0 0 32 28">
+<title>newspaper-o</title>
+<path d="M16 8h-6v6h6v-6zM18 18v2h-10v-2h10zM18 6v10h-10v-10h10zM28 18v2h-8v-2h8zM28 14v2h-8v-2h8zM28 10v2h-8v-2h8zM28 6v2h-8v-2h8zM4 21v-15h-2v15c0 0.547 0.453 1 1 1s1-0.453 1-1zM30 21v-17h-24v17c0 0.344-0.063 0.688-0.172 1h23.172c0.547 0 1-0.453 1-1zM32 2v19c0 1.656-1.344 3-3 3h-26c-1.656 0-3-1.344-3-3v-17h4v-2h28z"></path>
+</symbol>
+<symbol id="icon-star-o" viewbox="0 0 26 28">
+<title>star-o</title>
+<path d="M17.766 15.687l4.781-4.641-6.594-0.969-2.953-5.969-2.953 5.969-6.594 0.969 4.781 4.641-1.141 6.578 5.906-3.109 5.891 3.109zM26 10.109c0 0.281-0.203 0.547-0.406 0.75l-5.672 5.531 1.344 7.812c0.016 0.109 0.016 0.203 0.016 0.313 0 0.422-0.187 0.781-0.641 0.781-0.219 0-0.438-0.078-0.625-0.187l-7.016-3.687-7.016 3.687c-0.203 0.109-0.406 0.187-0.625 0.187-0.453 0-0.656-0.375-0.656-0.781 0-0.109 0.016-0.203 0.031-0.313l1.344-7.812-5.688-5.531c-0.187-0.203-0.391-0.469-0.391-0.75 0-0.469 0.484-0.656 0.875-0.719l7.844-1.141 3.516-7.109c0.141-0.297 0.406-0.641 0.766-0.641s0.625 0.344 0.766 0.641l3.516 7.109 7.844 1.141c0.375 0.063 0.875 0.25 0.875 0.719z"></path>
+</symbol>
+<symbol id="icon-desktop" viewbox="0 0 30 28">
+<title>desktop</title>
+<path d="M28 15.5v-13c0-0.266-0.234-0.5-0.5-0.5h-25c-0.266 0-0.5 0.234-0.5 0.5v13c0 0.266 0.234 0.5 0.5 0.5h25c0.266 0 0.5-0.234 0.5-0.5zM30 2.5v17c0 1.375-1.125 2.5-2.5 2.5h-8.5c0 1.328 1 2.453 1 3s-0.453 1-1 1h-8c-0.547 0-1-0.453-1-1 0-0.578 1-1.641 1-3h-8.5c-1.375 0-2.5-1.125-2.5-2.5v-17c0-1.375 1.125-2.5 2.5-2.5h25c1.375 0 2.5 1.125 2.5 2.5z"></path>
+</symbol>
+<symbol id="icon-certificate" viewbox="0 0 24 28">
+<title>certificate</title>
+<path d="M21.5 14l2.156 2.109c0.297 0.281 0.406 0.703 0.313 1.094-0.109 0.391-0.422 0.703-0.812 0.797l-2.938 0.75 0.828 2.906c0.109 0.391 0 0.812-0.297 1.094-0.281 0.297-0.703 0.406-1.094 0.297l-2.906-0.828-0.75 2.938c-0.094 0.391-0.406 0.703-0.797 0.812-0.094 0.016-0.203 0.031-0.297 0.031-0.297 0-0.594-0.125-0.797-0.344l-2.109-2.156-2.109 2.156c-0.281 0.297-0.703 0.406-1.094 0.313-0.406-0.109-0.703-0.422-0.797-0.812l-0.75-2.938-2.906 0.828c-0.391 0.109-0.812 0-1.094-0.297-0.297-0.281-0.406-0.703-0.297-1.094l0.828-2.906-2.938-0.75c-0.391-0.094-0.703-0.406-0.812-0.797-0.094-0.391 0.016-0.812 0.313-1.094l2.156-2.109-2.156-2.109c-0.297-0.281-0.406-0.703-0.313-1.094 0.109-0.391 0.422-0.703 0.812-0.797l2.938-0.75-0.828-2.906c-0.109-0.391 0-0.812 0.297-1.094 0.281-0.297 0.703-0.406 1.094-0.297l2.906 0.828 0.75-2.938c0.094-0.391 0.406-0.703 0.797-0.797 0.391-0.109 0.812 0 1.094 0.297l2.109 2.172 2.109-2.172c0.281-0.297 0.688-0.406 1.094-0.297 0.391 0.094 0.703 0.406 0.797 0.797l0.75 2.938 2.906-0.828c0.391-0.109 0.812 0 1.094 0.297 0.297 0.281 0.406 0.703 0.297 1.094l-0.828 2.906 2.938 0.75c0.391 0.094 0.703 0.406 0.812 0.797 0.094 0.391-0.016 0.812-0.313 1.094z"></path>
+</symbol>
+<symbol id="icon-envelope-o" viewbox="0 0 28 28">
+<title>envelope-o</title>
+<path d="M26 23.5v-12c-0.328 0.375-0.688 0.719-1.078 1.031-2.234 1.719-4.484 3.469-6.656 5.281-1.172 0.984-2.625 2.188-4.25 2.188h-0.031c-1.625 0-3.078-1.203-4.25-2.188-2.172-1.813-4.422-3.563-6.656-5.281-0.391-0.313-0.75-0.656-1.078-1.031v12c0 0.266 0.234 0.5 0.5 0.5h23c0.266 0 0.5-0.234 0.5-0.5zM26 7.078c0-0.391 0.094-1.078-0.5-1.078h-23c-0.266 0-0.5 0.234-0.5 0.5 0 1.781 0.891 3.328 2.297 4.438 2.094 1.641 4.188 3.297 6.266 4.953 0.828 0.672 2.328 2.109 3.422 2.109h0.031c1.094 0 2.594-1.437 3.422-2.109 2.078-1.656 4.172-3.313 6.266-4.953 1.016-0.797 2.297-2.531 2.297-3.859zM28 6.5v17c0 1.375-1.125 2.5-2.5 2.5h-23c-1.375 0-2.5-1.125-2.5-2.5v-17c0-1.375 1.125-2.5 2.5-2.5h23c1.375 0 2.5 1.125 2.5 2.5z"></path>
+</symbol>
+<symbol id="icon-share-alt" viewbox="0 0 24 28">
+<title>share-alt</title>
+<path d="M19 16c2.766 0 5 2.234 5 5s-2.234 5-5 5-5-2.234-5-5c0-0.172 0.016-0.359 0.031-0.531l-5.625-2.812c-0.891 0.828-2.094 1.344-3.406 1.344-2.766 0-5-2.234-5-5s2.234-5 5-5c1.313 0 2.516 0.516 3.406 1.344l5.625-2.812c-0.016-0.172-0.031-0.359-0.031-0.531 0-2.766 2.234-5 5-5s5 2.234 5 5-2.234 5-5 5c-1.313 0-2.516-0.516-3.406-1.344l-5.625 2.812c0.016 0.172 0.031 0.359 0.031 0.531s-0.016 0.359-0.031 0.531l5.625 2.812c0.891-0.828 2.094-1.344 3.406-1.344z"></path>
+</symbol>
+<symbol id="icon-print" viewbox="0 0 26 28">
+<title>print</title>
+<path d="M6 24h14v-4h-14v4zM6 14h14v-6h-2.5c-0.828 0-1.5-0.672-1.5-1.5v-2.5h-10v10zM24 15c0-0.547-0.453-1-1-1s-1 0.453-1 1 0.453 1 1 1 1-0.453 1-1zM26 15v6.5c0 0.266-0.234 0.5-0.5 0.5h-3.5v2.5c0 0.828-0.672 1.5-1.5 1.5h-15c-0.828 0-1.5-0.672-1.5-1.5v-2.5h-3.5c-0.266 0-0.5-0.234-0.5-0.5v-6.5c0-1.641 1.359-3 3-3h1v-8.5c0-0.828 0.672-1.5 1.5-1.5h10.5c0.828 0 1.969 0.469 2.562 1.062l2.375 2.375c0.594 0.594 1.062 1.734 1.062 2.562v4h1c1.641 0 3 1.359 3 3z"></path>
+</symbol>
+<symbol id="icon-notebook-list" viewbox="0 0 32 32">
+<title>notebook-list</title>
+<path d="M22.769 1.231v-1.231h1.231v1.231h1.234c1.362 0 2.458 1.104 2.458 2.466v25.837c0 1.371-1.101 2.466-2.458 2.466h-18.468c-1.362 0-2.458-1.104-2.458-2.466v-25.837c0-1.371 1.101-2.466 2.458-2.466h1.234v-1.231h1.231v1.231h3.692v-1.231h1.231v1.231h3.692v-1.231h1.231v1.231h3.692zM22.769 2.462h-3.692v1.231h-1.231v-1.231h-3.692v1.231h-1.231v-1.231h-3.692v1.231h-1.231v-1.231h-1.231c-0.68 0-1.231 0.54-1.231 1.235v25.839c0 0.682 0.56 1.235 1.231 1.235h18.462c0.68 0 1.231-0.54 1.231-1.235v-25.839c0-0.682-0.56-1.235-1.231-1.235h-1.231v1.231h-1.231v-1.231zM14.154 11.077v1.231h9.846v-1.231h-9.846zM8 9.846h3.692v3.692h-3.692v-3.692zM9.231 11.077v1.231h1.231v-1.231h-1.231zM8 16h3.692v3.692h-3.692v-3.692zM9.231 17.231v1.231h1.231v-1.231h-1.231zM14.154 17.231v1.231h9.846v-1.231h-9.846zM8 22.154h3.692v3.692h-3.692v-3.692zM9.231 23.385v1.231h1.231v-1.231h-1.231zM14.154 23.385v1.231h9.846v-1.231h-9.846z"></path>
+</symbol>
+<symbol id="icon-notebook-text" viewbox="0 0 32 32">
+<title>notebook-text</title>
+<path d="M22.154 1.231v-1.231h1.231v1.231h1.234c1.362 0 2.458 1.104 2.458 2.466v25.837c0 1.371-1.101 2.466-2.458 2.466h-18.468c-1.362 0-2.458-1.104-2.458-2.466v-25.837c0-1.371 1.101-2.466 2.458-2.466h1.234v-1.231h1.231v1.231h3.692v-1.231h1.231v1.231h3.692v-1.231h1.231v1.231h3.692zM22.154 2.462h-3.692v1.231h-1.231v-1.231h-3.692v1.231h-1.231v-1.231h-3.692v1.231h-1.231v-1.231h-1.231c-0.68 0-1.231 0.54-1.231 1.235v25.839c0 0.682 0.56 1.235 1.231 1.235h18.462c0.68 0 1.231-0.54 1.231-1.235v-25.839c0-0.682-0.56-1.235-1.231-1.235h-1.231v1.231h-1.231v-1.231zM7.385 7.385v1.231h16v-1.231h-16zM7.385 11.077v1.231h16v-1.231h-16zM7.385 14.769v1.231h16v-1.231h-16zM7.385 18.462v1.231h16v-1.231h-16zM7.385 22.154v1.231h16v-1.231h-16zM7.385 25.846v1.231h16v-1.231h-16z"></path>
+</symbol>
+<symbol id="icon-document-recording" viewbox="0 0 32 32">
+<title>document-recording</title>
+<path d="M19.556 0h0.593l7.111 8.296v21.344c0 1.295-1.060 2.359-2.367 2.359h-17.784c-1.311 0-2.367-1.065-2.367-2.379v-27.242c0-1.314 1.063-2.379 2.374-2.379h12.441zM18.963 1.185h-11.857c-0.652 0-1.18 0.54-1.18 1.18v27.27c0 0.652 0.539 1.18 1.185 1.18h17.778c0.655 0 1.185-0.527 1.185-1.177v-20.156h-4.743c-1.308 0-2.368-1.051-2.368-2.377v-5.919zM20.148 1.778v5.323c0 0.66 0.534 1.196 1.181 1.196h4.389l-5.57-6.519zM11.852 20.734v-1.771h1.185v1.769c0 1.641 1.315 2.972 2.963 2.972 1.636 0 2.963-1.333 2.963-2.972v-1.769h1.185v1.771c0 2.095-1.545 3.825-3.556 4.113v2.412h2.37v1.185h-5.926v-1.185h2.37v-2.413c-2.007-0.288-3.556-2.020-3.556-4.112v0zM14.222 16.002v0c0-0.984 0.796-1.78 1.778-1.78 0.989 0 1.778 0.797 1.778 1.78v4.737c0 0.984-0.796 1.78-1.778 1.78-0.989 0-1.778-0.797-1.778-1.78v-4.737zM16 15.407c-0.327 0-0.593 0.255-0.593 0.59v4.746c0 0.326 0.275 0.59 0.593 0.59 0.327 0 0.593-0.255 0.593-0.59v-4.746c0-0.326-0.275-0.59-0.593-0.59v0z"></path>
+</symbol>
+</defs>
+</svg></div>    
+</div> <!-- <FeatherSection name="SVGs"></FeatherSection> --> </div> <!--googleon: all --> 
+<div id="Header_T25F18B5E018_Col00" class="sf_colsIn header-start" data-sf-element="Div" data-placeholder-label="Header Start"><div id="Header_T25F18B5E024_Col00" class="sf_colsIn container flex-container" data-sf-element="Container" data-placeholder-label="Container"><div id="Header_T25F18B5E026_Col00" class="sf_colsIn branding" data-sf-element="Div" data-placeholder-label="Branding">
+<div class="site-logo" >
+    <div class="sf-Long-text" ><a href="/home"><img alt="Logo of Cuyahoga County" src="https://cuyahogacms.blob.core.windows.net/home/images/default-source/default-album/county_logo100.png?sfvrsn=89399372_2" /></a></div>    
+</div>
+<div class="site-name" >
+    <div class="sf-Long-text" ><a href="/home"><img src="https://cuyahogacms.blob.core.windows.net/home/images/default-source/default-album/cco.png?sfvrsn=6fb4683f_2" alt="Cuyahoga County. Ohio" /></a><br /><strong>Boards and Commissions</strong></div>    
+</div></div>
+<div >
+    <div class="sf-Long-text" ><div class="font-sizer"><button class="btn btn-default btn-sm hidden-xs" id="incfont" tabindex="-1">A +</button><button class="btn btn-default btn-xs hidden-xs" id="decfont" tabindex="-1">A -</button></div></div>    
+</div>
+
+
+<div class="search-box search-box--header form-inline">
+    <div class="form-inner">
+        <div class="form-group">
+            <input class="form-control" placeholder="I'm looking for..." type="text" id="2d353f69-772a-4651-bb17-08612438eb84">
+        </div>
+        <button type="button" class="btn btn-primary" id="d22f425a-a6fc-47e6-84f0-a84d3b84710e">
+            <span class="visually-hidden">Submit</span>
+            <svg class="icon icon-search"><use xlink:href="#icon-search" xmlns:xlink="http://www.w3.org/1999/xlink"></use></svg>
+        </button>
+    </div>
+
+    <input type="hidden" data-sf-role="resultsUrl" value="/boards-and-commissions/search-results" />
+    <input type="hidden" data-sf-role="indexCatalogue" value="bcindex" />
+    <input type="hidden" data-sf-role="wordsMode" value="AllWords" />
+    <input type="hidden" data-sf-role="disableSuggestions" value='false' />
+    <input type="hidden" data-sf-role="minSuggestionLength" value="3" />
+    <input type="hidden" data-sf-role="suggestionFields" value="Title,Content" />
+    <input type="hidden" data-sf-role="language" value="" />
+    <input type="hidden" data-sf-role="suggestionsRoute" value="/restapi/search/suggestions" />
+    <input type="hidden" data-sf-role="searchTextBoxId" value='#2d353f69-772a-4651-bb17-08612438eb84' />
+    <input type="hidden" data-sf-role="searchButtonId" value='#d22f425a-a6fc-47e6-84f0-a84d3b84710e' />
+
+    
+</div>
+
+
+
+
+
+
+
+
+<div class="social-links social-links--header" >
+    <div class="sf-Long-text" ><div class="social-links"><ul role="menubar"><li><a href="https://www.facebook.com/CuyahogaCounty" title="Facebook" target="_blank" data-sf-ec-immutable=""><em class="fab fa-facebook fa-lg"></em><span class="text-hide">Facebook</span></a></li><li><a href="https://twitter.com/CuyahogaCounty" title="Twitter" target="_blank" data-sf-ec-immutable=""><em class="fab fa-twitter fa-lg"></em><span class="text-hide">Twitter</span></a></li><li><a href="https://www.youtube.com/CuyahogaCounty" title="YouTube" target="_blank" data-sf-ec-immutable=""><em class="fab fa-youtube fa-lg"></em><span class="text-hide">Youtube</span></a></li><li><a href="/county-news/newsletter-registration" title="Newsletter Registration" target="_blank"><em class="fas fa-envelope fa-lg"></em><span class="text-hide">Newsletter Registration</span></a></li><li><a href="https://www.instagram.com/cuyahogacounty/" title="Instagram" target="_blank" data-sf-ec-immutable=""><em class="fab fa-instagram fa-lg"></em><span class="text-hide">Instagram</span></a></li><li><a href="/executive/news/lets-talk-cuyahoga-podcast" title="Podcast" target="_blank"><em class="fas fa-podcast fa-lg"></em><span class="text-hide">Podcast</span></a></li></ul></div></div>    
+</div>
+</div>
+</div><div id="Header_T25F18B5E019_Col00" class="sf_colsIn header-end" data-sf-element="Div" data-placeholder-label="Header End"><div id="Header_T25F18B5E025_Col00" class="sf_colsIn container flex-container" data-sf-element="Container" data-placeholder-label="Container">
+<div class="main-navigation ">
+    
+    <div class="navbar-header">
+        <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+        </button>
+    </div>
+
+    <div class="navbar-collapse js-navbar-collapse pull-left underButton phoneSizeMenuStyle collapse" id="bs-example-navbar-collapse-1">
+        <ul class="nav navbar-nav">
+        <li class=""><a href="/boards-and-commissions" target="_self">HOME</a></li>
+        <li class=""><a href="/boards-and-commissions/all-boards" target="_self">All Boards</a></li>
+        <li class=""><a href="/boards-and-commissions/calendar" target="_self">Calendar</a></li>
+        <li class=""><a href="/boards-and-commissions/about-us" target="_self">About Us</a></li>
+        </ul>
+    </div><!-- /.navbar-collapse -->
+</div>
+
+
+
+
+
+
+
+
+
+<div>
+    
+
+      <ul class=" list-unstyled btn btn-warning btn-sm warningButton text-white">
+     <li class="">
+        <a href="/boards-and-commissions/boards-and-commissions-application" target="_self">Apply Online</a>
+
+    </li>
+    </ul>
+</div>
+
+
+
+
+
+
+<div class="searchbox-toggle-button" >
+    <div class="sf-Long-text" ><button type="button"><span class="sr-only">search</span>
+<svg class="icon icon-search"><use xlink:href="#icon-search" xmlns:xlink="http://www.w3.org/1999/xlink"></use></svg>
+</button></div>    
+</div>
+</div>
+</div> </header> <!-- end Header --> <!-- Site Main --> <div class="site-main"> 
+
+<div class="site-alert">
+    </div> <!-- Main Content --> <main class="main-content" role="main" id="main" tabindex="-1">
+<div id="Contentplaceholder1_T04DEF6BE051_Col00" class="sf_colsIn container" data-sf-element="Container" data-placeholder-label="Container"><div>
+    <ul class="sf-breadscrumb breadcrumb">
+                <li><a href="/">Home </a></li>
+                <li><a href="/boards-and-commissions">Boards and Commissions </a></li>
+                <li class="active">BC Event Detail</li>
+    </ul>
+</div>
+<div >
+    <div class="sf-Long-text" ><h1>Event Details</h1><br /></div>    
+</div>
+<div class="moudle detail events" itemscope itemtype="http://schema.org/Event" >
+    <header class="head">
+        <h1 class="title" itemprop="name" >
+            01/29/24 - Board of Control Meeting
+        </h1>
+        <div class="content">
+                <span itemprop="description" ><p>This meeting is open to the public and may also be accessed via livestream using the following link: <a href="https://www.YouTube.com/CuyahogaCounty" target="_blank" data-sf-ec-immutable="">https://www.YouTube.com/CuyahogaCounty</a></p></span>
+        </div>
+        <div class="meta">
+            <div class="meta-item" itemprop="startDate" content="2024-01-29T16:00">
+                <h2>Date and time:</h2>
+                <p>
+
+
+January 29, 2024 <span> &nbsp; </span> 11:00 AM<span> - </span> 12:00 PM                </p>
             </div>
         </div>
-        <!--End Treeview Navigation-->
+        <div class="meta">
+            <div class="meta-item" itemprop="location" itemscope itemtype="http://schema.org/Place">
+                <h2>Location</h2>
+                <p itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+                    <span itemprop="streetAddress"> County Headquarters 2079 East Ninth Street 4th, Cmmt Room B</span>                                                                            </p>
+            </div>
+        </div>
 
-    <div id="contentColumn">
-    <p id="top">
-        You are here:
-        
-<link href=http://bc.cuyahogacounty.us/Style/BreadCrumbs.css type="text/css"
-	rel="stylesheet">
-<span id="ctl00_Bread_crumbs1_Label1"><a class='BreadCrumbLink' href='http://bc.cuyahogacounty.us/en-US/home.aspx'>Home</a>&nbsp;<span class='BreadCrumbSeparator'>&gt;</span>&nbsp;<a class='BreadCrumbLink' href='http://bc.cuyahogacounty.us/en-US/Internal-Boards.aspx'>Internal Boards</a>&nbsp;<span class='BreadCrumbSeparator'>&gt;</span>&nbsp;<a class='BreadCrumbLink' href='http://bc.cuyahogacounty.us/en-US/Board-of-Control.aspx'>Board of Control</a>&nbsp;</span>
+        </header>
 
-
-    </p>
-    
-    
-
-<h1>Board of Control Meeting</h1>
-<div class="padding">
-    <div id="ctl00_ContentPlaceHolder1_EventDetailsAndRegistration1_pnlEventDetails">
-	
-	    <blockquote>
-	    <h2 style="display: none;">Board of Control Meeting</h2>
-	    <dl>	    
-	        <dt>Start date:</dt>
-	            <dd>9/3/2019-11:00 AM</dd>
-	        <div id="ctl00_ContentPlaceHolder1_EventDetailsAndRegistration1_pnlEndDate">
-		
-	            <dt>End date:</dt>
-	                <dd>9/3/2019-12:00 PM</dd>
-	        
-	</div>
-	        <dt>
-                Address:
-            </dt>
-	            <dd>County Headquarters, 2079 East Ninth Street, 4th - Committee Room B</dd>
-	        <div id="ctl00_ContentPlaceHolder1_EventDetailsAndRegistration1_pnlDownloads">
-		
-	            <dt>
-                    Downloads:
-                </dt>
-	            <dd>
-	                <a href="http://bc.cuyahogacounty.us/ViewFile.aspx?file=4WMJGeytOlPc09gwkgQOWA%3d%3d">Minutes</a><br /><a href="http://bc.cuyahogacounty.us/ViewFile.aspx?file=ItAmWexRAtkvZMENqysomw%3d%3d">Agenda</a><br />
-	            </dd>
-	        
-	</div>
-	    </dl>
-		    
-	    </blockquote>
-        <br />
-        <style>
-    .embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }
-</style>
-<div class="embed-container"><iframe src="https://www.youtube.com/embed//yMhUaaxldIg" frameborder="0"></iframe></div>
-
-        <div id="ctl00_ContentPlaceHolder1_EventDetailsAndRegistration1_pnlRegisterButton">
-		
-            <p></p>
-        
-	</div>
-        
-        <!--p><a id="ctl00_ContentPlaceHolder1_EventDetailsAndRegistration1_lnkBackToCalendar">Back to calendar</a>   </p-->
-
-    
+    <div class="related-content">
+            <a href="https://cuyahogacms.blob.core.windows.net/home/docs/default-source/boards-and-commissions/internal/boc/2024/012924-bocagenda.pdf?sfvrsn=60356a8a_1">
+                <svg class="icon icon-notebook-list"><use xlink:href="#icon-notebook-list"></use></svg>
+                <span>Agenda</span>
+            </a>
+                            </div>
+    <div class="related-content">
+        <br /><br /><br />
+                    </div>
+        <div class="foot">
+                <div class="calendar-export">
+                    <h2>Add to:</h2>
+                    <ul>
+                        <li><a class="btn btn-default btn-xs" href="/Sitefinity/Public/Services/ICalanderService/file.ics/?id=2dad13bf-8e51-4dff-aace-c22ad38ff6bb&amp;provider=&amp;uiculture=en" target="_blank">Outlook</a></li>
+                        <li><a class="btn btn-default btn-xs" href="/Sitefinity/Public/Services/ICalanderService/file.ics/?id=2dad13bf-8e51-4dff-aace-c22ad38ff6bb&amp;provider=&amp;uiculture=en" target="_blank">ICal</a></li>
+                        <li><a class="btn btn-default btn-xs" href="http://www.google.com/calendar/event?action=TEMPLATE&amp;text=01%2f29%2f24+-+Board+of+Control+Meeting&amp;dates=20240129T160000Z/20240129T170000Z&amp;location=US%2cCounty+Headquarters+2079+East+Ninth+Street+4th%2c+Cmmt+Room+B&amp;sprop=website:https://cuyahogacounty.gov&amp;sprop=name:01%2f29%2f24+-+Board+of+Control+Meeting&amp;details=This+meeting+is+open+to+the+public+and+may+also+be+accessed+via+livestream+using+the+following+link%3a+https%3a%2f%2fwww.YouTube.com%2fCuyahogaCounty&amp;recur=" target="_blank">Google Calendar</a></li>
+                    </ul>
+                </div>
+        </div>
+    </div>
+<div class="row" data-sf-element="Row">
+    <div id="Contentplaceholder1_T04DEF6BE057_Col00" class="sf_colsIn col-md-12" data-sf-element="Column 1" data-placeholder-label="Column 1">
+<div >
+    <div class="sf-Long-text" ></div>    
 </div>
-    <p>
-        
-    </p>
-
+    </div>
 </div>
 
-    </div><!--end #rightColumn-->
-    <div id="footer">
-    <div id="siteFooter">
-         <br />
-The majority of the Boards and Commissions in Cuyahoga County are Citizen Policy Making and Advisory Boards and Commissions. All of these boards and commissions are governed by the laws and regulations that have authorized them. Members represent the specific mission of the boards or commission to which they have been appointed.
+</div>
+</main> <!-- end Main Content --> </div> <!-- end Site Main --> <!-- Footer --> <footer class="site-footer footer" role="contentinfo" aria-label="Site Footer">
+<div id="Footer_T25F18B5E001_Col00" class="sf_colsIn container" data-sf-element="Container" data-placeholder-label="Container"><div class="row" data-sf-element="Row">
+    <div id="Footer_T167E4FAD083_Col00" class="sf_colsIn col-md-4" data-sf-element="Column 1" data-placeholder-label="Column 1">
+<div >
+    <div class="sf-Long-text" > <p>The majority of the Boards and Commissions in Cuyahoga County are Citizen Policy Making and Advisory Boards and Commissions. All of these boards and commissions are governed by the laws and regulations that have authorized them. Members represent the specific mission of the boards or commission to which they have been appointed. </p></div>    
+</div>
     </div>
-    <div id="masterFooter">
-        <span id="ctl00_FooterBar"><ul class="footerNav right">
-<li><a href="http://www.cuyahogacounty.us/">County Home Page</a></li>
-<li><a href="https://www.cuyahogacounty.us/i-want-to-contact">A-Z Service Directory</a></li>
-<li><a href="http://cuyahogacounty.us/en-US/contact-list.aspx">Contact Us</a></li>
-<li><a href="http://www.cuyahogacounty.us/en-us/faqs.aspx">FAQs</a></li>
-<li><a href="http://www.cuyahogacounty.us/en-us/Terms-of-Use.aspx">Terms of Use</a></li>
-</ul>
-<ul class="footerNav">
-<li><a href="http://code.cuyahogacounty.us/en-US/CCRC-T1C106-Public-Records.aspx">Public Records Policy</a></li>
-<li><a href="http://www.cuyahogacounty.us/en-US/privacy-policy.aspx">Privacy Policy</a></li>
-<li><a href="http://www.cuyahogacounty.us/en-US/social-media-policy.aspx">Social Media Policy</a></li>
-<li><a href="https://cuyahogacounty.us/accessibility-statement-general">Accessibility Statement</a></li>
-<li><a href="http://www.cuyahogacounty.us/en-US/disclaimer.aspx">Disclaimer</a></li>
-</ul>
-<p><a href="http://isc.cuyahogacounty.us/">Powered by the Department of Information Technology</a></p></span>
+    <div id="Footer_T167E4FAD083_Col01" class="sf_colsIn col-md-4" data-sf-element="Column 2" data-placeholder-label="Column 2">
+<div >
+    <div class="sf-Long-text" ><h3>Useful Links</h3><ul><li><a href="https://codes.ohio.gov/ohio-revised-code" target="_blank" data-sf-ec-immutable="">Ohio Revised Codes</a> </li><li><a target="_blank" href="/code">Cuyahoga County Code</a> </li><li><a href="http://council.cuyahogacounty.us/en-US/Charter-CuyahogaCounty.aspx" target="_blank" data-sf-ec-immutable="">Cuyahoga County Charter</a>
+ </li></ul></div>    
+</div>
     </div>
-    </div><!--end #footer-->
-</div><!--end #container-->
-    
+    <div id="Footer_T167E4FAD083_Col02" class="sf_colsIn col-md-4" data-sf-element="Column 3" data-placeholder-label="Column 3">
+<div >
+    <div class="sf-Long-text" ><h3>Site Info</h3></div>    
+</div>
 
-<script type="text/javascript">
-//<![CDATA[
-Sys.Application.initialize();
-Sys.Application.add_init(function() {
-    $create(Telerik.Web.UI.RadMenu, {"_childListElementCssClass":null,"_skin":"RadMenuMasterNav","attributes":{"UseEmbeddedScripts":"false"},"clientStateFieldID":"ctl00_masterNav_Menu1_ClientState","collapseAnimation":"{\"duration\":450}","expandAnimation":"{\"duration\":450}","itemData":[{"navigateUrl":"http://www.cuyahogacounty.us/en-US/home.aspx","cssClass":"MainItem"},{"items":[{"navigateUrl":"http://www.cuyahogacounty.us/en-US/Organizational-Chart.aspx","cssClass":"MenuItem"},{"navigateUrl":"http://www.cuyahogacounty.us/en-US/history.aspx","cssClass":"MenuItem"}],"navigateUrl":"http://www.cuyahogacounty.us/en-US/government.aspx","cssClass":"MainItem"},{"items":[{"navigateUrl":"http://www.cuyahogacounty.us/en-US/Communities.aspx","cssClass":"MenuItem"}],"navigateUrl":"http://www.cuyahogacounty.us/en-US/resident-services.aspx","cssClass":"MainItem"},{"navigateUrl":"http://www.cuyahogacounty.us/en-US/visitors.aspx","cssClass":"MainItem"},{"navigateUrl":"http://www.cuyahogacounty.us/en-US/business.aspx","cssClass":"MainItem"},{"navigateUrl":"http://www.cuyahogacounty.us/en-US/contact-list.aspx","cssClass":"MainItem"},{"navigateUrl":"http://www.cuyahogacounty.us/en-US/online-services.aspx","cssClass":"MainItem"}]}, null, null, $get("ctl00_masterNav_Menu1"));
-});
-Sys.Application.add_init(function() {
-    $create(Telerik.Web.UI.RadMenu, {"_childListElementCssClass":null,"_skin":"RadMenuSiteSpecificNav","attributes":{"UseEmbeddedScripts":"false"},"clientStateFieldID":"ctl00_siteSpecificNav_Menu1_ClientState","collapseAnimation":"{\"duration\":450}","expandAnimation":"{\"duration\":450}","itemData":[{"navigateUrl":"http://bc.cuyahogacounty.us/en-US/home.aspx","cssClass":"MainItem"},{"navigateUrl":"http://bc.cuyahogacounty.us/en-US/boards-commissions-form.aspx","cssClass":"MainItem"},{"navigateUrl":"http://bc.cuyahogacounty.us/en-US/Internal-Boards.aspx","cssClass":"MainItem rmSelected"},{"navigateUrl":"http://bc.cuyahogacounty.us/en-US/External-Boards.aspx","cssClass":"MainItem"},{"navigateUrl":"http://bc.cuyahogacounty.us/en-US/Other-Boards.aspx","cssClass":"MainItem"},{"navigateUrl":"http://bc.cuyahogacounty.us/en-US/SiteMap.aspx","cssClass":"MainItem"},{"navigateUrl":"http://bc.cuyahogacounty.us/en-US/MyAccount.aspx","cssClass":"MainItem"}]}, null, null, $get("ctl00_siteSpecificNav_Menu1"));
-});
-//]]>
-</script>
-</form>
-</body>
-</html>
+
+<div>
+    
+    <ul class="list-unstyled">
+     <li class="">
+        <a href="/a-z-directory" target="_self">Departments</a>
+    </li>
+     <li class="">
+        <a href="/faqs" target="_self">FAQs</a>
+    </li>
+     <li class="">
+        <a href="/public-records-request" target="_self">Public Records Request</a>
+    </li>
+     <li class="">
+        <a href="/privacy-policy" target="_self">Privacy Policy</a>
+    </li>
+     <li class="">
+        <a href="/disclaimer" target="_self">Disclaimer</a>
+    </li>
+     <li class="">
+        <a href="/accessibility" target="_self">Accessibility</a>
+    </li>
+     <li class="">
+        <a href="/i-want-to-contact/county-social-media" target="_self">County Social Media</a>
+    </li>
+    </ul>
+</div>
+
+
+
+
+
+    </div>
+</div>
+<div class="row footer-bottom" data-sf-element="Row">
+    <div id="Footer_T25F18B5E036_Col00" class="sf_colsIn col-md-6" data-sf-element="Column 1" data-placeholder-label="Column 1">
+<div >
+    <div class="sf-Long-text" ><a target="_blank" href="/information-technology">Powered by the Department of Information Technology</a>
+<br /><br /><a href="https://www.sitefinity.com/customers/website-of-the-year/2017" target="_blank" data-sf-ec-immutable="">Progress Sitefinity 2017 Website of the Year - Government Category</a><br /></div>    
+</div>
+    </div>
+    <div id="Footer_T25F18B5E036_Col01" class="sf_colsIn col-md-6" data-sf-element="Column 2" data-placeholder-label="Column 2">
+<div >
+    <div class="sf-Long-text" ><p>The official government website of Cuyahoga County. <br />Quick facts about Cuyahoga County from the <a href="https://www.census.gov/quickfacts/fact/table/cuyahogacountyohio/PST045219">U.S. Census Bureau</a> <br />Cuyahoga County is a member of the <a href="https://www.naco.org/">National Association of Counties</a></p></div>    
+</div>
+    </div>
+</div>
+
+</div>
+
+
+
+
+
+
+
+
+</footer> <!-- end Footer --> </div> <script src="/Frontend-Assembly/Telerik.Sitefinity.Frontend/Mvc/Scripts/Bootstrap/js/bootstrap.min.js?package=Bootstrap&amp;v=MTQuMi43OTAwLjA%3d" type="text/javascript"></script> <script src="/ResourcePackages/Bootstrap/assets/dist/js/slick.min.js"></script> <script src="/ResourcePackages/Bootstrap/assets/dist/js/project.min.js"></script> <script src="/Frontend-Assembly/Telerik.Sitefinity.Frontend.Search/Mvc/Scripts/SearchBox/Search-box.min.js?package=Bootstrap&amp;v=MTQuMi43OTAwLjA%3d" type="text/javascript"></script><script type="application/json" id="PersonalizationTracker">
+	{"IsPagePersonalizationTarget":false,"IsUrlPersonalizationTarget":false,"PageId":"4ca9b761-bf60-419f-b987-6814fc3d45a9"}
+</script><script type="text/javascript" src="/WebResource.axd?d=Oiw5o8i74rDb2VpVaCaMSqM7nqpJ7y9OdepsWDIrAYMyxQaEl6SKqYBKfnuQhljNeS8ETgA7LZkl-qD6Zgl62djfgm2ytO4J-XoYuTm3QEXKf1E0g0uL-02gaUtRmWPN_dtbCNDV73tMqHSfelJH31cpRO-Fr6KCcp6rbXwsaJGsMQlQFVbBO4inQJKd9bPDWb_JGiXu0bk-Q2YYFfukA45QgfR0tXm1Ne33G3qHZag1&amp;t=637988280879082224">
+
+</script> <script src="/ResourcePackages/Bootstrap/assets/dist/js/sweetalert2.all.min.js"></script> <link href="/ResourcePackages/Bootstrap/assets/dist/css/sweetalert2.css" rel="stylesheet" /> <script type="text/javascript" src="https://app-script.monsido.com/v2/monsido-script.js"></script> <script type="text/javascript">
+  window._monsido = window._monsido || {
+        token: "kdx8gAyHUT8TGciNL_KoQw",
+        statistics: {
+            enabled: true,
+            documentTracking: {
+                enabled: true,
+                documentCls: "monsido_download",
+                documentIgnoreCls: "monsido_ignore_download",
+                documentExt: ["pdf","doc","ppt","docx","pptx"],
+            },
+        },
+    };
+</script> </body> </html>

--- a/tests/test_cuya_board_control.py
+++ b/tests/test_cuya_board_control.py
@@ -1,8 +1,7 @@
 from datetime import datetime
 from os.path import dirname, join
 
-import pytest  # noqa
-from city_scrapers_core.constants import BOARD, PASSED
+from city_scrapers_core.constants import BOARD, TENTATIVE
 from city_scrapers_core.utils import file_response
 from freezegun import freeze_time
 
@@ -10,15 +9,15 @@ from city_scrapers.spiders.cuya_board_control import CuyaBoardControlSpider
 
 test_response = file_response(
     join(dirname(__file__), "files", "cuya_board_control.html"),
-    url="http://bc.cuyahogacounty.us/en-US/Board-of-Control.aspx",
+    url="https://cuyahogacounty.gov/boards-and-commissions/board-details/internal/board-of-control",  # noqa
 )
 test_detail_response = file_response(
     join(dirname(__file__), "files", "cuya_board_control_detail.html"),
-    url="http://bc.cuyahogacounty.us/en-US/090319-BOC-meeting.aspx",
+    url="https://cuyahogacounty.gov/boards-and-commissions/bc-event-detail//2024/01/29/boards-and-commissions/01-29-24---board-of-control-meeting",  # noqa
 )
 spider = CuyaBoardControlSpider()
 
-freezer = freeze_time("2019-09-16")
+freezer = freeze_time("2024-01-25")
 freezer.start()
 
 parsed_items = [item for item in spider.parse(test_response)]
@@ -28,23 +27,26 @@ freezer.stop()
 
 
 def test_count():
-    assert len(parsed_items) == 37
+    assert len(parsed_items) == 5
 
 
 def test_title():
-    assert parsed_item["title"] == "Board of Control"
+    assert parsed_item["title"] == "01/29/24 - Board of Control Meeting"
 
 
 def test_description():
-    assert parsed_item["description"] == ""
+    assert (
+        parsed_item["description"]
+        == "This meeting is open to the public and may also be accessed via livestream using the following link: https://www.YouTube.com/CuyahogaCounty"  # noqa
+    )
 
 
 def test_start():
-    assert parsed_item["start"] == datetime(2019, 9, 3, 11, 0)
+    assert parsed_item["start"] == datetime(2024, 1, 29, 11, 0)
 
 
 def test_end():
-    assert parsed_item["end"] == datetime(2019, 9, 3, 12, 0)
+    assert parsed_item["end"] == datetime(2024, 1, 29, 12, 0)
 
 
 def test_time_notes():
@@ -52,38 +54,36 @@ def test_time_notes():
 
 
 def test_id():
-    assert parsed_item["id"] == "cuya_board_control/201909031100/x/board_of_control"
+    assert (
+        parsed_item["id"]
+        == "cuya_board_control/202401291100/x/01_29_24_board_of_control_meeting"
+    )
 
 
 def test_status():
-    assert parsed_item["status"] == PASSED
+    assert parsed_item["status"] == TENTATIVE
 
 
 def test_location():
     assert parsed_item["location"] == {
-        **spider.location,
-        "name": "County Headquarters 4th - Committee Room B",
+        "name": "",
+        "address": "County Headquarters 2079 East Ninth Street 4th, Cmmt Room B",
     }
 
 
 def test_source():
     assert (
         parsed_item["source"]
-        == "http://bc.cuyahogacounty.us/en-US/090319-BOC-meeting.aspx"
+        == "https://cuyahogacounty.gov/boards-and-commissions/bc-event-detail//2024/01/29/boards-and-commissions/01-29-24---board-of-control-meeting"  # noqa
     )
 
 
 def test_links():
     assert parsed_item["links"] == [
         {
-            "href": "http://bc.cuyahogacounty.us/ViewFile.aspx?file=4WMJGeytOlPc09gwkgQOWA%3d%3d",  # noqa
-            "title": "Minutes",
-        },
-        {
-            "href": "http://bc.cuyahogacounty.us/ViewFile.aspx?file=ItAmWexRAtkvZMENqysomw%3d%3d",  # noqa
+            "href": "https://cuyahogacms.blob.core.windows.net/home/docs/default-source/boards-and-commissions/internal/boc/2024/012924-bocagenda.pdf?sfvrsn=60356a8a_1",  # noqa
             "title": "Agenda",
-        },
-        {"href": "https://www.youtube.com/embed//yMhUaaxldIg", "title": "Video"},
+        }
     ]
 
 


### PR DESCRIPTION
What's this PR do?
Fixes our Cuyahoga County Board of Control spider (aka. cuya_control_board), which broke due to URL and page structure changes across Cuyahoga County's website.

Why are we doing this?
To ensure our Cuyahoga County Board of Control spider works. The changes in this PR include use of a new class mixin for scraping the Cuyahoga County website.

Steps to manually test
Clone this repo, run the command: cd city_scrapers && scrapy crawl cuya_board_control

Are there any smells or added technical debt to note?
No
