### PR TITLE
🏗️  Add spider: Cleveland Police Commission

### DIFF
--- a/city_scrapers/spiders/cle_cpc.py
+++ b/city_scrapers/spiders/cle_cpc.py
@@ -18,18 +18,22 @@ class CleCpcSpider(CityScrapersSpider):
 
     def parse(self, response):
         """
-        `parse` should always `yield` Meeting items.
-
-        Change the `_parse_title`, `_parse_start`, etc methods to fit your scraping
-        needs.
+        Parses meeting calendar page. Because this website has a variety of
+        quirks that can lead to duplicate data we only scrape the first
+        unique link for each meeting.
         """
-        calendars = response.css('.mec-wrap.mec-skin-grid-container')
+        calendars = response.css(".mec-wrap.mec-skin-grid-container")
         if len(calendars) <= 1:
             raise ("Meetings calendar not found")
+
+        unique_links = []
         for event in calendars[0].css("article.mec-event-article"):
-            event_link = event.css("h4.mec-event-title a::attr(href)").get()
-            if event_link:
-                yield response.follow(event_link, callback=self._parse_detail)
+            link = event.css("h4.mec-event-title a::attr(href)").get()
+            if link not in unique_links:
+                unique_links.append(link)
+
+        for link in unique_links:
+            yield response.follow(link, callback=self._parse_detail)
 
     def _parse_detail(self, response):
         """

--- a/city_scrapers/spiders/cle_cpc.py
+++ b/city_scrapers/spiders/cle_cpc.py
@@ -8,7 +8,7 @@ from city_scrapers_core.spiders import CityScrapersSpider
 class CleCpcSpider(CityScrapersSpider):
     name = "cle_cpc"
     agency = "Cleveland Community Police Commission"
-    timezone = "America/Chicago"
+    timezone = "America/Detroit"
     start_urls = ["https://clecpc.org/get-involved/calendar/"]
     links = [
         {

--- a/city_scrapers/spiders/cle_cpc.py
+++ b/city_scrapers/spiders/cle_cpc.py
@@ -1,0 +1,126 @@
+from datetime import datetime, time
+
+from city_scrapers_core.constants import COMMISSION
+from city_scrapers_core.items import Meeting
+from city_scrapers_core.spiders import CityScrapersSpider
+
+class CleCpcSpider(CityScrapersSpider):
+    name = "cle_cpc"
+    agency = "Cleveland Community Police Commission"
+    timezone = "America/Chicago"
+    start_urls = ["https://clecpc.org/get-involved/calendar/"]
+
+    def parse(self, response):
+        """
+        `parse` should always `yield` Meeting items.
+
+        Change the `_parse_title`, `_parse_start`, etc methods to fit your scraping
+        needs.
+        """
+        for event in response.css("article.mec-event-article"):
+            event_link = event.css("h4.mec-event-title a::attr(href)").get()
+            if event_link:
+                yield response.follow(event_link, callback=self._parse_detail)
+
+    def _parse_detail(self, response):
+        """
+        Parse details from the event detail page.
+        """
+
+        date = self._parse_date(response)
+        start_time, end_time = self._parse_start_end_time(response)
+        meeting = Meeting(
+            title=self._parse_title(response),
+            description=self._parse_description(response),
+            classification=COMMISSION,
+            start=self._gen_datetime(date, start_time),
+            end=self._gen_datetime(date, end_time),
+            time_notes="",
+            all_day=False,
+            location=self._parse_location(response),
+            links=self._parse_links(response),
+            source=self._parse_source(response),
+        )
+        meeting["status"] = self._get_status(meeting)
+        meeting["id"] = self._get_id(meeting)
+        yield meeting
+
+    def _parse_title(self, response):
+        """Parse or generate meeting title."""
+        title = response.css(".mec-single-title::text").get()
+        if not title:
+            return None
+        return title.strip()
+
+    def _parse_description(self, response):
+        """
+        Extracts and returns all text within the mec-single-event-description element.
+        """
+        description_parts = response.css(
+            ".mec-single-event-description *::text"
+        ).getall()
+        full_description = " ".join(
+            part.strip() for part in description_parts if part.strip()
+        )
+        return full_description
+
+    def _parse_date(self, response):
+        # Extracting the date string
+        date_str = response.css(
+            ".mec-single-event-date .mec-start-date-label::text"
+        ).get()
+        # Parsing the date string into a datetime object
+        date = datetime.strptime(date_str, "%b %d %Y") if date_str else None
+        return date
+
+    def _parse_start_end_time(self, response):
+        # Extracting the time string
+        time_str = response.css(".mec-single-event-time .mec-events-abbr::text").get()
+        if time_str:
+            time_parts = time_str.split(" - ")
+            if len(time_parts) == 2:
+                # Splitting the start and end time and converting to datetime objects
+                start_time_str, end_time_str = time_parts
+                start_time = datetime.strptime(start_time_str, "%I:%M %p").time()
+                end_time = datetime.strptime(end_time_str, "%I:%M %p").time()
+                return start_time, end_time
+            else:
+                # Log a warning or handle the case where the time format is unexpected
+                self.logger.warning(f"Unexpected time format: {time_str}")
+        # Return None for both start and end times if the time element doesn't exist or format is incorrect
+        return None, None
+
+    def _gen_datetime(self, date, time_obj):
+        """
+        Generate a datetime object from a date and a time object.
+        If time_obj is None, set the time to midnight.
+        """
+        if time_obj is None:
+            time_obj = time(0, 0)  # Midnight
+        return datetime.combine(date, time_obj)
+
+    def _parse_location(self, response):
+        org_name = response.css(".org::text").get().strip()
+        address = response.css(".mec-address::text").get().strip()
+        return {
+            "name": org_name,
+            "address": address,
+        }
+
+    def _parse_links(self, response):
+        """Parse or generate links."""
+        links = []
+        # Target all links within mec-single-event-description, regardless of nesting
+        for link_element in response.css(".mec-events-content a"):
+            # Extracting all text within the link, including text in nested elements
+            link_text = link_element.css("*::text").get().lower()
+            link_href = link_element.attrib.get("href", "")
+            if "agenda" in link_text:
+                links.append({"href": link_href, "title": "Agenda"})
+            if "youtube.com" in link_href:
+                links.append({"href": link_href, "title": "Video"})
+        return links
+
+    def _parse_source(self, response):
+        """Generate source."""
+        return response.url

--- a/city_scrapers/spiders/cle_cpc.py
+++ b/city_scrapers/spiders/cle_cpc.py
@@ -9,6 +9,12 @@ class CleCpcSpider(CityScrapersSpider):
     agency = "Cleveland Community Police Commission"
     timezone = "America/Chicago"
     start_urls = ["https://clecpc.org/get-involved/calendar/"]
+    links = [
+        {
+            "title": "Meeting agendas and minutes",
+            "href": "https://clecpc.org/resources/meeting-agendas-minutes/",
+        }
+    ]
 
     def parse(self, response):
         """
@@ -41,7 +47,7 @@ class CleCpcSpider(CityScrapersSpider):
             time_notes="",
             all_day=False,
             location=self._parse_location(response),
-            links=self._parse_links(response),
+            links=self.links,
             source=self._parse_source(response),
         )
         meeting["status"] = self._get_status(meeting)
@@ -109,20 +115,6 @@ class CleCpcSpider(CityScrapersSpider):
             "name": org_name,
             "address": address,
         }
-
-    def _parse_links(self, response):
-        """Parse or generate links."""
-        links = []
-        # Target all links within mec-single-event-description, regardless of nesting
-        for link_element in response.css(".mec-events-content a"):
-            # Extracting all text within the link, including text in nested elements
-            link_text = link_element.css("*::text").get().lower()
-            link_href = link_element.attrib.get("href", "")
-            if "agenda" in link_text:
-                links.append({"href": link_href, "title": "Agenda"})
-            if "youtube.com" in link_href:
-                links.append({"href": link_href, "title": "Video"})
-        return links
 
     def _parse_source(self, response):
         """Generate source."""

--- a/city_scrapers/spiders/cle_cpc.py
+++ b/city_scrapers/spiders/cle_cpc.py
@@ -1,6 +1,6 @@
 from datetime import datetime, time
 
-from city_scrapers_core.constants import COMMISSION
+from city_scrapers_core.constants import COMMISSION, PASSED, TENTATIVE
 from city_scrapers_core.items import Meeting
 from city_scrapers_core.spiders import CityScrapersSpider
 
@@ -119,3 +119,13 @@ class CleCpcSpider(CityScrapersSpider):
     def _parse_source(self, response):
         """Generate source."""
         return response.url
+
+    def _get_status(self, item):
+        """
+        Overrides the parent class method because basing a meeting's
+        cancellation status on the title and time of the meeting is not
+        reliable. Instead, we'll only focus on the meeting's start time.
+        """
+        if item["start"] < datetime.now():
+            return PASSED
+        return TENTATIVE

--- a/city_scrapers/spiders/cle_cpc.py
+++ b/city_scrapers/spiders/cle_cpc.py
@@ -17,7 +17,10 @@ class CleCpcSpider(CityScrapersSpider):
         Change the `_parse_title`, `_parse_start`, etc methods to fit your scraping
         needs.
         """
-        for event in response.css("article.mec-event-article"):
+        calendars = response.css('.mec-wrap.mec-skin-grid-container')
+        if len(calendars) <= 1:
+            raise ("Meetings calendar not found")
+        for event in calendars[0].css("article.mec-event-article"):
             event_link = event.css("h4.mec-event-title a::attr(href)").get()
             if event_link:
                 yield response.follow(event_link, callback=self._parse_detail)

--- a/city_scrapers/spiders/cle_cpc.py
+++ b/city_scrapers/spiders/cle_cpc.py
@@ -4,6 +4,7 @@ from city_scrapers_core.constants import COMMISSION, PASSED, TENTATIVE
 from city_scrapers_core.items import Meeting
 from city_scrapers_core.spiders import CityScrapersSpider
 
+
 class CleCpcSpider(CityScrapersSpider):
     name = "cle_cpc"
     agency = "Cleveland Community Police Commission"
@@ -39,7 +40,6 @@ class CleCpcSpider(CityScrapersSpider):
         """
         Parse details from the event detail page.
         """
-
         date = self._parse_date(response)
         start_time, end_time = self._parse_start_end_time(response)
         meeting = Meeting(
@@ -59,7 +59,7 @@ class CleCpcSpider(CityScrapersSpider):
         yield meeting
 
     def _parse_title(self, response):
-        """Parse or generate meeting title."""
+        """Parse meeting title."""
         title = response.css(".mec-single-title::text").get()
         if not title:
             return None
@@ -78,6 +78,7 @@ class CleCpcSpider(CityScrapersSpider):
         return full_description
 
     def _parse_date(self, response):
+        """Parse date from calendar element."""
         # Extracting the date string
         date_str = response.css(
             ".mec-single-event-date .mec-start-date-label::text"
@@ -87,7 +88,10 @@ class CleCpcSpider(CityScrapersSpider):
         return date
 
     def _parse_start_end_time(self, response):
-        # Extracting the time string
+        """
+        Parses start and end times from calendar element.
+        If times are missing, returns None for both.
+        """
         time_str = response.css(".mec-single-event-time .mec-events-abbr::text").get()
         if time_str:
             time_parts = time_str.split(" - ")
@@ -98,9 +102,8 @@ class CleCpcSpider(CityScrapersSpider):
                 end_time = datetime.strptime(end_time_str, "%I:%M %p").time()
                 return start_time, end_time
             else:
-                # Log a warning or handle the case where the time format is unexpected
+                # Log a warning in case where the time format is unexpected
                 self.logger.warning(f"Unexpected time format: {time_str}")
-        # Return None for both start and end times if the time element doesn't exist or format is incorrect
         return None, None
 
     def _gen_datetime(self, date, time_obj):
@@ -113,6 +116,7 @@ class CleCpcSpider(CityScrapersSpider):
         return datetime.combine(date, time_obj)
 
     def _parse_location(self, response):
+        """Parses location from calendar element."""
         org_name = response.css(".org::text").get().strip()
         address = response.css(".mec-address::text").get().strip()
         return {
@@ -121,7 +125,6 @@ class CleCpcSpider(CityScrapersSpider):
         }
 
     def _parse_source(self, response):
-        """Generate source."""
         return response.url
 
     def _get_status(self, item):

--- a/tests/files/cle_cpc.html
+++ b/tests/files/cle_cpc.html
@@ -1,0 +1,2184 @@
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="profile" href="http://gmpg.org/xfn/11">
+<link rel="pingback" href="https://clecpc.org/xmlrpc.php">
+
+<script type="text/javascript">
+  WebFontConfig = {"google":{"families":["Source+Sans+Pro:b:latin,latin-ext","Source+Sans+Pro:r,i,b,bi:latin,latin-ext"]},"api_url":"https:\/\/fonts-api.wp.com\/css"};
+  (function() {
+    var wf = document.createElement('script');
+    wf.src = 'https://clecpc.org/wp-content/mu-plugins/wpcomsh/vendor/automattic/custom-fonts/js/webfont.js';
+    wf.type = 'text/javascript';
+    wf.async = 'true';
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(wf, s);
+	})();
+</script><style id="jetpack-custom-fonts-css">.wf-active body, .wf-active button, .wf-active input, .wf-active select, .wf-active textarea{font-family:"Source Sans Pro",sans-serif}.wf-active pre{font-family:"Source Sans Pro",sans-serif}.wf-active blockquote:before{font-family:"Source Sans Pro",sans-serif}.wf-active .menu-toggle{font-family:"Source Sans Pro",sans-serif}.wf-active .main-navigation li{font-family:"Source Sans Pro",sans-serif}.wf-active .site-footer a.button{font-family:"Source Sans Pro",sans-serif}.wf-active a.blue{font-family:"Source Sans Pro",sans-serif}.wf-active .widget_blog_subscription input[type="submit"]{font-family:"Source Sans Pro",sans-serif}.wf-active .footer-menu .widget_nav_menu li{font-family:"Source Sans Pro",sans-serif}.wf-active .entry-content a.button{font-family:"Source Sans Pro",sans-serif}.wf-active .block-two a.blue{font-family:"Source Sans Pro",sans-serif}.wf-active .contact-form input[type="submit"]{font-family:"Source Sans Pro",sans-serif}.wf-active h1, .wf-active h2, .wf-active h3, .wf-active h4, .wf-active h5, .wf-active h6{font-family:"Source Sans Pro",sans-serif;font-weight:700;font-style:normal}.wf-active p.site-title{font-family:"Source Sans Pro",sans-serif;font-weight:700;font-style:normal}.wf-active h1{font-style:normal;font-weight:700}.wf-active h2{font-style:normal;font-weight:700}.wf-active h3{font-style:normal;font-weight:700}.wf-active h4{font-style:normal;font-weight:700}.wf-active h5{font-style:normal;font-weight:700}.wf-active h6{font-style:normal;font-weight:700}.wf-active .widget-title, .wf-active .widgettitle{font-style:normal;font-weight:700}.wf-active .widget_calendar th{font-weight:700;font-style:normal}.wf-active .entry-title{font-style:normal;font-weight:700}.wf-active .page-title{font-style:normal;font-weight:700}.wf-active .author-title{font-weight:700;font-style:normal}.wf-active .news .two-third .customwidget .entry-title{font-style:normal;font-weight:700}.wf-active .content-caption .entry-content h1, .wf-active .content-caption .entry-content h2, .wf-active .content-caption .entry-content h3, .wf-active .content-caption .entry-content h4, .wf-active .content-caption .entry-content h5, .wf-active .content-caption .entry-content h6{font-family:"Source Sans Pro",sans-serif;font-weight:700;font-style:normal}.wf-active .block-one .child-pages h2{font-style:normal;font-weight:700}.wf-active .page-template-grid-page.singular .columns .entry-title, .wf-active .page-template-involved-template.singular .columns .entry-title, .wf-active .singular .block-six .columns .entry-title{font-style:normal;font-weight:700}@media screen and ( min-width: 55em ){.wf-active .singular .entry-title, .wf-active h1{font-style:normal;font-weight:700}}@media screen and ( min-width: 55em ){.wf-active .page-template-boxed-sidebar-template h1, .wf-active .page-template-boxed-sidebar-template.singular .entry-title{font-style:normal;font-weight:700}}@media screen and ( min-width: 55em ){.wf-active .site-title{font-style:normal;font-weight:700}}@media screen and ( min-width: 55em ){.wf-active .singular.page-template-right-column-page-php .entry-title, .wf-active h2{font-style:normal;font-weight:700}}@media screen and ( min-width: 55em ){.wf-active h3{font-style:normal;font-weight:700}}@media screen and ( min-width: 55em ){.wf-active h4{font-style:normal;font-weight:700}}@media screen and ( min-width: 55em ){.wf-active h5{font-style:normal;font-weight:700}}@media screen and ( min-width: 55em ){.wf-active h6{font-style:normal;font-weight:700}}@media screen and ( min-width: 55em ){.wf-active .archive.list-layout .entry-title, .wf-active .blog.list-layout .entry-title{font-style:normal;font-weight:700}}@media screen and ( min-width: 55em ){.wf-active .home.singular.page-template-right-column-page-php .entry-title{font-style:normal;font-weight:700}}@media screen and ( min-width: 55em ){.wf-active .home.singular.page-template-right-column-page-php .block-one .child-pages h2{font-style:normal;font-weight:700}}@media screen and ( min-width: 55em ){.wf-active .home.singular.page-template-right-column-page-php .news .two-third .customwidget .entry-title{font-style:normal;font-weight:700}}</style>
+<meta name='robots' content='index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1' />
+
+	<!-- This site is optimized with the Yoast SEO plugin v21.9.1 - https://yoast.com/wordpress/plugins/seo/ -->
+	<title>Calendar - Cleveland Community Police Commission</title>
+	<link rel="canonical" href="https://clecpc.org/get-involved/calendar/" />
+	<meta property="og:locale" content="en_US" />
+	<meta property="og:type" content="article" />
+	<meta property="og:title" content="Calendar - Cleveland Community Police Commission" />
+	<meta property="og:description" content="Your involvement is needed to shape how policing looks in Cleveland. Participate in CPC and community meetings to share your thoughts about policing and related issues in your community.Continue reading Calendar &rarr;" />
+	<meta property="og:url" content="https://clecpc.org/get-involved/calendar/" />
+	<meta property="og:site_name" content="Cleveland Community Police Commission" />
+	<meta property="article:modified_time" content="2023-07-28T16:49:19+00:00" />
+	<meta property="og:image" content="https://clecpc.org/wp-content/uploads/Header-Image-Calendar.jpg" />
+	<meta property="og:image:width" content="2500" />
+	<meta property="og:image:height" content="849" />
+	<meta property="og:image:type" content="image/jpeg" />
+	<meta name="twitter:card" content="summary_large_image" />
+	<meta name="twitter:label1" content="Est. reading time" />
+	<meta name="twitter:data1" content="5 minutes" />
+	<script type="application/ld+json" class="yoast-schema-graph">{"@context":"https://schema.org","@graph":[{"@type":"WebPage","@id":"https://clecpc.org/get-involved/calendar/","url":"https://clecpc.org/get-involved/calendar/","name":"Calendar - Cleveland Community Police Commission","isPartOf":{"@id":"https://clecpc.org/#website"},"primaryImageOfPage":{"@id":"https://clecpc.org/get-involved/calendar/#primaryimage"},"image":{"@id":"https://clecpc.org/get-involved/calendar/#primaryimage"},"thumbnailUrl":"https://i0.wp.com/clecpc.org/wp-content/uploads/Header-Image-Calendar.jpg?fit=2500%2C849&ssl=1","datePublished":"2019-11-04T15:32:43+00:00","dateModified":"2023-07-28T16:49:19+00:00","breadcrumb":{"@id":"https://clecpc.org/get-involved/calendar/#breadcrumb"},"inLanguage":"en-US","potentialAction":[{"@type":"ReadAction","target":["https://clecpc.org/get-involved/calendar/"]}]},{"@type":"ImageObject","inLanguage":"en-US","@id":"https://clecpc.org/get-involved/calendar/#primaryimage","url":"https://i0.wp.com/clecpc.org/wp-content/uploads/Header-Image-Calendar.jpg?fit=2500%2C849&ssl=1","contentUrl":"https://i0.wp.com/clecpc.org/wp-content/uploads/Header-Image-Calendar.jpg?fit=2500%2C849&ssl=1","width":2500,"height":849},{"@type":"BreadcrumbList","@id":"https://clecpc.org/get-involved/calendar/#breadcrumb","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://clecpc.org/"},{"@type":"ListItem","position":2,"name":"Get Involved","item":"https://clecpc.org/get-involved/"},{"@type":"ListItem","position":3,"name":"Calendar"}]},{"@type":"WebSite","@id":"https://clecpc.org/#website","url":"https://clecpc.org/","name":"Cleveland Community Police Commission","description":"","publisher":{"@id":"https://clecpc.org/#organization"},"potentialAction":[{"@type":"SearchAction","target":{"@type":"EntryPoint","urlTemplate":"https://clecpc.org/?s={search_term_string}"},"query-input":"required name=search_term_string"}],"inLanguage":"en-US"},{"@type":"Organization","@id":"https://clecpc.org/#organization","name":"Cleveland Community Police Commission","url":"https://clecpc.org/","logo":{"@type":"ImageObject","inLanguage":"en-US","@id":"https://clecpc.org/#/schema/logo/image/","url":"https://i0.wp.com/clecpc.org/wp-content/uploads/CPCLogo-Nav5.png?fit=105%2C71&ssl=1","contentUrl":"https://i0.wp.com/clecpc.org/wp-content/uploads/CPCLogo-Nav5.png?fit=105%2C71&ssl=1","width":105,"height":71,"caption":"Cleveland Community Police Commission"},"image":{"@id":"https://clecpc.org/#/schema/logo/image/"}}]}</script>
+	<!-- / Yoast SEO plugin. -->
+
+
+<link rel='dns-prefetch' href='//secure.gravatar.com' />
+<link rel='dns-prefetch' href='//stats.wp.com' />
+<link rel='dns-prefetch' href='//fonts-api.wp.com' />
+<link rel='dns-prefetch' href='//widgets.wp.com' />
+<link rel='dns-prefetch' href='//s0.wp.com' />
+<link rel='dns-prefetch' href='//0.gravatar.com' />
+<link rel='dns-prefetch' href='//1.gravatar.com' />
+<link rel='dns-prefetch' href='//2.gravatar.com' />
+<link rel='dns-prefetch' href='//i0.wp.com' />
+<link rel='dns-prefetch' href='//c0.wp.com' />
+<link rel='dns-prefetch' href='//jetpack.wordpress.com' />
+<link rel='dns-prefetch' href='//public-api.wordpress.com' />
+<link rel="alternate" type="application/rss+xml" title="Cleveland Community Police Commission &raquo; Feed" href="https://clecpc.org/feed/" />
+<link rel="alternate" type="application/rss+xml" title="Cleveland Community Police Commission &raquo; Comments Feed" href="https://clecpc.org/comments/feed/" />
+		<!-- This site uses the Google Analytics by MonsterInsights plugin v8.23.1 - Using Analytics tracking - https://www.monsterinsights.com/ -->
+							<script src="//www.googletagmanager.com/gtag/js?id=G-ZXWB1C1R71"  data-cfasync="false" data-wpfc-render="false" type="text/javascript" async></script>
+			<script data-cfasync="false" data-wpfc-render="false" type="text/javascript">
+				var mi_version = '8.23.1';
+				var mi_track_user = true;
+				var mi_no_track_reason = '';
+				
+								var disableStrs = [
+										'ga-disable-G-ZXWB1C1R71',
+									];
+
+				/* Function to detect opted out users */
+				function __gtagTrackerIsOptedOut() {
+					for (var index = 0; index < disableStrs.length; index++) {
+						if (document.cookie.indexOf(disableStrs[index] + '=true') > -1) {
+							return true;
+						}
+					}
+
+					return false;
+				}
+
+				/* Disable tracking if the opt-out cookie exists. */
+				if (__gtagTrackerIsOptedOut()) {
+					for (var index = 0; index < disableStrs.length; index++) {
+						window[disableStrs[index]] = true;
+					}
+				}
+
+				/* Opt-out function */
+				function __gtagTrackerOptout() {
+					for (var index = 0; index < disableStrs.length; index++) {
+						document.cookie = disableStrs[index] + '=true; expires=Thu, 31 Dec 2099 23:59:59 UTC; path=/';
+						window[disableStrs[index]] = true;
+					}
+				}
+
+				if ('undefined' === typeof gaOptout) {
+					function gaOptout() {
+						__gtagTrackerOptout();
+					}
+				}
+								window.dataLayer = window.dataLayer || [];
+
+				window.MonsterInsightsDualTracker = {
+					helpers: {},
+					trackers: {},
+				};
+				if (mi_track_user) {
+					function __gtagDataLayer() {
+						dataLayer.push(arguments);
+					}
+
+					function __gtagTracker(type, name, parameters) {
+						if (!parameters) {
+							parameters = {};
+						}
+
+						if (parameters.send_to) {
+							__gtagDataLayer.apply(null, arguments);
+							return;
+						}
+
+						if (type === 'event') {
+														parameters.send_to = monsterinsights_frontend.v4_id;
+							var hookName = name;
+							if (typeof parameters['event_category'] !== 'undefined') {
+								hookName = parameters['event_category'] + ':' + name;
+							}
+
+							if (typeof MonsterInsightsDualTracker.trackers[hookName] !== 'undefined') {
+								MonsterInsightsDualTracker.trackers[hookName](parameters);
+							} else {
+								__gtagDataLayer('event', name, parameters);
+							}
+							
+						} else {
+							__gtagDataLayer.apply(null, arguments);
+						}
+					}
+
+					__gtagTracker('js', new Date());
+					__gtagTracker('set', {
+						'developer_id.dZGIzZG': true,
+											});
+										__gtagTracker('config', 'G-ZXWB1C1R71', {"forceSSL":"true","link_attribution":"true"} );
+															window.gtag = __gtagTracker;										(function () {
+						/* https://developers.google.com/analytics/devguides/collection/analyticsjs/ */
+						/* ga and __gaTracker compatibility shim. */
+						var noopfn = function () {
+							return null;
+						};
+						var newtracker = function () {
+							return new Tracker();
+						};
+						var Tracker = function () {
+							return null;
+						};
+						var p = Tracker.prototype;
+						p.get = noopfn;
+						p.set = noopfn;
+						p.send = function () {
+							var args = Array.prototype.slice.call(arguments);
+							args.unshift('send');
+							__gaTracker.apply(null, args);
+						};
+						var __gaTracker = function () {
+							var len = arguments.length;
+							if (len === 0) {
+								return;
+							}
+							var f = arguments[len - 1];
+							if (typeof f !== 'object' || f === null || typeof f.hitCallback !== 'function') {
+								if ('send' === arguments[0]) {
+									var hitConverted, hitObject = false, action;
+									if ('event' === arguments[1]) {
+										if ('undefined' !== typeof arguments[3]) {
+											hitObject = {
+												'eventAction': arguments[3],
+												'eventCategory': arguments[2],
+												'eventLabel': arguments[4],
+												'value': arguments[5] ? arguments[5] : 1,
+											}
+										}
+									}
+									if ('pageview' === arguments[1]) {
+										if ('undefined' !== typeof arguments[2]) {
+											hitObject = {
+												'eventAction': 'page_view',
+												'page_path': arguments[2],
+											}
+										}
+									}
+									if (typeof arguments[2] === 'object') {
+										hitObject = arguments[2];
+									}
+									if (typeof arguments[5] === 'object') {
+										Object.assign(hitObject, arguments[5]);
+									}
+									if ('undefined' !== typeof arguments[1].hitType) {
+										hitObject = arguments[1];
+										if ('pageview' === hitObject.hitType) {
+											hitObject.eventAction = 'page_view';
+										}
+									}
+									if (hitObject) {
+										action = 'timing' === arguments[1].hitType ? 'timing_complete' : hitObject.eventAction;
+										hitConverted = mapArgs(hitObject);
+										__gtagTracker('event', action, hitConverted);
+									}
+								}
+								return;
+							}
+
+							function mapArgs(args) {
+								var arg, hit = {};
+								var gaMap = {
+									'eventCategory': 'event_category',
+									'eventAction': 'event_action',
+									'eventLabel': 'event_label',
+									'eventValue': 'event_value',
+									'nonInteraction': 'non_interaction',
+									'timingCategory': 'event_category',
+									'timingVar': 'name',
+									'timingValue': 'value',
+									'timingLabel': 'event_label',
+									'page': 'page_path',
+									'location': 'page_location',
+									'title': 'page_title',
+									'referrer' : 'page_referrer',
+								};
+								for (arg in args) {
+																		if (!(!args.hasOwnProperty(arg) || !gaMap.hasOwnProperty(arg))) {
+										hit[gaMap[arg]] = args[arg];
+									} else {
+										hit[arg] = args[arg];
+									}
+								}
+								return hit;
+							}
+
+							try {
+								f.hitCallback();
+							} catch (ex) {
+							}
+						};
+						__gaTracker.create = newtracker;
+						__gaTracker.getByName = newtracker;
+						__gaTracker.getAll = function () {
+							return [];
+						};
+						__gaTracker.remove = noopfn;
+						__gaTracker.loaded = true;
+						window['__gaTracker'] = __gaTracker;
+					})();
+									} else {
+										console.log("");
+					(function () {
+						function __gtagTracker() {
+							return null;
+						}
+
+						window['__gtagTracker'] = __gtagTracker;
+						window['gtag'] = __gtagTracker;
+					})();
+									}
+			</script>
+				<!-- / Google Analytics by MonsterInsights -->
+		<script type="text/javascript">
+/* <![CDATA[ */
+window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/14.0.0\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/14.0.0\/svg\/","svgExt":".svg","source":{"concatemoji":"https:\/\/clecpc.org\/wp-includes\/js\/wp-emoji-release.min.js?ver=6.4.2"}};
+/*! This file is auto-generated */
+!function(i,n){var o,s,e;function c(e){try{var t={supportTests:e,timestamp:(new Date).valueOf()};sessionStorage.setItem(o,JSON.stringify(t))}catch(e){}}function p(e,t,n){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);var t=new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data),r=(e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(n,0,0),new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data));return t.every(function(e,t){return e===r[t]})}function u(e,t,n){switch(t){case"flag":return n(e,"\ud83c\udff3\ufe0f\u200d\u26a7\ufe0f","\ud83c\udff3\ufe0f\u200b\u26a7\ufe0f")?!1:!n(e,"\ud83c\uddfa\ud83c\uddf3","\ud83c\uddfa\u200b\ud83c\uddf3")&&!n(e,"\ud83c\udff4\udb40\udc67\udb40\udc62\udb40\udc65\udb40\udc6e\udb40\udc67\udb40\udc7f","\ud83c\udff4\u200b\udb40\udc67\u200b\udb40\udc62\u200b\udb40\udc65\u200b\udb40\udc6e\u200b\udb40\udc67\u200b\udb40\udc7f");case"emoji":return!n(e,"\ud83e\udef1\ud83c\udffb\u200d\ud83e\udef2\ud83c\udfff","\ud83e\udef1\ud83c\udffb\u200b\ud83e\udef2\ud83c\udfff")}return!1}function f(e,t,n){var r="undefined"!=typeof WorkerGlobalScope&&self instanceof WorkerGlobalScope?new OffscreenCanvas(300,150):i.createElement("canvas"),a=r.getContext("2d",{willReadFrequently:!0}),o=(a.textBaseline="top",a.font="600 32px Arial",{});return e.forEach(function(e){o[e]=t(a,e,n)}),o}function t(e){var t=i.createElement("script");t.src=e,t.defer=!0,i.head.appendChild(t)}"undefined"!=typeof Promise&&(o="wpEmojiSettingsSupports",s=["flag","emoji"],n.supports={everything:!0,everythingExceptFlag:!0},e=new Promise(function(e){i.addEventListener("DOMContentLoaded",e,{once:!0})}),new Promise(function(t){var n=function(){try{var e=JSON.parse(sessionStorage.getItem(o));if("object"==typeof e&&"number"==typeof e.timestamp&&(new Date).valueOf()<e.timestamp+604800&&"object"==typeof e.supportTests)return e.supportTests}catch(e){}return null}();if(!n){if("undefined"!=typeof Worker&&"undefined"!=typeof OffscreenCanvas&&"undefined"!=typeof URL&&URL.createObjectURL&&"undefined"!=typeof Blob)try{var e="postMessage("+f.toString()+"("+[JSON.stringify(s),u.toString(),p.toString()].join(",")+"));",r=new Blob([e],{type:"text/javascript"}),a=new Worker(URL.createObjectURL(r),{name:"wpTestEmojiSupports"});return void(a.onmessage=function(e){c(n=e.data),a.terminate(),t(n)})}catch(e){}c(n=f(s,u,p))}t(n)}).then(function(e){for(var t in e)n.supports[t]=e[t],n.supports.everything=n.supports.everything&&n.supports[t],"flag"!==t&&(n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&n.supports[t]);n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&!n.supports.flag,n.DOMReady=!1,n.readyCallback=function(){n.DOMReady=!0}}).then(function(){return e}).then(function(){var e;n.supports.everything||(n.readyCallback(),(e=n.source||{}).concatemoji?t(e.concatemoji):e.wpemoji&&e.twemoji&&(t(e.twemoji),t(e.wpemoji)))}))}((window,document),window._wpemojiSettings);
+/* ]]> */
+</script>
+<link rel='stylesheet' id='mec-select2-style-css' href='https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/packages/select2/select2.min.css?ver=6.5.6' type='text/css' media='all' />
+<link rel='stylesheet' id='mec-font-icons-css' href='https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/css/iconfonts.css?ver=6.4.2' type='text/css' media='all' />
+<link rel='stylesheet' id='mec-frontend-style-css' href='https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/css/frontend.min.css?ver=6.5.6' type='text/css' media='all' />
+<link rel='stylesheet' id='mec-tooltip-style-css' href='https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/packages/tooltip/tooltip.css?ver=6.4.2' type='text/css' media='all' />
+<link rel='stylesheet' id='mec-tooltip-shadow-style-css' href='https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/packages/tooltip/tooltipster-sideTip-shadow.min.css?ver=6.4.2' type='text/css' media='all' />
+<link rel='stylesheet' id='featherlight-css' href='https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/packages/featherlight/featherlight.css?ver=6.4.2' type='text/css' media='all' />
+<link rel='stylesheet' id='mec-google-fonts-css' href='//fonts-api.wp.com/css?family=Montserrat%3A400%2C700%7CRoboto%3A100%2C300%2C400%2C700&#038;ver=6.4.2' type='text/css' media='all' />
+<link rel='stylesheet' id='mec-lity-style-css' href='https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/packages/lity/lity.min.css?ver=6.4.2' type='text/css' media='all' />
+<link rel='stylesheet' id='mec-general-calendar-style-css' href='https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/css/mec-general-calendar.css?ver=6.4.2' type='text/css' media='all' />
+<style id='wp-emoji-styles-inline-css' type='text/css'>
+
+	img.wp-smiley, img.emoji {
+		display: inline !important;
+		border: none !important;
+		box-shadow: none !important;
+		height: 1em !important;
+		width: 1em !important;
+		margin: 0 0.07em !important;
+		vertical-align: -0.1em !important;
+		background: none !important;
+		padding: 0 !important;
+	}
+</style>
+<link rel='stylesheet' id='mediaelement-css' href='https://c0.wp.com/c/6.4.2/wp-includes/js/mediaelement/mediaelementplayer-legacy.min.css' type='text/css' media='all' />
+<link rel='stylesheet' id='wp-mediaelement-css' href='https://c0.wp.com/c/6.4.2/wp-includes/js/mediaelement/wp-mediaelement.min.css' type='text/css' media='all' />
+<style id='classic-theme-styles-inline-css' type='text/css'>
+/*! This file is auto-generated */
+.wp-block-button__link{color:#fff;background-color:#32373c;border-radius:9999px;box-shadow:none;text-decoration:none;padding:calc(.667em + 2px) calc(1.333em + 2px);font-size:1.125em}.wp-block-file__button{background:#32373c;color:#fff;text-decoration:none}
+</style>
+<link rel='stylesheet' id='wpcom-text-widget-styles-css' href='https://clecpc.org/wp-content/mu-plugins/wpcomsh/vendor/automattic/text-media-widget-styles/css/widget-text.css?ver=20170607' type='text/css' media='all' />
+<style id='global-styles-inline-css' type='text/css'>
+body{--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray: #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink: #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange: #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan: #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue: #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple: #9b51e0;--wp--preset--color--purple: #980560;--wp--preset--color--blue: #20c9f3;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan: linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange: linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red: linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray: linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum: linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple: linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux: linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean: linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%);--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium: 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large: 42px;--wp--preset--font-family--albert-sans: 'Albert Sans', sans-serif;--wp--preset--font-family--alegreya: Alegreya, serif;--wp--preset--font-family--arvo: Arvo, serif;--wp--preset--font-family--bodoni-moda: 'Bodoni Moda', serif;--wp--preset--font-family--cabin: Cabin, sans-serif;--wp--preset--font-family--chivo: Chivo, sans-serif;--wp--preset--font-family--commissioner: Commissioner, sans-serif;--wp--preset--font-family--cormorant: Cormorant, serif;--wp--preset--font-family--courier-prime: 'Courier Prime', monospace;--wp--preset--font-family--crimson-pro: 'Crimson Pro', serif;--wp--preset--font-family--dm-mono: 'DM Mono', monospace;--wp--preset--font-family--dm-sans: 'DM Sans', sans-serif;--wp--preset--font-family--domine: Domine, serif;--wp--preset--font-family--eb-garamond: 'EB Garamond', serif;--wp--preset--font-family--epilogue: Epilogue, sans-serif;--wp--preset--font-family--figtree: Figtree, sans-serif;--wp--preset--font-family--fira-sans: 'Fira Sans', sans-serif;--wp--preset--font-family--fraunces: Fraunces, serif;--wp--preset--font-family--ibm-plex-mono: 'IBM Plex Mono', monospace;--wp--preset--font-family--ibm-plex-sans: 'IBM Plex Sans', sans-serif;--wp--preset--font-family--inter: Inter, sans-serif;--wp--preset--font-family--josefin-sans: 'Josefin Sans', sans-serif;--wp--preset--font-family--jost: Jost, sans-serif;--wp--preset--font-family--libre-baskerville: 'Libre Baskerville', serif;--wp--preset--font-family--libre-franklin: 'Libre Franklin', sans-serif;--wp--preset--font-family--literata: Literata, serif;--wp--preset--font-family--lora: Lora, serif;--wp--preset--font-family--merriweather: Merriweather, serif;--wp--preset--font-family--montserrat: Montserrat, sans-serif;--wp--preset--font-family--newsreader: Newsreader, serif;--wp--preset--font-family--nunito: Nunito, sans-serif;--wp--preset--font-family--open-sans: 'Open Sans', sans-serif;--wp--preset--font-family--overpass: Overpass, sans-serif;--wp--preset--font-family--petrona: Petrona, serif;--wp--preset--font-family--piazzolla: Piazzolla, serif;--wp--preset--font-family--playfair-display: 'Playfair Display', serif;--wp--preset--font-family--plus-jakarta-sans: 'Plus Jakarta Sans', sans-serif;--wp--preset--font-family--poppins: Poppins, sans-serif;--wp--preset--font-family--raleway: Raleway, sans-serif;--wp--preset--font-family--roboto: Roboto, sans-serif;--wp--preset--font-family--roboto-slab: 'Roboto Slab', serif;--wp--preset--font-family--rubik: Rubik, sans-serif;--wp--preset--font-family--sora: Sora, sans-serif;--wp--preset--font-family--source-sans-3: 'Source Sans 3', sans-serif;--wp--preset--font-family--source-serif-4: 'Source Serif 4', serif;--wp--preset--font-family--space-mono: 'Space Mono', monospace;--wp--preset--font-family--texturina: Texturina, serif;--wp--preset--font-family--work-sans: 'Work Sans', sans-serif;--wp--preset--spacing--20: 0.44rem;--wp--preset--spacing--30: 0.67rem;--wp--preset--spacing--40: 1rem;--wp--preset--spacing--50: 1.5rem;--wp--preset--spacing--60: 2.25rem;--wp--preset--spacing--70: 3.38rem;--wp--preset--spacing--80: 5.06rem;--wp--preset--shadow--natural: 6px 6px 9px rgba(0, 0, 0, 0.2);--wp--preset--shadow--deep: 12px 12px 50px rgba(0, 0, 0, 0.4);--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0, 0.2);--wp--preset--shadow--outlined: 6px 6px 0px -3px rgba(255, 255, 255, 1), 6px 6px rgba(0, 0, 0, 1);--wp--preset--shadow--crisp: 6px 6px 0px rgba(0, 0, 0, 1);}:where(.is-layout-flex){gap: 0.5em;}:where(.is-layout-grid){gap: 0.5em;}body .is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}body .is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}body .is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}body .is-layout-constrained > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}body .is-layout-constrained > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}body .is-layout-constrained > .aligncenter{margin-left: auto !important;margin-right: auto !important;}body .is-layout-constrained > :where(:not(.alignleft):not(.alignright):not(.alignfull)){max-width: var(--wp--style--global--content-size);margin-left: auto !important;margin-right: auto !important;}body .is-layout-constrained > .alignwide{max-width: var(--wp--style--global--wide-size);}body .is-layout-flex{display: flex;}body .is-layout-flex{flex-wrap: wrap;align-items: center;}body .is-layout-flex > *{margin: 0;}body .is-layout-grid{display: grid;}body .is-layout-grid > *{margin: 0;}:where(.wp-block-columns.is-layout-flex){gap: 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}:where(.wp-block-post-template.is-layout-flex){gap: 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}.has-black-color{color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color: var(--wp--preset--color--white) !important;}.has-pale-pink-color{color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color: var(--wp--preset--color--vivid-purple) !important;}.has-black-background-color{background-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color: var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color: var(--wp--preset--color--vivid-purple) !important;}.has-black-border-color{border-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color: var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color: var(--wp--preset--color--vivid-purple) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background: var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background: var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange) !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background: var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background: var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background: var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background: var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background: var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background: var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background: var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background: var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size: var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size: var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size: var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size: var(--wp--preset--font-size--x-large) !important;}.has-albert-sans-font-family{font-family: var(--wp--preset--font-family--albert-sans) !important;}.has-alegreya-font-family{font-family: var(--wp--preset--font-family--alegreya) !important;}.has-arvo-font-family{font-family: var(--wp--preset--font-family--arvo) !important;}.has-bodoni-moda-font-family{font-family: var(--wp--preset--font-family--bodoni-moda) !important;}.has-cabin-font-family{font-family: var(--wp--preset--font-family--cabin) !important;}.has-chivo-font-family{font-family: var(--wp--preset--font-family--chivo) !important;}.has-commissioner-font-family{font-family: var(--wp--preset--font-family--commissioner) !important;}.has-cormorant-font-family{font-family: var(--wp--preset--font-family--cormorant) !important;}.has-courier-prime-font-family{font-family: var(--wp--preset--font-family--courier-prime) !important;}.has-crimson-pro-font-family{font-family: var(--wp--preset--font-family--crimson-pro) !important;}.has-dm-mono-font-family{font-family: var(--wp--preset--font-family--dm-mono) !important;}.has-dm-sans-font-family{font-family: var(--wp--preset--font-family--dm-sans) !important;}.has-domine-font-family{font-family: var(--wp--preset--font-family--domine) !important;}.has-eb-garamond-font-family{font-family: var(--wp--preset--font-family--eb-garamond) !important;}.has-epilogue-font-family{font-family: var(--wp--preset--font-family--epilogue) !important;}.has-figtree-font-family{font-family: var(--wp--preset--font-family--figtree) !important;}.has-fira-sans-font-family{font-family: var(--wp--preset--font-family--fira-sans) !important;}.has-fraunces-font-family{font-family: var(--wp--preset--font-family--fraunces) !important;}.has-ibm-plex-mono-font-family{font-family: var(--wp--preset--font-family--ibm-plex-mono) !important;}.has-ibm-plex-sans-font-family{font-family: var(--wp--preset--font-family--ibm-plex-sans) !important;}.has-inter-font-family{font-family: var(--wp--preset--font-family--inter) !important;}.has-josefin-sans-font-family{font-family: var(--wp--preset--font-family--josefin-sans) !important;}.has-jost-font-family{font-family: var(--wp--preset--font-family--jost) !important;}.has-libre-baskerville-font-family{font-family: var(--wp--preset--font-family--libre-baskerville) !important;}.has-libre-franklin-font-family{font-family: var(--wp--preset--font-family--libre-franklin) !important;}.has-literata-font-family{font-family: var(--wp--preset--font-family--literata) !important;}.has-lora-font-family{font-family: var(--wp--preset--font-family--lora) !important;}.has-merriweather-font-family{font-family: var(--wp--preset--font-family--merriweather) !important;}.has-montserrat-font-family{font-family: var(--wp--preset--font-family--montserrat) !important;}.has-newsreader-font-family{font-family: var(--wp--preset--font-family--newsreader) !important;}.has-nunito-font-family{font-family: var(--wp--preset--font-family--nunito) !important;}.has-open-sans-font-family{font-family: var(--wp--preset--font-family--open-sans) !important;}.has-overpass-font-family{font-family: var(--wp--preset--font-family--overpass) !important;}.has-petrona-font-family{font-family: var(--wp--preset--font-family--petrona) !important;}.has-piazzolla-font-family{font-family: var(--wp--preset--font-family--piazzolla) !important;}.has-playfair-display-font-family{font-family: var(--wp--preset--font-family--playfair-display) !important;}.has-plus-jakarta-sans-font-family{font-family: var(--wp--preset--font-family--plus-jakarta-sans) !important;}.has-poppins-font-family{font-family: var(--wp--preset--font-family--poppins) !important;}.has-raleway-font-family{font-family: var(--wp--preset--font-family--raleway) !important;}.has-roboto-font-family{font-family: var(--wp--preset--font-family--roboto) !important;}.has-roboto-slab-font-family{font-family: var(--wp--preset--font-family--roboto-slab) !important;}.has-rubik-font-family{font-family: var(--wp--preset--font-family--rubik) !important;}.has-sora-font-family{font-family: var(--wp--preset--font-family--sora) !important;}.has-source-sans-3-font-family{font-family: var(--wp--preset--font-family--source-sans-3) !important;}.has-source-serif-4-font-family{font-family: var(--wp--preset--font-family--source-serif-4) !important;}.has-space-mono-font-family{font-family: var(--wp--preset--font-family--space-mono) !important;}.has-texturina-font-family{font-family: var(--wp--preset--font-family--texturina) !important;}.has-work-sans-font-family{font-family: var(--wp--preset--font-family--work-sans) !important;}
+:where(.wp-block-columns.is-layout-flex){gap: 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}
+.wp-block-pullquote{font-size: 1.5em;line-height: 1.6;}
+.wp-block-navigation a:where(:not(.wp-element-button)){color: inherit;}
+:where(.wp-block-post-template.is-layout-flex){gap: 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}
+</style>
+<link rel='stylesheet' id='simple-banner-style-css' href='https://clecpc.org/wp-content/plugins/simple-banner/simple-banner.css?ver=2.17.0' type='text/css' media='all' />
+<link rel='stylesheet' id='dashicons-css' href='https://c0.wp.com/c/6.4.2/wp-includes/css/dashicons.min.css' type='text/css' media='all' />
+<link rel='stylesheet' id='wp-components-css' href='https://clecpc.org/wp-content/plugins/gutenberg/build/components/style.css?ver=17.5.2' type='text/css' media='all' />
+<link rel='stylesheet' id='godaddy-styles-css' href='https://clecpc.org/wp-content/plugins/coblocks/includes/Dependencies/GoDaddy/Styles/build/latest.css?ver=2.0.2' type='text/css' media='all' />
+<link rel='stylesheet' id='megamenu-css' href='https://clecpc.org/wp-content/uploads/maxmegamenu/style.css?ver=5fec45' type='text/css' media='all' />
+<link rel='stylesheet' id='pena-fonts-css' href='https://fonts-api.wp.com/css?family=Merriweather%3A400%2C300%2C300italic%2C400italic%2C700%2C700italic%2C900%2C900italic%7CMontserrat%3A400%2C700&#038;subset=latin%2Clatin-ext' type='text/css' media='all' />
+<link rel='stylesheet' id='pena-style-css' href='https://clecpc.org/wp-content/themes/pena/style.css?ver=6.4.2' type='text/css' media='all' />
+<link rel='stylesheet' id='genericons-css' href='https://clecpc.org/wp-content/plugins/jetpack/_inc/genericons/genericons/genericons.css?ver=3.1' type='text/css' media='all' />
+<link rel='stylesheet' id='tablepress-default-css' href='https://clecpc.org/wp-content/plugins/tablepress/css/build/default.css?ver=2.2.4' type='text/css' media='all' />
+<link rel='stylesheet' id='simcal-qtip-css' href='https://clecpc.org/wp-content/plugins/google-calendar-events/assets/generated/vendor/jquery.qtip.min.css?ver=3.3.0' type='text/css' media='all' />
+<link rel='stylesheet' id='simcal-default-calendar-grid-css' href='https://clecpc.org/wp-content/plugins/google-calendar-events/assets/generated/default-calendar-grid.min.css?ver=3.3.0' type='text/css' media='all' />
+<link rel='stylesheet' id='simcal-default-calendar-list-css' href='https://clecpc.org/wp-content/plugins/google-calendar-events/assets/generated/default-calendar-list.min.css?ver=3.3.0' type='text/css' media='all' />
+<link rel='stylesheet' id='elementor-icons-css' href='https://clecpc.org/wp-content/plugins/elementor/assets/lib/eicons/css/elementor-icons.min.css?ver=5.27.0' type='text/css' media='all' />
+<link rel='stylesheet' id='elementor-frontend-css' href='https://clecpc.org/wp-content/plugins/elementor/assets/css/frontend.min.css?ver=3.19.0' type='text/css' media='all' />
+<link rel='stylesheet' id='swiper-css' href='https://clecpc.org/wp-content/plugins/elementor/assets/lib/swiper/css/swiper.min.css?ver=5.3.6' type='text/css' media='all' />
+<link rel='stylesheet' id='elementor-post-1894-css' href='https://clecpc.org/wp-content/uploads/elementor/css/post-1894.css?ver=1706540261' type='text/css' media='all' />
+<link rel='stylesheet' id='elementor-global-css' href='https://clecpc.org/wp-content/uploads/elementor/css/global.css?ver=1706540262' type='text/css' media='all' />
+<link rel='stylesheet' id='elementor-post-84-css' href='https://clecpc.org/wp-content/uploads/elementor/css/post-84.css?ver=1706545488' type='text/css' media='all' />
+<link rel='stylesheet' id='fluentform-elementor-widget-css' href='https://clecpc.org/wp-content/plugins/fluentform/assets/css/fluent-forms-elementor-widget.css?ver=5.1.9' type='text/css' media='all' />
+<link rel='stylesheet' id='ics-calendar-css' href='https://clecpc.org/wp-content/plugins/ics-calendar/assets/style.min.css?ver=10.14.1' type='text/css' media='all' />
+<link rel='stylesheet' id='eael-general-css' href='https://clecpc.org/wp-content/plugins/essential-addons-for-elementor-lite/assets/front-end/css/view/general.min.css?ver=5.9.7' type='text/css' media='all' />
+<style id='jetpack-global-styles-frontend-style-inline-css' type='text/css'>
+:root { --font-headings: unset; --font-base: unset; --font-headings-default: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif; --font-base-default: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;}
+</style>
+<link rel='stylesheet' id='google-fonts-1-css' href='https://fonts-api.wp.com/css?family=Roboto%3A100%2C100italic%2C200%2C200italic%2C300%2C300italic%2C400%2C400italic%2C500%2C500italic%2C600%2C600italic%2C700%2C700italic%2C800%2C800italic%2C900%2C900italic%7CRoboto+Slab%3A100%2C100italic%2C200%2C200italic%2C300%2C300italic%2C400%2C400italic%2C500%2C500italic%2C600%2C600italic%2C700%2C700italic%2C800%2C800italic%2C900%2C900italic&#038;display=auto&#038;ver=6.4.2' type='text/css' media='all' />
+<link rel='stylesheet' id='jetpack_css-css' href='https://clecpc.org/wp-content/plugins/jetpack/css/jetpack.css?ver=13.1-a.7' type='text/css' media='all' />
+<link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin><script type="text/javascript" src="https://c0.wp.com/c/6.4.2/wp-includes/js/jquery/jquery.min.js" id="jquery-core-js"></script>
+<script type="text/javascript" src="https://c0.wp.com/c/6.4.2/wp-includes/js/jquery/jquery-migrate.min.js" id="jquery-migrate-js"></script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/js/mec-general-calendar.js?ver=6.5.6" id="mec-general-calendar-script-js"></script>
+<script type="text/javascript" id="mec-frontend-script-js-extra">
+/* <![CDATA[ */
+var mecdata = {"day":"day","days":"days","hour":"hour","hours":"hours","minute":"minute","minutes":"minutes","second":"second","seconds":"seconds","elementor_edit_mode":"no","recapcha_key":"","ajax_url":"https:\/\/clecpc.org\/wp-admin\/admin-ajax.php","fes_nonce":"521bf637ff","current_year":"2024","current_month":"01","datepicker_format":"yy-mm-dd"};
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/js/frontend.js?ver=6.5.6" id="mec-frontend-script-js"></script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/js/events.js?ver=6.5.6" id="mec-events-script-js"></script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/google-analytics-for-wordpress/assets/js/frontend-gtag.min.js?ver=8.23.1" id="monsterinsights-frontend-script-js"></script>
+<script data-cfasync="false" data-wpfc-render="false" type="text/javascript" id='monsterinsights-frontend-script-js-extra'>/* <![CDATA[ */
+var monsterinsights_frontend = {"js_events_tracking":"true","download_extensions":"doc,pdf,ppt,zip,xls,docx,pptx,xlsx","inbound_paths":"[{\"path\":\"\\\/go\\\/\",\"label\":\"affiliate\"},{\"path\":\"\\\/recommend\\\/\",\"label\":\"affiliate\"}]","home_url":"https:\/\/clecpc.org","hash_tracking":"false","v4_id":"G-ZXWB1C1R71"};/* ]]> */
+</script>
+<script type="text/javascript" id="simple-banner-script-js-before">
+/* <![CDATA[ */
+const simpleBannerScriptParams = {"version":"2.17.0","hide_simple_banner":"yes","simple_banner_prepend_element":false,"simple_banner_position":"","header_margin":"","header_padding":"","simple_banner_z_index":"","simple_banner_text":"Public Feedback Needed by 9\/8\/23:<br><a href=\"https:\/\/bit.ly\/CPCPlan2023\">Send us your comments about the CPC's Work Plan<\/a>","pro_version_enabled":"","disabled_on_current_page":false,"debug_mode":"","id":84,"disabled_pages_array":[],"is_current_page_a_post":false,"disabled_on_posts":"","simple_banner_disabled_page_paths":false,"simple_banner_font_size":"14","simple_banner_color":"#fdec35","simple_banner_text_color":"#2e2e2e","simple_banner_link_color":"#3756d2","simple_banner_close_color":"","simple_banner_custom_css":"","simple_banner_scrolling_custom_css":"","simple_banner_text_custom_css":"","simple_banner_button_css":"","site_custom_css":"","keep_site_custom_css":"","site_custom_js":"","keep_site_custom_js":"","wp_body_open_enabled":"","wp_body_open":true,"close_button_enabled":"","close_button_expiration":"11","close_button_cookie_set":false,"current_date":{"date":"2024-01-29 23:45:01.818736","timezone_type":3,"timezone":"UTC"},"start_date":{"date":"2024-01-29 23:45:01.818744","timezone_type":3,"timezone":"UTC"},"end_date":{"date":"2024-01-29 23:45:01.818749","timezone_type":3,"timezone":"UTC"},"simple_banner_start_after_date":"","simple_banner_remove_after_date":"","simple_banner_insert_inside_element":""}
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/simple-banner/simple-banner.js?ver=2.17.0" id="simple-banner-script-js"></script>
+<link rel="https://api.w.org/" href="https://clecpc.org/wp-json/" /><link rel="alternate" type="application/json" href="https://clecpc.org/wp-json/wp/v2/pages/84" /><link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://clecpc.org/xmlrpc.php?rsd" />
+
+<link rel='shortlink' href='https://wp.me/PbpSKv-1m' />
+<link rel="alternate" type="application/json+oembed" href="https://clecpc.org/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fclecpc.org%2Fget-involved%2Fcalendar%2F" />
+<link rel="alternate" type="text/xml+oembed" href="https://clecpc.org/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fclecpc.org%2Fget-involved%2Fcalendar%2F&#038;format=xml" />
+<style type="text/css">.simple-banner{display:none;}</style><style type="text/css">.simple-banner .simple-banner-text{font-size:14;}</style><style type="text/css">.simple-banner{background:#fdec35;}</style><style type="text/css">.simple-banner .simple-banner-text{color:#2e2e2e;}</style><style type="text/css">.simple-banner .simple-banner-text a{color:#3756d2;}</style><style type="text/css">.simple-banner{z-index: 99999;}</style><style id="simple-banner-site-custom-css-dummy" type="text/css"></style><script id="simple-banner-site-custom-js-dummy" type="text/javascript"></script>	<style>img#wpstats{display:none}</style>
+		<meta name="generator" content="Elementor 3.19.0; features: e_optimized_assets_loading, additional_custom_breakpoints, block_editor_assets_optimize, e_image_loading_optimization; settings: css_print_method-external, google_font-enabled, font_display-auto">
+	<style type="text/css">
+			.site-title,
+		.site-description {
+			position: absolute;
+			clip: rect(1px, 1px, 1px, 1px);
+		}
+		</style>
+	<!-- There is no amphtml version available for this URL. --><script>( HTMLScriptElement.supports && HTMLScriptElement.supports("importmap") ) || document.write( '<script src="https://clecpc.org/wp-content/plugins/gutenberg/build/modules/importmap-polyfill.min.js"></scr' + 'ipt>' );</script><link rel="icon" href="https://i0.wp.com/clecpc.org/wp-content/uploads/2019/11/CPC-Bug3-Website.png?fit=32%2C32&#038;ssl=1" sizes="32x32" />
+<link rel="icon" href="https://i0.wp.com/clecpc.org/wp-content/uploads/2019/11/CPC-Bug3-Website.png?fit=192%2C192&#038;ssl=1" sizes="192x192" />
+<link rel="apple-touch-icon" href="https://i0.wp.com/clecpc.org/wp-content/uploads/2019/11/CPC-Bug3-Website.png?fit=180%2C180&#038;ssl=1" />
+<meta name="msapplication-TileImage" content="https://i0.wp.com/clecpc.org/wp-content/uploads/2019/11/CPC-Bug3-Website.png?fit=270%2C270&#038;ssl=1" />
+<link rel="stylesheet" type="text/css" id="wp-custom-css" href="https://clecpc.org/?custom-css=fe099d12e0" /><!-- Your Google Analytics Plugin is missing the tracking ID -->
+<style type="text/css">.mec-wrap, .mec-wrap div:not([class^="elementor-"]), .lity-container, .mec-wrap h1, .mec-wrap h2, .mec-wrap h3, .mec-wrap h4, .mec-wrap h5, .mec-wrap h6, .entry-content .mec-wrap h1, .entry-content .mec-wrap h2, .entry-content .mec-wrap h3, .entry-content .mec-wrap h4, .entry-content .mec-wrap h5, .entry-content .mec-wrap h6, .mec-wrap .mec-totalcal-box input[type="submit"], .mec-wrap .mec-totalcal-box .mec-totalcal-view span, .mec-agenda-event-title a, .lity-content .mec-events-meta-group-booking select, .lity-content .mec-book-ticket-variation h5, .lity-content .mec-events-meta-group-booking input[type="number"], .lity-content .mec-events-meta-group-booking input[type="text"], .lity-content .mec-events-meta-group-booking input[type="email"],.mec-organizer-item a, .mec-single-event .mec-events-meta-group-booking ul.mec-book-tickets-container li.mec-book-ticket-container label { font-family: "Montserrat", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;}.mec-event-content p, .mec-search-bar-result .mec-event-detail{ font-family: Roboto, sans-serif;} .mec-wrap .mec-totalcal-box input, .mec-wrap .mec-totalcal-box select, .mec-checkboxes-search .mec-searchbar-category-wrap, .mec-wrap .mec-totalcal-box .mec-totalcal-view span { font-family: "Roboto", Helvetica, Arial, sans-serif; }.mec-event-grid-modern .event-grid-modern-head .mec-event-day, .mec-event-list-minimal .mec-time-details, .mec-event-list-minimal .mec-event-detail, .mec-event-list-modern .mec-event-detail, .mec-event-grid-minimal .mec-time-details, .mec-event-grid-minimal .mec-event-detail, .mec-event-grid-simple .mec-event-detail, .mec-event-cover-modern .mec-event-place, .mec-event-cover-clean .mec-event-place, .mec-calendar .mec-event-article .mec-localtime-details div, .mec-calendar .mec-event-article .mec-event-detail, .mec-calendar.mec-calendar-daily .mec-calendar-d-top h2, .mec-calendar.mec-calendar-daily .mec-calendar-d-top h3, .mec-toggle-item-col .mec-event-day, .mec-weather-summary-temp { font-family: "Roboto", sans-serif; } .mec-fes-form, .mec-fes-list, .mec-fes-form input, .mec-event-date .mec-tooltip .box, .mec-event-status .mec-tooltip .box, .ui-datepicker.ui-widget, .mec-fes-form button[type="submit"].mec-fes-sub-button, .mec-wrap .mec-timeline-events-container p, .mec-wrap .mec-timeline-events-container h4, .mec-wrap .mec-timeline-events-container div, .mec-wrap .mec-timeline-events-container a, .mec-wrap .mec-timeline-events-container span { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif !important; }</style><style type="text/css">/** Mega Menu CSS: fs **/</style>
+<style id="wpforms-css-vars-root">
+				:root {
+					--wpforms-field-border-radius: 3px;
+--wpforms-field-background-color: #ffffff;
+--wpforms-field-border-color: rgba( 0, 0, 0, 0.25 );
+--wpforms-field-text-color: rgba( 0, 0, 0, 0.7 );
+--wpforms-label-color: rgba( 0, 0, 0, 0.85 );
+--wpforms-label-sublabel-color: rgba( 0, 0, 0, 0.55 );
+--wpforms-label-error-color: #d63637;
+--wpforms-button-border-radius: 3px;
+--wpforms-button-background-color: #066aab;
+--wpforms-button-text-color: #ffffff;
+--wpforms-field-size-input-height: 43px;
+--wpforms-field-size-input-spacing: 15px;
+--wpforms-field-size-font-size: 16px;
+--wpforms-field-size-line-height: 19px;
+--wpforms-field-size-padding-h: 14px;
+--wpforms-field-size-checkbox-size: 16px;
+--wpforms-field-size-sublabel-spacing: 5px;
+--wpforms-field-size-icon-size: 1;
+--wpforms-label-size-font-size: 16px;
+--wpforms-label-size-line-height: 19px;
+--wpforms-label-size-sublabel-font-size: 14px;
+--wpforms-label-size-sublabel-line-height: 17px;
+--wpforms-button-size-font-size: 17px;
+--wpforms-button-size-height: 41px;
+--wpforms-button-size-padding-h: 15px;
+--wpforms-button-size-margin-top: 10px;
+
+				}
+			</style></head>
+
+<body class="page-template page-template-templates page-template-full-width-page page-template-templatesfull-width-page-php page page-id-84 page-child parent-pageid-80 wp-custom-logo mega-menu-menu-1 group-blog singular no-sidebar standard-menu sidebar-right elementor-default elementor-kit-1894 elementor-page elementor-page-84">
+	<a class="skip-link screen-reader-text" href="#content">Skip to content</a>
+
+	<header id="masthead" class="site-header" role="banner">
+		<div class="site-branding">
+				<a href="https://clecpc.org/" class="custom-logo-link" rel="home"><img width="105" height="71" src="https://i0.wp.com/clecpc.org/wp-content/uploads/CPCLogo-Nav5.png?fit=105%2C71&amp;ssl=1" class="custom-logo" alt="Cleveland Community Police Commission" decoding="async" data-attachment-id="1717" data-permalink="https://clecpc.org/cpclogo-nav5/" data-orig-file="https://i0.wp.com/clecpc.org/wp-content/uploads/CPCLogo-Nav5.png?fit=105%2C71&amp;ssl=1" data-orig-size="105,71" data-comments-opened="1" data-image-meta="{&quot;aperture&quot;:&quot;0&quot;,&quot;credit&quot;:&quot;&quot;,&quot;camera&quot;:&quot;&quot;,&quot;caption&quot;:&quot;&quot;,&quot;created_timestamp&quot;:&quot;0&quot;,&quot;copyright&quot;:&quot;&quot;,&quot;focal_length&quot;:&quot;0&quot;,&quot;iso&quot;:&quot;0&quot;,&quot;shutter_speed&quot;:&quot;0&quot;,&quot;title&quot;:&quot;&quot;,&quot;orientation&quot;:&quot;0&quot;}" data-image-title="CPCLogo-Nav5" data-image-description="" data-image-caption="" data-medium-file="https://i0.wp.com/clecpc.org/wp-content/uploads/CPCLogo-Nav5.png?fit=105%2C71&amp;ssl=1" data-large-file="https://i0.wp.com/clecpc.org/wp-content/uploads/CPCLogo-Nav5.png?fit=105%2C71&amp;ssl=1" /></a>									<p class="site-title"><a href="https://clecpc.org/" rel="home">Cleveland Community Police Commission</a></p>
+						</div><!-- .site-branding -->
+			<nav id="site-navigation" class="main-navigation" role="navigation">
+				<button class="menu-toggle" aria-controls="primary-menu" aria-expanded="false">Menu</button>
+				<div id="mega-menu-wrap-menu-1" class="mega-menu-wrap"><div class="mega-menu-toggle"><div class="mega-toggle-blocks-left"></div><div class="mega-toggle-blocks-center"></div><div class="mega-toggle-blocks-right"><div class='mega-toggle-block mega-menu-toggle-block mega-toggle-block-1' id='mega-toggle-block-1' tabindex='0'><span class='mega-toggle-label' role='button' aria-expanded='false'><span class='mega-toggle-label-closed'></span><span class='mega-toggle-label-open'></span></span></div></div></div><ul id="mega-menu-menu-1" class="mega-menu max-mega-menu mega-menu-horizontal mega-no-js" data-event="hover_intent" data-effect="fade_up" data-effect-speed="200" data-effect-mobile="disabled" data-effect-speed-mobile="0" data-mobile-force-width="body" data-second-click="go" data-document-click="collapse" data-vertical-behaviour="standard" data-breakpoint="900" data-unbind="true" data-mobile-state="collapse_all" data-hover-intent-timeout="300" data-hover-intent-interval="100"><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-has-children mega-align-bottom-left mega-menu-flyout mega-menu-item-1532' id='mega-menu-item-1532'><a class="mega-menu-link" href="https://clecpc.org/about-us/" aria-haspopup="true" aria-expanded="false" tabindex="0">About Us<span class="mega-indicator"></span></a>
+<ul class="mega-sub-menu">
+<li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-5420' id='mega-menu-item-5420'><a class="mega-menu-link" href="https://clecpc.org/about-us/">About</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-13293' id='mega-menu-item-13293'><a class="mega-menu-link" href="https://clecpc.org/about-us/news/">News</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-4920' id='mega-menu-item-4920'><a class="mega-menu-link" href="https://clecpc.org/about-us/our-partners/">Community Partners</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-12256' id='mega-menu-item-12256'><a class="mega-menu-link" href="https://clecpc.org/about-us/rules-and-procedures/">Rules and Procedures</a></li></ul>
+</li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-has-children mega-align-bottom-left mega-menu-flyout mega-menu-item-145' id='mega-menu-item-145'><a class="mega-menu-link" href="https://clecpc.org/our-work/" aria-haspopup="true" aria-expanded="false" tabindex="0">Our Work<span class="mega-indicator"></span></a>
+<ul class="mega-sub-menu">
+<li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-13692' id='mega-menu-item-13692'><a class="mega-menu-link" href="https://clecpc.org/our-work/committees/">Committees</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-has-children mega-menu-item-5421' id='mega-menu-item-5421'><a class="mega-menu-link" href="https://clecpc.org/our-work/" aria-haspopup="true" aria-expanded="false">Reports & Recommendations<span class="mega-indicator"></span></a>
+	<ul class="mega-sub-menu">
+<li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-147' id='mega-menu-item-147'><a class="mega-menu-link" href="https://clecpc.org/our-work/accountability/">Accountability</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-148' id='mega-menu-item-148'><a class="mega-menu-link" href="https://clecpc.org/our-work/bias-free-policing/">Bias-Free Policing</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-1679' id='mega-menu-item-1679'><a class="mega-menu-link" href="https://clecpc.org/our-work/civilian-oversight/">Civilian Oversight</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-150' id='mega-menu-item-150'><a class="mega-menu-link" href="https://clecpc.org/our-work/cpop/">Community &amp; Problem-Oriented Policing (CPOP)</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-151' id='mega-menu-item-151'><a class="mega-menu-link" href="https://clecpc.org/our-work/search-seizure/">Search &amp; Seizure</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-149' id='mega-menu-item-149'><a class="mega-menu-link" href="https://clecpc.org/our-work/use-of-force/">Use of Force</a></li>	</ul>
+</li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-9188' id='mega-menu-item-9188'><a class="mega-menu-link" href="https://clecpc.org/100-years-project/">100 Years Project</a></li></ul>
+</li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-current-page-ancestor mega-current-menu-ancestor mega-current-menu-parent mega-current-page-parent mega-current_page_parent mega-current_page_ancestor mega-menu-item-has-children mega-align-bottom-left mega-menu-flyout mega-menu-item-153' id='mega-menu-item-153'><a class="mega-menu-link" href="https://clecpc.org/get-involved/" aria-haspopup="true" aria-expanded="false" tabindex="0">Get Involved<span class="mega-indicator"></span></a>
+<ul class="mega-sub-menu">
+<li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-current-page-ancestor mega-current-page-parent mega-menu-item-5422' id='mega-menu-item-5422'><a class="mega-menu-link" href="https://clecpc.org/get-involved/">Ways to Get Involved</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-current-menu-item mega-page_item mega-page-item-84 mega-current_page_item mega-menu-item-154' id='mega-menu-item-154'><a class="mega-menu-link" href="https://clecpc.org/get-involved/calendar/" aria-current="page">Event Calendar</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-690' id='mega-menu-item-690'><a class="mega-menu-link" href="https://clecpc.org/get-involved/work-groups/">CPC Work Groups</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-5009' id='mega-menu-item-5009'><a class="mega-menu-link" href="https://clecpc.org/get-involved/dpc-meetings/">District Policing Committee Meetings</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-2250' id='mega-menu-item-2250'><a class="mega-menu-link" href="https://clecpc.org/get-involved/feedback/">Community Feedback</a></li></ul>
+</li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-has-children mega-align-bottom-left mega-menu-flyout mega-menu-item-155' id='mega-menu-item-155'><a class="mega-menu-link" href="https://clecpc.org/resources/" aria-haspopup="true" aria-expanded="false" tabindex="0">Resources<span class="mega-indicator"></span></a>
+<ul class="mega-sub-menu">
+<li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-6202' id='mega-menu-item-6202'><a class="mega-menu-link" href="https://clecpc.org/resources/">Resources</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-156' id='mega-menu-item-156'><a class="mega-menu-link" href="https://clecpc.org/resources/consent-decree/">The Consent Decree</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-1449' id='mega-menu-item-1449'><a class="mega-menu-link" href="https://clecpc.org/resources/general-police-orders/">General Police Orders</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-157' id='mega-menu-item-157'><a class="mega-menu-link" href="https://clecpc.org/resources/meeting-agendas-minutes/">Agendas & Minutes</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-158' id='mega-menu-item-158'><a class="mega-menu-link" href="https://clecpc.org/resources/case-updates-filings/">Case Updates &amp; Filings</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-12695' id='mega-menu-item-12695'><a class="mega-menu-link" href="https://clecpc.org/resources/community-grants/">Community Grants</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-14381' id='mega-menu-item-14381'><a class="mega-menu-link" href="https://clecpc.org/resources/brady-giglio/">Brady-Giglio</a></li></ul>
+</li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-align-bottom-left mega-menu-flyout mega-menu-item-159' id='mega-menu-item-159'><a class="mega-menu-link" href="https://clecpc.org/contact/" tabindex="0">Contact Us</a></li></ul></div>			</nav><!-- #site-navigation -->
+	</header>
+		<div class="featured-image">
+									<div class="header section pages" style="background-image:url(https://i0.wp.com/clecpc.org/wp-content/uploads/Header-Image-Calendar.jpg?fit=2500%2C849&#038;ssl=1);">
+		<div class="entry-content">
+			<h1>Calendar</h1>
+		</div>
+		<span class="overlay"></span>
+		</div>
+		</div>
+
+	<div class="hfeed site page-content">
+		<div class="content site-content">
+			<div id="primary" class="content-area gridpage">
+				<main id="main" class="site-main" role="main">
+					<div class="main-content">
+						
+<article id="post-84" class="post-84 page type-page status-publish has-post-thumbnail hentry">
+
+	<div class="entry-content">
+				<div data-elementor-type="wp-page" data-elementor-id="84" class="elementor elementor-84">
+						<section data-particle_enable="false" data-particle-mobile-disabled="false" class="elementor-section elementor-top-section elementor-element elementor-element-5e74edf7 elementor-section-boxed elementor-section-height-default elementor-section-height-default" data-id="5e74edf7" data-element_type="section">
+						<div class="elementor-container elementor-column-gap-default">
+					<div class="elementor-column elementor-col-100 elementor-top-column elementor-element elementor-element-5914e3b2" data-id="5914e3b2" data-element_type="column">
+			<div class="elementor-widget-wrap elementor-element-populated">
+						<div class="elementor-element elementor-element-20068f46 elementor-widget elementor-widget-text-editor" data-id="20068f46" data-element_type="widget" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+							<p><strong>CPC &amp; Community Events Calendar</strong></p>						</div>
+				</div>
+				<div class="elementor-element elementor-element-ba19fb4 elementor-widget elementor-widget-text-editor" data-id="ba19fb4" data-element_type="widget" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+							<p><strong>Your involvement is needed to shape how policing looks in Cleveland.</strong> Participate in CPC meetings, join a CPC work group, take part in events hosted by local community organizations and attend police district meetings to share your thoughts about policing and related issues in your community.</p>						</div>
+				</div>
+				<div class="elementor-element elementor-element-19e3df5 elementor-widget elementor-widget-spacer" data-id="19e3df5" data-element_type="widget" data-widget_type="spacer.default">
+				<div class="elementor-widget-container">
+					<div class="elementor-spacer">
+			<div class="elementor-spacer-inner"></div>
+		</div>
+				</div>
+				</div>
+				<div class="elementor-element elementor-element-60c90b1 elementor-widget elementor-widget-text-editor" data-id="60c90b1" data-element_type="widget" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+							<p>CPC Meetings and Events</p>						</div>
+				</div>
+				<div class="elementor-element elementor-element-8b72a1d elementor-widget elementor-widget-text-editor" data-id="8b72a1d" data-element_type="widget" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+							<div id="MECCopyCode" class="mec-calendar-metabox mec-shortcode" title="Click to copy shortcode"><div class="mec-wrap mec-skin-grid-container  " id="mec_skin_13107">
+
+    
+            <div class="mec-skin-grid-events-container" id="mec_skin_events_13107">
+        <div class="mec-wrap colorskin-custom">
+    <div class="mec-event-grid-minimal" data-widget-autoplay="1" data-widget-loop="1" data-widget-autoplay-time="3000">
+        <div class="row"><div class="col-md-6 col-sm-6"><article class="mec-past-event mec-event-article mec-clear  " itemscope>                    <div class="mec-event-date mec-bg-color-hover mec-border-color-hover mec-color"><span>01</span>Feb</div>
+            <div class="event-detail-wrap">
+                <h4 class="mec-event-title"><a class="mec-color-hover" data-event-id="15122" href="https://clecpc.org/events/police-discipline-work-group/" target="_self" rel="noopener">Police Discipline Work Group</a><span class="event-color" style="background: #08ad00"></span></h4>
+                                <div class="mec-time-details"><span class="mec-start-time">6:30 pm</span> &#8211; <span class="mec-end-time">8:30 pm</span></div>                <div class="mec-event-detail">
+                    <div class="mec-event-loc-place">CPC Offices</div>
+                                                                            </div>
+            </div>
+        </article></div>                <div class="col-md-6 col-sm-6"><article class="mec-past-event mec-event-article mec-clear  " itemscope>                    <div class="mec-event-date mec-bg-color-hover mec-border-color-hover mec-color"><span>07</span>Feb</div>
+            <div class="event-detail-wrap">
+                <h4 class="mec-event-title"><a class="mec-color-hover" data-event-id="14892" href="https://clecpc.org/events/rules-committee-1st-wednesday/" target="_self" rel="noopener">Cancelled: Rules Committee Meeting January 3rd</a></h4>
+                                <div class="mec-time-details"><span class="mec-start-time">6:00 pm</span> &#8211; <span class="mec-end-time">8:00 pm</span></div>                <div class="mec-event-detail">
+                    <div class="mec-event-loc-place">CPC Office</div>
+                                                                            </div>
+            </div>
+        </article></div></div>                <div class="row"><div class="col-md-6 col-sm-6"><article class="mec-past-event mec-event-article mec-clear  " itemscope>                    <div class="mec-event-date mec-bg-color-hover mec-border-color-hover mec-color"><span>08</span>Feb</div>
+            <div class="event-detail-wrap">
+                <h4 class="mec-event-title"><a class="mec-color-hover" data-event-id="14824" href="https://clecpc.org/events/cpc-behavioral-health-crisis-intervention-work-group/" target="_self" rel="noopener">Behavioral Health &amp; Crisis Intervention Work Group- January 11th Cancelled</a></h4>
+                                                <div class="mec-event-detail">
+                    <div class="mec-event-loc-place">CPC Office</div>
+                                                                            </div>
+            </div>
+        </article></div>        <div class="col-md-6 col-sm-6"><article class="mec-past-event mec-event-article mec-clear  " itemscope>                    <div class="mec-event-date mec-bg-color-hover mec-border-color-hover mec-color"><span>08</span>Feb</div>
+            <div class="event-detail-wrap">
+                <h4 class="mec-event-title"><a class="mec-color-hover" data-event-id="15122" href="https://clecpc.org/events/police-discipline-work-group/" target="_self" rel="noopener">Police Discipline Work Group</a><span class="event-color" style="background: #08ad00"></span></h4>
+                                <div class="mec-time-details"><span class="mec-start-time">6:30 pm</span> &#8211; <span class="mec-end-time">8:30 pm</span></div>                <div class="mec-event-detail">
+                    <div class="mec-event-loc-place">CPC Offices</div>
+                                                                            </div>
+            </div>
+        </article></div></div>                <div class="row"><div class="col-md-6 col-sm-6"><article class="mec-past-event mec-event-article mec-clear  " itemscope>                    <div class="mec-event-date mec-bg-color-hover mec-border-color-hover mec-color"><span>14</span>Feb</div>
+            <div class="event-detail-wrap">
+                <h4 class="mec-event-title"><a class="mec-color-hover" data-event-id="12838" href="https://clecpc.org/events/police-training-committee/" target="_self" rel="noopener">Police Training Committee &#8211;</a></h4>
+                                <div class="mec-time-details"><span class="mec-start-time">6:00 pm</span> &#8211; <span class="mec-end-time">8:00 pm</span></div>                <div class="mec-event-detail">
+                    <div class="mec-event-loc-place">CPC Office</div>
+                                                                            </div>
+            </div>
+        </article></div>                <div class="col-md-6 col-sm-6"><article class="mec-past-event mec-event-article mec-clear  " itemscope>                    <div class="mec-event-date mec-bg-color-hover mec-border-color-hover mec-color"><span>15</span>Feb</div>
+            <div class="event-detail-wrap">
+                <h4 class="mec-event-title"><a class="mec-color-hover" data-event-id="15122" href="https://clecpc.org/events/police-discipline-work-group/" target="_self" rel="noopener">Police Discipline Work Group</a><span class="event-color" style="background: #08ad00"></span></h4>
+                                <div class="mec-time-details"><span class="mec-start-time">6:30 pm</span> &#8211; <span class="mec-end-time">8:30 pm</span></div>                <div class="mec-event-detail">
+                    <div class="mec-event-loc-place">CPC Offices</div>
+                                                                            </div>
+            </div>
+        </article></div></div>                        	</div>
+</div>
+
+    </div>
+    <div class="mec-skin-grid-no-events-container mec-util-hidden" id="mec_skin_no_events_13107">
+        No event found!    </div>
+    
+        <div class="mec-load-more-wrap"><div tabindex="0" class="mec-load-more-button ">Load More</div></div>
+    
+</div></div>						</div>
+				</div>
+				<div class="elementor-element elementor-element-9154760 elementor-widget elementor-widget-spacer" data-id="9154760" data-element_type="widget" data-widget_type="spacer.default">
+				<div class="elementor-widget-container">
+					<div class="elementor-spacer">
+			<div class="elementor-spacer-inner"></div>
+		</div>
+				</div>
+				</div>
+				<div class="elementor-element elementor-element-b26a10b elementor-widget elementor-widget-text-editor" data-id="b26a10b" data-element_type="widget" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+							<p>Community Events</p>						</div>
+				</div>
+				<div class="elementor-element elementor-element-afdc9a6 elementor-widget elementor-widget-text-editor" data-id="afdc9a6" data-element_type="widget" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+							<div class="mec-wrap mec-skin-grid-container  " id="mec_skin_1061">
+
+    
+            <div class="mec-skin-grid-events-container" id="mec_skin_events_1061">
+        <div class="mec-wrap colorskin-custom">
+    <div class="mec-event-grid-minimal" data-widget-autoplay="1" data-widget-loop="1" data-widget-autoplay-time="3000">
+        <div class="row"><div class="col-md-6 col-sm-6"><article class="mec-past-event mec-event-article mec-clear  " itemscope>                    <div class="mec-event-date mec-bg-color-hover mec-border-color-hover mec-color"><span>01</span>Feb</div>
+            <div class="event-detail-wrap">
+                <h4 class="mec-event-title"><a class="mec-color-hover" data-event-id="1096" href="https://clecpc.org/events/first-district-dpc-meeting/" target="_self" rel="noopener">1st District &#8211; District Policing Committee Meeting</a><span class="event-color" style="background: #fdd700"></span></h4>
+                                <div class="mec-time-details"><span class="mec-start-time">6:00 pm</span> &#8211; <span class="mec-end-time">7:00 pm</span></div>                <div class="mec-event-detail">
+                    <div class="mec-event-loc-place">St. Ignatius of Antioch</div>
+                                                                            </div>
+            </div>
+        </article></div>        <div class="col-md-6 col-sm-6"><article class="mec-past-event mec-event-article mec-clear  " itemscope>                    <div class="mec-event-date mec-bg-color-hover mec-border-color-hover mec-color"><span>01</span>Feb</div>
+            <div class="event-detail-wrap">
+                <h4 class="mec-event-title"><a class="mec-color-hover" data-event-id="15122" href="https://clecpc.org/events/police-discipline-work-group/" target="_self" rel="noopener">Police Discipline Work Group</a><span class="event-color" style="background: #08ad00"></span></h4>
+                                <div class="mec-time-details"><span class="mec-start-time">6:30 pm</span> &#8211; <span class="mec-end-time">8:30 pm</span></div>                <div class="mec-event-detail">
+                    <div class="mec-event-loc-place">CPC Offices</div>
+                                                                            </div>
+            </div>
+        </article></div></div>                <div class="row"><div class="col-md-6 col-sm-6"><article class="mec-past-event mec-event-article mec-clear  " itemscope>                    <div class="mec-event-date mec-bg-color-hover mec-border-color-hover mec-color"><span>07</span>Feb</div>
+            <div class="event-detail-wrap">
+                <h4 class="mec-event-title"><a class="mec-color-hover" data-event-id="14892" href="https://clecpc.org/events/rules-committee-1st-wednesday/" target="_self" rel="noopener">Cancelled: Rules Committee Meeting January 3rd</a></h4>
+                                <div class="mec-time-details"><span class="mec-start-time">6:00 pm</span> &#8211; <span class="mec-end-time">8:00 pm</span></div>                <div class="mec-event-detail">
+                    <div class="mec-event-loc-place">CPC Office</div>
+                                                                            </div>
+            </div>
+        </article></div>                <div class="col-md-6 col-sm-6"><article class="mec-past-event mec-event-article mec-clear  " itemscope>                    <div class="mec-event-date mec-bg-color-hover mec-border-color-hover mec-color"><span>08</span>Feb</div>
+            <div class="event-detail-wrap">
+                <h4 class="mec-event-title"><a class="mec-color-hover" data-event-id="14824" href="https://clecpc.org/events/cpc-behavioral-health-crisis-intervention-work-group/" target="_self" rel="noopener">Behavioral Health &amp; Crisis Intervention Work Group- January 11th Cancelled</a></h4>
+                                                <div class="mec-event-detail">
+                    <div class="mec-event-loc-place">CPC Office</div>
+                                                                            </div>
+            </div>
+        </article></div></div>        <div class="row"><div class="col-md-6 col-sm-6"><article class="mec-past-event mec-event-article mec-clear  " itemscope>                    <div class="mec-event-date mec-bg-color-hover mec-border-color-hover mec-color"><span>08</span>Feb</div>
+            <div class="event-detail-wrap">
+                <h4 class="mec-event-title"><a class="mec-color-hover" data-event-id="15122" href="https://clecpc.org/events/police-discipline-work-group/" target="_self" rel="noopener">Police Discipline Work Group</a><span class="event-color" style="background: #08ad00"></span></h4>
+                                <div class="mec-time-details"><span class="mec-start-time">6:30 pm</span> &#8211; <span class="mec-end-time">8:30 pm</span></div>                <div class="mec-event-detail">
+                    <div class="mec-event-loc-place">CPC Offices</div>
+                                                                            </div>
+            </div>
+        </article></div>                <div class="col-md-6 col-sm-6"><article class="mec-past-event mec-event-article mec-clear  " itemscope>                    <div class="mec-event-date mec-bg-color-hover mec-border-color-hover mec-color"><span>13</span>Feb</div>
+            <div class="event-detail-wrap">
+                <h4 class="mec-event-title"><a class="mec-color-hover" data-event-id="3417" href="https://clecpc.org/events/cprb-civilian-police-review-board-meeting/" target="_self" rel="noopener">Civilian Police Review Board (CPRB) Meeting</a><span class="event-color" style="background: #0059ce"></span></h4>
+                                <div class="mec-time-details"><span class="mec-start-time">9:00 am</span></div>                <div class="mec-event-detail">
+                    <div class="mec-event-loc-place">Cleveland City Hall</div>
+                                                                            </div>
+            </div>
+        </article></div></div>                        	</div>
+</div>
+
+    </div>
+    <div class="mec-skin-grid-no-events-container mec-util-hidden" id="mec_skin_no_events_1061">
+        No event found!    </div>
+    
+        <div class="mec-load-more-wrap"><div tabindex="0" class="mec-load-more-button ">Load More</div></div>
+    
+</div>						</div>
+				</div>
+				<div class="elementor-element elementor-element-ac36be1 elementor-widget elementor-widget-spacer" data-id="ac36be1" data-element_type="widget" data-widget_type="spacer.default">
+				<div class="elementor-widget-container">
+					<div class="elementor-spacer">
+			<div class="elementor-spacer-inner"></div>
+		</div>
+				</div>
+				</div>
+				<div class="elementor-element elementor-element-a037ece elementor-widget elementor-widget-text-editor" data-id="a037ece" data-element_type="widget" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+							<p>Full Event Calendar</p>						</div>
+				</div>
+				<div class="elementor-element elementor-element-8f05af8 elementor-widget elementor-widget-text-editor" data-id="8f05af8" data-element_type="widget" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+							<p><span style="color: var( --e-global-color-text ); font-family: var( --e-global-typography-text-font-family ), Sans-serif; font-weight: var( --e-global-typography-text-font-weight ); font-size: 1rem;"><div id="mec_skin_1057" class="mec-wrap colorskin-custom   mec-full-calendar-wrap">
+
+    <div class="mec-search-form mec-totalcal-box">
+                                    <div id="mec_search_form_1057" class="mec-dropdown-wrap">
+
+            
+            <div class="mec-dropdown-wrap">
+                                    <div class="mec-dropdown-search"><i class="mec-sl-folder"></i><select name=' ' id='mec_sf_category_1057' class='postform'>
+	<option value='' selected='selected'>Category</option>
+	<option class="level-0" value="689310775">City Council Meetings</option>
+	<option class="level-0" value="689310811">City of Cleveland Events</option>
+	<option class="level-0" value="689310799">Civilian Police Review Board</option>
+	<option class="level-0" value="689310766">CPC Events</option>
+	<option class="level-1" value="689310747">&nbsp;&nbsp;&nbsp;Commissioner Meetings</option>
+	<option class="level-1" value="689310748">&nbsp;&nbsp;&nbsp;CPC Public Meetings</option>
+	<option class="level-1" value="689310776">&nbsp;&nbsp;&nbsp;Work Group Meetings</option>
+	<option class="level-0" value="689310794">Events in the Community</option>
+	<option class="level-0" value="689310751">Police District Meetings</option>
+	<option class="level-1" value="689310757">&nbsp;&nbsp;&nbsp;1st District Meetings</option>
+	<option class="level-1" value="689310758">&nbsp;&nbsp;&nbsp;2nd District Meetings</option>
+	<option class="level-1" value="689310759">&nbsp;&nbsp;&nbsp;3rd District Meetings</option>
+	<option class="level-1" value="689310760">&nbsp;&nbsp;&nbsp;4th District Meetings</option>
+	<option class="level-1" value="689310761">&nbsp;&nbsp;&nbsp;5th District Meetings</option>
+	<option class="level-0" value="689310790">Status Conferences</option>
+	<option class="level-0" value="689310785">Ward Community Meetings</option>
+</select>
+</div>                                                                                                            </div>
+        </div>
+        <div id="mec_search_form_1057">
+                                </div>
+        <div id="mec_search_form_1057" class="mec-full-calendar-search-ends">
+                                        <div class="mec-date-search"><input type="hidden" id="mec-filter-none" value="Select"><i class="mec-sl-calendar"></i>
+                    <select id="mec_sf_month_1057">
+                        <option value="">Select Month</option><option value="01">January</option><option value="02">February</option><option value="03">March</option><option value="04">April</option><option value="05">May</option><option value="06">June</option><option value="07">July</option><option value="08">August</option><option value="09">September</option><option value="10">October</option><option value="11">November</option><option value="12">December</option></select><select id="mec_sf_year_1057"><option value="2019">2019</option><option value="2020">2020</option><option value="2021">2021</option><option value="2022">2022</option><option value="2023">2023</option><option value="2024" selected>2024</option><option value="2025">2025</option><option value="2026">2026</option><option value="2027">2027</option><option value="2028">2028</option></select></div>                                                <div class="col-md-12 mec-tab-loader">
+                <div class="mec-totalcal-view">
+                                        <span class="mec-totalcal-monthlyview mec-totalcalview-selected" data-skin="monthly">Monthly</span>                    <span class="mec-totalcal-weeklyview" data-skin="weekly">Weekly</span>                    <span class="mec-totalcal-dailyview" data-skin="daily">Daily</span>                    <span class="mec-totalcal-listview" data-skin="list">List</span>                                                        </div>
+            </div>
+        </div>
+            </div>
+
+    <div id="mec_full_calendar_container_1057" class="mec-full-calendar-skin-container">
+        <div id="mec_skin_1057" class="mec-wrap colorskin-custom  ">
+
+    
+    <div class="mec-calendar mec-box-calendar mec-event-calendar-classic mec-event-container-simple">
+                <div class="mec-calendar-side mec-clear">
+                        <div class="mec-skin-monthly-view-month-navigator-container">
+                <div class="mec-month-navigator" id="mec_month_navigator_1057_202401"><div class="mec-previous-month mec-load-month mec-previous-month" data-mec-year="2023" data-mec-month="12"><a href="#" class="mec-load-month-link"><i class="mec-sl-angle-left"></i> December</a></div><div class="mec-calendar-header"><h2>January 2024</h2></div><div class="mec-next-month mec-load-month mec-next-month" data-mec-year="2024" data-mec-month="02"><a href="#" class="mec-load-month-link">February <i class="mec-sl-angle-right"></i></a></div></div>
+            </div>
+            
+            <div class="mec-calendar-table" id="mec_skin_events_1057">
+                <div class="mec-month-container mec-month-container-selected" id="mec_monthly_view_month_1057_202401" data-month-id="202401"><dl class="mec-calendar-table-head"><dt class="mec-calendar-day-head">SU</dt><dt class="mec-calendar-day-head">MO</dt><dt class="mec-calendar-day-head">TU</dt><dt class="mec-calendar-day-head">WE</dt><dt class="mec-calendar-day-head">TH</dt><dt class="mec-calendar-day-head">FR</dt><dt class="mec-calendar-day-head">SA</dt></dl><dl class="mec-calendar-row">
+    <dt class="mec-table-nullday">31</dt><dt class="mec-calendar-day " data-mec-cell="20240101" data-day="1" data-month="202401">1</dt></dt><dt class="mec-calendar-day " data-mec-cell="20240102" data-day="2" data-month="202401">2</dt></dt><dt class="mec-calendar-day " data-mec-cell="20240103" data-day="3" data-month="202401"><div class="">3</div><div class="mec-past-event ended-relative simple-skin-ended"><a class="mec-monthly-tooltip event-single-link-simple" data-tooltip-content="#mec-tooltip-148921704304800-20240103" data-event-id="14892" href="https://clecpc.org/events/rules-committee-1st-wednesday/" ><h4 class="mec-event-title">Cancelled: Rules Committee Meeting January 3rd</h4></a></div><div class="tooltip_templates event-single-content-simple">
+                        <div id="mec-tooltip-148921704304800-20240103">
+                            <div class="mec-tooltip-event-title">Cancelled: Rules Committee Meeting January 3rd</div><div class="mec-tooltip-event-time"><i class="mec-sl-clock-o"></i> 6:00 pm &#8211; 8:00 pm</div><div class="mec-tooltip-event-content"><div class="mec-tooltip-event-desc">
+
+
+
+
+The Rules Committee Meeting for January has been cancelled/ Postponed. A new date will be posted when the committee reschedules. 
+
+
+
+Rules CommitteeMeeting Dates: Every 1st Wednesday of the MonthTime: 6:00pm &#8211; 8:00pmLocation: CPC Office, 3631 Perkins Avenue, 4th Floor, Cleveland, OH 44114Chair: Teri Wang Mem , &#8230;</div></div>
+                        </div>
+                    </div></dt><dt class="mec-calendar-day " data-mec-cell="20240104" data-day="4" data-month="202401"><div class="">4</div><div class="mec-past-event ended-relative simple-skin-ended"><a class="mec-monthly-tooltip event-single-link-simple" data-tooltip-content="#mec-tooltip-10961704391200-20240104" data-event-id="1096" href="https://clecpc.org/events/first-district-dpc-meeting/" ><h4 class="mec-event-title">1st District &#8211; District Policing Committee Meeting</h4></a></div><div class="tooltip_templates event-single-content-simple">
+                        <div id="mec-tooltip-10961704391200-20240104">
+                            <div class="mec-tooltip-event-title">1st District &#8211; District Policing Committee Meeting</div><div class="mec-tooltip-event-time"><i class="mec-sl-clock-o"></i> 6:00 pm &#8211; 7:00 pm</div>
+                        </div>
+                    </div></dt><dt class="mec-calendar-day " data-mec-cell="20240105" data-day="5" data-month="202401">5</dt></dt><dt class="mec-calendar-day " data-mec-cell="20240106" data-day="6" data-month="202401">6</dt></dt></dl><dl class="mec-calendar-row"><dt class="mec-calendar-day " data-mec-cell="20240107" data-day="7" data-month="202401">7</dt></dt><dt class="mec-calendar-day " data-mec-cell="20240108" data-day="8" data-month="202401"><div class="">8</div><div class="mec-past-event ended-relative simple-skin-ended"><a class="mec-monthly-tooltip event-single-link-simple" data-tooltip-content="#mec-tooltip-150651704738600-20240108" data-event-id="15065" href="https://clecpc.org/events/budget-grants-committee-meeting-nov-29-2023-781/" ><h4 class="mec-event-title">Budget &amp; Grants Committee Meeting</h4></a></div><div class="tooltip_templates event-single-content-simple">
+                        <div id="mec-tooltip-150651704738600-20240108">
+                            <div class="mec-tooltip-event-title">Budget &amp; Grants Committee Meeting</div><div class="mec-tooltip-event-time"><i class="mec-sl-clock-o"></i> 6:30 pm &#8211; 8:30 pm</div><div class="mec-tooltip-event-content"><div class="mec-tooltip-event-desc">
+Budget &amp; Grants CommitteeDate: Monday, January 8, 2024Time: 6:30pm &#8211; 8:30pmLocation: CPC Office, 3631 Perkins Avenue, 4th Floor, Cleveland, OH 44114Public Livestream: <a href="http://www.youtube.com/@ClevelandCPCJan" rel="nofollow">http://www.youtube.com/@ClevelandCPCJan</a>. 8th Meeting Agenda (pdf)Chair: Dr. John Adams Members: Alana Garrett-Ferguson, Cait Kennedy, Piet van Lier,  , &#8230;</div></div>
+                        </div>
+                    </div></dt><dt class="mec-calendar-day " data-mec-cell="20240109" data-day="9" data-month="202401"><div class="">9</div><div class="mec-past-event ended-relative simple-skin-ended"><a class="mec-monthly-tooltip event-single-link-simple" data-tooltip-content="#mec-tooltip-34171704790800-20240109" data-event-id="3417" href="https://clecpc.org/events/cprb-civilian-police-review-board-meeting/" ><h4 class="mec-event-title">Civilian Police Review Board (CPRB) Meeting</h4></a></div><div class="tooltip_templates event-single-content-simple">
+                        <div id="mec-tooltip-34171704790800-20240109">
+                            <div class="mec-tooltip-event-title">Civilian Police Review Board (CPRB) Meeting</div><div class="mec-tooltip-event-time"><i class="mec-sl-clock-o"></i> 9:00 am</div><div class="mec-tooltip-event-content"><div class="mec-tooltip-event-desc">
+Meeting Dates: Second Tuesday of the month Time: 9:00am until all cases are heardLocation: <a href="https://cityclevelandoh.webex.com/cityclevelandoh/j.php?MTID=m1d33399dc7219eb4e936d8c4d2e952c5Meetings" rel="nofollow">https://cityclevelandoh.webex.com/cityclevelandoh/j.php?MTID=m1d33399dc7219eb4e936d8c4d2e952c5Meetings</a> are streamed live on YouTube: <a href="http://www.youtube.com/@clevelandopsThe" rel="nofollow">http://www.youtube.com/@clevelandopsThe</a> CPRB currently meets on the second Tuesday of every month at 9 , &#8230;</div></div>
+                        </div>
+                    </div><div class="mec-past-event ended-relative simple-skin-ended"><a class="mec-monthly-tooltip event-single-link-simple" data-tooltip-content="#mec-tooltip-11041704823200-20240109" data-event-id="1104" href="https://clecpc.org/events/second-district-dpc-meeting/" ><h4 class="mec-event-title">2nd District &#8211; District Policing Committee Meeting</h4></a></div><div class="tooltip_templates event-single-content-simple">
+                        <div id="mec-tooltip-11041704823200-20240109">
+                            <div class="mec-tooltip-event-title">2nd District &#8211; District Policing Committee Meeting</div><div class="mec-tooltip-event-time"><i class="mec-sl-clock-o"></i> 6:00 pm &#8211; 8:00 pm</div>
+                        </div>
+                    </div></dt><dt class="mec-calendar-day " data-mec-cell="20240110" data-day="10" data-month="202401"><div class="">10</div><div class="mec-past-event ended-relative simple-skin-ended"><a class="mec-monthly-tooltip event-single-link-simple" data-tooltip-content="#mec-tooltip-128381704909600-20240110" data-event-id="12838" href="https://clecpc.org/events/police-training-committee/" ><h4 class="mec-event-title">Police Training Committee &#8211;</h4></a></div><div class="tooltip_templates event-single-content-simple">
+                        <div id="mec-tooltip-128381704909600-20240110">
+                            <div class="mec-tooltip-event-title">Police Training Committee &#8211;</div><div class="mec-tooltip-event-time"><i class="mec-sl-clock-o"></i> 6:00 pm &#8211; 8:00 pm</div><div class="mec-tooltip-event-content"><div class="mec-tooltip-event-desc">
+Meeting Name: CPC Police Training CommitteeDate(s): Every 2nd Wednesday of the MonthTime: 6:00pm &#8211; 8:00pmLocation: CPC Office, 3631 Perkins Avenue, 4th Floor, Cleveland, OH 44114Livestream: <a href="http://www.youtube.com/@ClevelandCPCChair" rel="nofollow">http://www.youtube.com/@ClevelandCPCChair</a>: John AdamsMembers: James Chura, Charles Donaldson, Gregory Reaves
+
+
+
+
+ , &#8230;</div></div>
+                        </div>
+                    </div></dt><dt class="mec-calendar-day " data-mec-cell="20240111" data-day="11" data-month="202401"><div class="">11</div><div class="mec-past-event ended-relative simple-skin-ended"><a class="mec-monthly-tooltip event-single-link-simple" data-tooltip-content="#mec-tooltip-148241704996000-20240111" data-event-id="14824" href="https://clecpc.org/events/cpc-behavioral-health-crisis-intervention-work-group/" ><h4 class="mec-event-title">Behavioral Health &amp; Crisis Intervention Work Group- January 11th Cancelled</h4></a></div><div class="tooltip_templates event-single-content-simple">
+                        <div id="mec-tooltip-148241704996000-20240111">
+                            <div class="mec-tooltip-event-title">Behavioral Health &amp; Crisis Intervention Work Group- January 11th Cancelled</div><div class="mec-tooltip-event-content"><div class="mec-tooltip-event-desc">
+CPC Behavioral Health &amp; Crisis Intervention Work Group. Chair: Commissioner Shandra Benito
+
+
+
+
+January 11th Meeting has been cancelled. Regular meeting schedule:  2nd Thursday of the Month6:00pm &#8211; 8:00pm In Person or at the CPC Office 3631 Perkins Avenue, 4th Floor or Virtually on Microsoft Teams.
+
+
+
+
+Work g , &#8230;</div></div>
+                        </div>
+                    </div></dt><dt class="mec-calendar-day " data-mec-cell="20240112" data-day="12" data-month="202401">12</dt></dt><dt class="mec-calendar-day " data-mec-cell="20240113" data-day="13" data-month="202401">13</dt></dt></dl><dl class="mec-calendar-row"><dt class="mec-calendar-day " data-mec-cell="20240114" data-day="14" data-month="202401">14</dt></dt><dt class="mec-calendar-day " data-mec-cell="20240115" data-day="15" data-month="202401">15</dt></dt><dt class="mec-calendar-day " data-mec-cell="20240116" data-day="16" data-month="202401"><div class="">16</div><div class="mec-past-event ended-relative simple-skin-ended"><a class="mec-monthly-tooltip event-single-link-simple" data-tooltip-content="#mec-tooltip-34121705428000-20240116" data-event-id="3412" href="https://clecpc.org/events/3rd-district-dpc-meeting/" ><h4 class="mec-event-title">3rd District – District Policing Committee Meeting</h4></a></div><div class="tooltip_templates event-single-content-simple">
+                        <div id="mec-tooltip-34121705428000-20240116">
+                            <div class="mec-tooltip-event-title">3rd District – District Policing Committee Meeting</div><div class="mec-tooltip-event-time"><i class="mec-sl-clock-o"></i> 6:00 pm &#8211; 7:00 pm</div>
+                        </div>
+                    </div><div class="mec-past-event ended-relative simple-skin-ended"><a class="mec-monthly-tooltip event-single-link-simple" data-tooltip-content="#mec-tooltip-135201705428000-20240116" data-event-id="13520" href="https://clecpc.org/events/police-accountability-committee-sept-19-2023/" ><h4 class="mec-event-title">Police Accountability Committee</h4></a></div><div class="tooltip_templates event-single-content-simple">
+                        <div id="mec-tooltip-135201705428000-20240116">
+                            <div class="mec-tooltip-event-title">Police Accountability Committee</div><div class="mec-tooltip-event-time"><i class="mec-sl-clock-o"></i> 6:00 pm &#8211; 8:00 pm</div><div class="mec-tooltip-event-content"><div class="mec-tooltip-event-desc">
+Police Accountability CommitteeDate: Tuesday, January 16, 2024Time: 6:00pm &#8211; 8:00pmLocation: CPC Office, 3631 Perkins Avenue, 4th Floor, Cleveland, OH 44114Livestream: <a href="http://www.youtube.com/@ClevelandCPCChair" rel="nofollow">http://www.youtube.com/@ClevelandCPCChair</a>: Teri WangMembers: John Adams, Shandra Benito, James Chura, Sharena Zayed
+
+
+
+
+ , &#8230;</div></div>
+                        </div>
+                    </div></dt><dt class="mec-calendar-day " data-mec-cell="20240117" data-day="17" data-month="202401"><div class="">17</div><div class="mec-past-event ended-relative simple-skin-ended"><a class="mec-monthly-tooltip event-single-link-simple" data-tooltip-content="#mec-tooltip-46701705514400-20240117" data-event-id="4670" href="https://clecpc.org/events/fifth-district-dpc-meeting/" ><h4 class="mec-event-title">5th District Policing Committee Meeting</h4></a></div><div class="tooltip_templates event-single-content-simple">
+                        <div id="mec-tooltip-46701705514400-20240117">
+                            <div class="mec-tooltip-event-title">5th District Policing Committee Meeting</div><div class="mec-tooltip-event-time"><i class="mec-sl-clock-o"></i> 6:00 pm &#8211; 7:00 pm</div><div class="mec-tooltip-event-content"><div class="mec-tooltip-event-desc">
+Meeting Dates:&nbsp;Third Wednesday of the MonthTime:&nbsp;6:00pm – 7:00pmLocation:&nbsp;Five Pointe Community Center, 813 E. 152nd Street, Cleveland, OH 44110
+
+
+
+Join the Fifth District Cleveland Police Commander, Supervisors and Officers at the 5th District&#8217;s monthly community meetings.  This is an opportunity , &#8230;</div></div>
+                        </div>
+                    </div><div class="mec-past-event ended-relative simple-skin-ended"><a class="mec-monthly-tooltip event-single-link-simple" data-tooltip-content="#mec-tooltip-128351705514400-20240117" data-event-id="12835" href="https://clecpc.org/events/police-policy-committee-meeting/" ><h4 class="mec-event-title">Police Policy Committee</h4></a></div><div class="tooltip_templates event-single-content-simple">
+                        <div id="mec-tooltip-128351705514400-20240117">
+                            <div class="mec-tooltip-event-title">Police Policy Committee</div><div class="mec-tooltip-event-time"><i class="mec-sl-clock-o"></i> 6:00 pm &#8211; 8:00 pm</div><div class="mec-tooltip-event-content"><div class="mec-tooltip-event-desc">
+Police Policy CommitteeDate(s): Every 3rd Wednesday of the MonthTime: 6:00pm &#8211; 8:00pmLocation: CPC Office, 3631 Perkins Avenue, 4th Floor, Cleveland, OH 44114Livestream: <a href="http://www.youtube.com/@ClevelandCPC" rel="nofollow">http://www.youtube.com/@ClevelandCPC</a>* The November meeting has been moved to Thursday, Nov. 9th * Meeting AgendaChair: Piet van LierMembers: Shandra B , &#8230;</div></div>
+                        </div>
+                    </div></dt><dt class="mec-calendar-day " data-mec-cell="20240118" data-day="18" data-month="202401">18</dt></dt><dt class="mec-calendar-day " data-mec-cell="20240119" data-day="19" data-month="202401">19</dt></dt><dt class="mec-calendar-day " data-mec-cell="20240120" data-day="20" data-month="202401">20</dt></dt></dl><dl class="mec-calendar-row"><dt class="mec-calendar-day " data-mec-cell="20240121" data-day="21" data-month="202401">21</dt></dt><dt class="mec-calendar-day " data-mec-cell="20240122" data-day="22" data-month="202401">22</dt></dt><dt class="mec-calendar-day " data-mec-cell="20240123" data-day="23" data-month="202401">23</dt></dt><dt class="mec-calendar-day " data-mec-cell="20240124" data-day="24" data-month="202401"><div class="">24</div><div class="mec-past-event ended-relative simple-skin-ended"><a class="mec-monthly-tooltip event-single-link-simple" data-tooltip-content="#mec-tooltip-150371706119200-20240124" data-event-id="15037" href="https://clecpc.org/events/full-commission-meeting/" ><h4 class="mec-event-title">Full Commission Meeting</h4></a></div><div class="tooltip_templates event-single-content-simple">
+                        <div id="mec-tooltip-150371706119200-20240124">
+                            <div class="mec-tooltip-event-title">Full Commission Meeting</div><div class="mec-tooltip-event-time"><i class="mec-sl-clock-o"></i> 6:00 pm</div><div class="mec-tooltip-event-content"><div class="mec-tooltip-event-desc">
+Full Commission Meeting January 24th. 
+
+
+
+6 p.m. &#8211; 8:30 p.m.
+
+
+
+3631 Perkins Ave. 4th Floor
+
+
+
+Agenda to be Determined 
+ , &#8230;</div></div>
+                        </div>
+                    </div><div class="mec-past-event ended-relative simple-skin-ended"><a class="mec-monthly-tooltip event-single-link-simple" data-tooltip-content="#mec-tooltip-11081706122800-20240124" data-event-id="1108" href="https://clecpc.org/events/fourth-district-dpc-meeting/" ><h4 class="mec-event-title">4th District Policing Committee Meeting</h4></a></div><div class="tooltip_templates event-single-content-simple">
+                        <div id="mec-tooltip-11081706122800-20240124">
+                            <div class="mec-tooltip-event-title">4th District Policing Committee Meeting</div><div class="mec-tooltip-event-time"><i class="mec-sl-clock-o"></i> 7:00 pm &#8211; 8:00 pm</div>
+                        </div>
+                    </div></dt><dt class="mec-calendar-day " data-mec-cell="20240125" data-day="25" data-month="202401"><div class="">25</div><div class="mec-past-event ended-relative simple-skin-ended"><a class="mec-monthly-tooltip event-single-link-simple" data-tooltip-content="#mec-tooltip-148241706205600-20240125" data-event-id="14824" href="https://clecpc.org/events/cpc-behavioral-health-crisis-intervention-work-group/" ><h4 class="mec-event-title">Behavioral Health &amp; Crisis Intervention Work Group- January 11th Cancelled</h4></a></div><div class="tooltip_templates event-single-content-simple">
+                        <div id="mec-tooltip-148241706205600-20240125">
+                            <div class="mec-tooltip-event-title">Behavioral Health &amp; Crisis Intervention Work Group- January 11th Cancelled</div><div class="mec-tooltip-event-content"><div class="mec-tooltip-event-desc">
+CPC Behavioral Health &amp; Crisis Intervention Work Group. Chair: Commissioner Shandra Benito
+
+
+
+
+January 11th Meeting has been cancelled. Regular meeting schedule:  2nd Thursday of the Month6:00pm &#8211; 8:00pm In Person or at the CPC Office 3631 Perkins Avenue, 4th Floor or Virtually on Microsoft Teams.
+
+
+
+
+Work g , &#8230;</div></div>
+                        </div>
+                    </div><div class="mec-past-event ended-relative simple-skin-ended"><a class="mec-monthly-tooltip event-single-link-simple" data-tooltip-content="#mec-tooltip-151221706207400-20240125" data-event-id="15122" href="https://clecpc.org/events/police-discipline-work-group/" ><h4 class="mec-event-title">Police Discipline Work Group</h4></a></div><div class="tooltip_templates event-single-content-simple">
+                        <div id="mec-tooltip-151221706207400-20240125">
+                            <div class="mec-tooltip-event-title">Police Discipline Work Group</div><div class="mec-tooltip-event-time"><i class="mec-sl-clock-o"></i> 6:30 pm &#8211; 8:30 pm</div><div class="mec-tooltip-event-content"><div class="mec-tooltip-event-desc">Work Group to review the police disciplinary policy, disciplinary matrix and police manual of rules 
+ , &#8230;</div></div>
+                        </div>
+                    </div></dt><dt class="mec-calendar-day " data-mec-cell="20240126" data-day="26" data-month="202401">26</dt></dt><dt class="mec-calendar-day " data-mec-cell="20240127" data-day="27" data-month="202401">27</dt></dt></dl><dl class="mec-calendar-row"><dt class="mec-calendar-day " data-mec-cell="20240128" data-day="28" data-month="202401">28</dt></dt><dt class="mec-calendar-day  mec-selected-day" data-mec-cell="20240129" data-day="29" data-month="202401">29</dt></dt><dt class="mec-calendar-day " data-mec-cell="20240130" data-day="30" data-month="202401">30</dt></dt><dt class="mec-calendar-day " data-mec-cell="20240131" data-day="31" data-month="202401">31</dt></dt><dt class="mec-table-nullday">1</dt><dt class="mec-table-nullday">2</dt><dt class="mec-table-nullday">3</dt></dl></div>
+            </div>
+
+                    </div>
+            </div>
+
+</div>    </div>
+
+</div></span></p>						</div>
+				</div>
+					</div>
+		</div>
+					</div>
+		</section>
+				</div>
+					</div><!-- .entry-content -->
+
+			<footer class="entry-footer">
+					</footer><!-- .entry-footer -->
+	</article><!-- #post-## -->						
+					</div><!-- .main-content -->
+
+				</main><!-- #main -->
+			</div><!-- #primary -->
+		</div><!-- .content -->
+	</div><!-- .site -->
+
+	<div class="social-block">
+			</div>
+	
+	
+	<footer id="colophon" class="site-footer" role="contentinfo">
+
+		<div class="hfeed site">
+
+			<div class="content site-content">
+
+				<div class="footer-widgets clear">
+
+					
+						<div class="widget-area">
+
+							<aside id="text-3" class="widget widget_text"><h2 class="widget-title">Community Police Commission</h2>			<div class="textwidget"></div>
+		</aside><aside id="custom_html-10" class="widget_text widget widget_custom_html"><h2 class="widget-title">Subscribe</h2><div class="textwidget custom-html-widget"><div class="wp-block-button"><a class="wp-block-button__link has-background" href="http://eepurl.com/gVB5J5" style="background-color:#0071a1;border-radius:6px" target="_blank" rel="noreferrer noopener"> Newsletter Sign up</a></div></div></aside><aside id="jetpack_widget_social_icons-6" class="widget jetpack_widget_social_icons">
+			<ul class="jetpack-social-widget-list size-medium">
+
+				
+											<li class="jetpack-social-widget-item">
+							<a href="https://www.facebook.com/216cpc/" target="_blank" rel="noopener noreferrer"><span class="screen-reader-text">Facebook</span><svg class="icon icon-facebook" aria-hidden="true" role="presentation"> <use href="#icon-facebook" xlink:href="#icon-facebook"></use> </svg>							</a>
+						</li>
+					
+				
+											<li class="jetpack-social-widget-item">
+							<a href="https://twitter.com/216cpc" target="_blank" rel="noopener noreferrer"><span class="screen-reader-text">Twitter</span><svg class="icon icon-twitter" aria-hidden="true" role="presentation"> <use href="#icon-twitter" xlink:href="#icon-twitter"></use> </svg>							</a>
+						</li>
+					
+				
+											<li class="jetpack-social-widget-item">
+							<a href="https://www.youtube.com/channel/UCZsDVxlvwJyEJU8-UuXgFiQ" target="_blank" rel="noopener noreferrer"><span class="screen-reader-text">YouTube</span><svg class="icon icon-youtube" aria-hidden="true" role="presentation"> <use href="#icon-youtube" xlink:href="#icon-youtube"></use> </svg>							</a>
+						</li>
+					
+				
+											<li class="jetpack-social-widget-item">
+							<a href="https://www.instagram.com/cleveland_cpc/" target="_blank" rel="noopener noreferrer"><span class="screen-reader-text">Instagram</span><svg class="icon icon-instagram" aria-hidden="true" role="presentation"> <use href="#icon-instagram" xlink:href="#icon-instagram"></use> </svg>							</a>
+						</li>
+					
+				
+			</ul>
+
+			</aside>
+						</div><!-- .widget-area -->
+
+					
+					
+						<div class="widget-area">
+
+							<aside id="widget_contact_info-3" class="widget widget_contact_info"><h2 class="widget-title">Address &amp; Info</h2><div itemscope itemtype="http://schema.org/LocalBusiness"><div class="confit-address" itemscope itemtype="http://schema.org/PostalAddress" itemprop="address"><a href="https://maps.google.com/maps?z=16&#038;q=3631%2Bperkins%2Bavenue%2C%2B4th%2Bfloor%2Bcleveland%2C%2Boh%2B44114" target="_blank" rel="noopener noreferrer">3631 Perkins Avenue, 4th Floor<br/>Cleveland, OH 44114</a></div><div class="confit-phone"><span itemprop="telephone">Phone: 1-216-505-5920</span></div><div class="confit-hours" itemprop="openingHours">Hours: M– F: 7:30am – 4:30pm</div></div></aside>
+						</div><!-- .widget-area -->
+
+					
+					
+						<div class="widget-area">
+
+							<aside id="custom_html-8" class="widget_text widget widget_custom_html"><h2 class="widget-title">Links</h2><div class="textwidget custom-html-widget"><a href="https://clecpc.org/about-us/">About Us</a><br>
+<a href="https://clecpc.org/our-work/">Our Work </a><br>
+<a href="https://clecpc.org/get-involved/work-groups/">Work Groups </a><br>
+
+<a href="https://clecpc.org/get-involved/calendar/">Event Calendar</a> <br>
+<a href="https://clecpc.org/contact/">Contact Us </a></div></aside><aside id="text-19" class="widget widget_text">			<div class="textwidget"><p>© 2023 Cleveland Community Police Commission</p>
+</div>
+		</aside>
+						</div><!-- .widget-area -->
+
+				
+				</div><!-- .footer-widgets -->
+
+			</div><!-- .site -->
+
+		</div><!-- .content -->
+
+	</footer><!-- #colophon -->
+				<div class="site-info">
+				<div class="hfeed site">
+					<div class="content site-content">
+						
+						
+											</div><!-- .content -->
+				</div><!-- .site -->
+			</div><!-- .site-info -->
+<!--  -->
+<style>
+			.sd-social-icon .sd-content ul li a.sd-button>span {
+				margin-left: 0;
+			}
+		</style><script defer id="bilmur" data-provider="wordpress.com" data-service="atomic"  src="https://s0.wp.com/wp-content/js/bilmur.min.js?m=202405"></script>
+<div class="simple-banner simple-banner-text" style="display:none !important"></div><link rel='stylesheet' id='mec-owl-carousel-style-css' href='https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/packages/owl-carousel/owl.carousel.min.css?ver=6.4.2' type='text/css' media='all' />
+<link rel='stylesheet' id='mec-owl-carousel-theme-style-css' href='https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/packages/owl-carousel/owl.theme.min.css?ver=6.4.2' type='text/css' media='all' />
+<script type="text/javascript" src="https://c0.wp.com/c/6.4.2/wp-includes/js/jquery/ui/core.min.js" id="jquery-ui-core-js"></script>
+<script type="text/javascript" src="https://c0.wp.com/c/6.4.2/wp-includes/js/jquery/ui/datepicker.min.js" id="jquery-ui-datepicker-js"></script>
+<script type="text/javascript" id="jquery-ui-datepicker-js-after">
+/* <![CDATA[ */
+jQuery(function(jQuery){jQuery.datepicker.setDefaults({"closeText":"Close","currentText":"Today","monthNames":["January","February","March","April","May","June","July","August","September","October","November","December"],"monthNamesShort":["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],"nextText":"Next","prevText":"Previous","dayNames":["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],"dayNamesShort":["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],"dayNamesMin":["S","M","T","W","T","F","S"],"dateFormat":"MM d, yy","firstDay":0,"isRTL":false});});
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/js/jquery.typewatch.js?ver=6.5.6" id="mec-typekit-script-js"></script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/packages/featherlight/featherlight.js?ver=6.5.6" id="featherlight-js"></script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/packages/select2/select2.full.min.js?ver=6.5.6" id="mec-select2-script-js"></script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/packages/tooltip/tooltip.js?ver=6.5.6" id="mec-tooltip-script-js"></script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/packages/lity/lity.min.js?ver=6.5.6" id="mec-lity-script-js"></script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/packages/colorbrightness/colorbrightness.min.js?ver=6.5.6" id="mec-colorbrightness-script-js"></script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/packages/owl-carousel/owl.carousel.min.js?ver=6.5.6" id="mec-owl-carousel-script-js"></script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/jetpack/jetpack_vendor/automattic/jetpack-image-cdn/dist/image-cdn.js?minify=false&amp;ver=132249e245926ae3e188" id="jetpack-photon-js"></script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/coblocks/dist/js/coblocks-animation.js?ver=3.1.5" id="coblocks-animation-js"></script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/coblocks/dist/js/vendors/tiny-swiper.js?ver=3.1.5" id="coblocks-tiny-swiper-js"></script>
+<script type="text/javascript" id="coblocks-tinyswiper-initializer-js-extra">
+/* <![CDATA[ */
+var coblocksTinyswiper = {"carouselPrevButtonAriaLabel":"Previous","carouselNextButtonAriaLabel":"Next","sliderImageAriaLabel":"Image"};
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/coblocks/dist/js/coblocks-tinyswiper-initializer.js?ver=3.1.5" id="coblocks-tinyswiper-initializer-js"></script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/themes/pena/js/navigation.js?ver=20120206" id="pena-navigation-js"></script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/themes/pena/js/skip-link-focus-fix.js?ver=20130115" id="pena-skip-link-focus-fix-js"></script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/google-calendar-events/assets/generated/vendor/jquery.qtip.min.js?ver=3.3.0" id="simcal-qtip-js"></script>
+<script type="text/javascript" id="simcal-default-calendar-js-extra">
+/* <![CDATA[ */
+var simcal_default_calendar = {"ajax_url":"\/wp-admin\/admin-ajax.php","nonce":"33ae85abc3","locale":"en_US","text_dir":"ltr","months":{"full":["January","February","March","April","May","June","July","August","September","October","November","December"],"short":["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"]},"days":{"full":["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],"short":["Sun","Mon","Tue","Wed","Thu","Fri","Sat"]},"meridiem":{"AM":"AM","am":"am","PM":"PM","pm":"pm"}};
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/google-calendar-events/assets/generated/default-calendar.min.js?ver=3.3.0" id="simcal-default-calendar-js"></script>
+<script type="text/javascript" id="ics-calendar-js-extra">
+/* <![CDATA[ */
+var r34ics_ajax_obj = {"ajaxurl":"https:\/\/clecpc.org\/wp-admin\/admin-ajax.php","r34ics_nonce":"29c44410b8"};
+var ics_calendar_i18n = {"hide_past_events":"Hide past events","show_past_events":"Show past events"};
+var r34ics_days_of_week_map = {"Sunday":"Sun","Monday":"Mon","Tuesday":"Tue","Wednesday":"Wed","Thursday":"Thu","Friday":"Fri","Saturday":"Sat"};
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/ics-calendar/assets/script.min.js?ver=10.14.1" id="ics-calendar-js"></script>
+<script type="text/javascript" id="eael-general-js-extra">
+/* <![CDATA[ */
+var localize = {"ajaxurl":"https:\/\/clecpc.org\/wp-admin\/admin-ajax.php","nonce":"c54b5b13cc","i18n":{"added":"Added ","compare":"Compare","loading":"Loading..."},"eael_translate_text":{"required_text":"is a required field","invalid_text":"Invalid","billing_text":"Billing","shipping_text":"Shipping","fg_mfp_counter_text":"of"},"page_permalink":"https:\/\/clecpc.org\/get-involved\/calendar\/","cart_redirectition":"","cart_page_url":"","el_breakpoints":{"mobile":{"label":"Mobile Portrait","value":767,"default_value":767,"direction":"max","is_enabled":true},"mobile_extra":{"label":"Mobile Landscape","value":880,"default_value":880,"direction":"max","is_enabled":false},"tablet":{"label":"Tablet Portrait","value":1024,"default_value":1024,"direction":"max","is_enabled":true},"tablet_extra":{"label":"Tablet Landscape","value":1200,"default_value":1200,"direction":"max","is_enabled":false},"laptop":{"label":"Laptop","value":1366,"default_value":1366,"direction":"max","is_enabled":false},"widescreen":{"label":"Widescreen","value":2400,"default_value":2400,"direction":"min","is_enabled":false}},"ParticleThemesData":{"default":"{\"particles\":{\"number\":{\"value\":160,\"density\":{\"enable\":true,\"value_area\":800}},\"color\":{\"value\":\"#ffffff\"},\"shape\":{\"type\":\"circle\",\"stroke\":{\"width\":0,\"color\":\"#000000\"},\"polygon\":{\"nb_sides\":5},\"image\":{\"src\":\"img\/github.svg\",\"width\":100,\"height\":100}},\"opacity\":{\"value\":0.5,\"random\":false,\"anim\":{\"enable\":false,\"speed\":1,\"opacity_min\":0.1,\"sync\":false}},\"size\":{\"value\":3,\"random\":true,\"anim\":{\"enable\":false,\"speed\":40,\"size_min\":0.1,\"sync\":false}},\"line_linked\":{\"enable\":true,\"distance\":150,\"color\":\"#ffffff\",\"opacity\":0.4,\"width\":1},\"move\":{\"enable\":true,\"speed\":6,\"direction\":\"none\",\"random\":false,\"straight\":false,\"out_mode\":\"out\",\"bounce\":false,\"attract\":{\"enable\":false,\"rotateX\":600,\"rotateY\":1200}}},\"interactivity\":{\"detect_on\":\"canvas\",\"events\":{\"onhover\":{\"enable\":true,\"mode\":\"repulse\"},\"onclick\":{\"enable\":true,\"mode\":\"push\"},\"resize\":true},\"modes\":{\"grab\":{\"distance\":400,\"line_linked\":{\"opacity\":1}},\"bubble\":{\"distance\":400,\"size\":40,\"duration\":2,\"opacity\":8,\"speed\":3},\"repulse\":{\"distance\":200,\"duration\":0.4},\"push\":{\"particles_nb\":4},\"remove\":{\"particles_nb\":2}}},\"retina_detect\":true}","nasa":"{\"particles\":{\"number\":{\"value\":250,\"density\":{\"enable\":true,\"value_area\":800}},\"color\":{\"value\":\"#ffffff\"},\"shape\":{\"type\":\"circle\",\"stroke\":{\"width\":0,\"color\":\"#000000\"},\"polygon\":{\"nb_sides\":5},\"image\":{\"src\":\"img\/github.svg\",\"width\":100,\"height\":100}},\"opacity\":{\"value\":1,\"random\":true,\"anim\":{\"enable\":true,\"speed\":1,\"opacity_min\":0,\"sync\":false}},\"size\":{\"value\":3,\"random\":true,\"anim\":{\"enable\":false,\"speed\":4,\"size_min\":0.3,\"sync\":false}},\"line_linked\":{\"enable\":false,\"distance\":150,\"color\":\"#ffffff\",\"opacity\":0.4,\"width\":1},\"move\":{\"enable\":true,\"speed\":1,\"direction\":\"none\",\"random\":true,\"straight\":false,\"out_mode\":\"out\",\"bounce\":false,\"attract\":{\"enable\":false,\"rotateX\":600,\"rotateY\":600}}},\"interactivity\":{\"detect_on\":\"canvas\",\"events\":{\"onhover\":{\"enable\":true,\"mode\":\"bubble\"},\"onclick\":{\"enable\":true,\"mode\":\"repulse\"},\"resize\":true},\"modes\":{\"grab\":{\"distance\":400,\"line_linked\":{\"opacity\":1}},\"bubble\":{\"distance\":250,\"size\":0,\"duration\":2,\"opacity\":0,\"speed\":3},\"repulse\":{\"distance\":400,\"duration\":0.4},\"push\":{\"particles_nb\":4},\"remove\":{\"particles_nb\":2}}},\"retina_detect\":true}","bubble":"{\"particles\":{\"number\":{\"value\":15,\"density\":{\"enable\":true,\"value_area\":800}},\"color\":{\"value\":\"#1b1e34\"},\"shape\":{\"type\":\"polygon\",\"stroke\":{\"width\":0,\"color\":\"#000\"},\"polygon\":{\"nb_sides\":6},\"image\":{\"src\":\"img\/github.svg\",\"width\":100,\"height\":100}},\"opacity\":{\"value\":0.3,\"random\":true,\"anim\":{\"enable\":false,\"speed\":1,\"opacity_min\":0.1,\"sync\":false}},\"size\":{\"value\":50,\"random\":false,\"anim\":{\"enable\":true,\"speed\":10,\"size_min\":40,\"sync\":false}},\"line_linked\":{\"enable\":false,\"distance\":200,\"color\":\"#ffffff\",\"opacity\":1,\"width\":2},\"move\":{\"enable\":true,\"speed\":8,\"direction\":\"none\",\"random\":false,\"straight\":false,\"out_mode\":\"out\",\"bounce\":false,\"attract\":{\"enable\":false,\"rotateX\":600,\"rotateY\":1200}}},\"interactivity\":{\"detect_on\":\"canvas\",\"events\":{\"onhover\":{\"enable\":false,\"mode\":\"grab\"},\"onclick\":{\"enable\":false,\"mode\":\"push\"},\"resize\":true},\"modes\":{\"grab\":{\"distance\":400,\"line_linked\":{\"opacity\":1}},\"bubble\":{\"distance\":400,\"size\":40,\"duration\":2,\"opacity\":8,\"speed\":3},\"repulse\":{\"distance\":200,\"duration\":0.4},\"push\":{\"particles_nb\":4},\"remove\":{\"particles_nb\":2}}},\"retina_detect\":true}","snow":"{\"particles\":{\"number\":{\"value\":450,\"density\":{\"enable\":true,\"value_area\":800}},\"color\":{\"value\":\"#fff\"},\"shape\":{\"type\":\"circle\",\"stroke\":{\"width\":0,\"color\":\"#000000\"},\"polygon\":{\"nb_sides\":5},\"image\":{\"src\":\"img\/github.svg\",\"width\":100,\"height\":100}},\"opacity\":{\"value\":0.5,\"random\":true,\"anim\":{\"enable\":false,\"speed\":1,\"opacity_min\":0.1,\"sync\":false}},\"size\":{\"value\":5,\"random\":true,\"anim\":{\"enable\":false,\"speed\":40,\"size_min\":0.1,\"sync\":false}},\"line_linked\":{\"enable\":false,\"distance\":500,\"color\":\"#ffffff\",\"opacity\":0.4,\"width\":2},\"move\":{\"enable\":true,\"speed\":6,\"direction\":\"bottom\",\"random\":false,\"straight\":false,\"out_mode\":\"out\",\"bounce\":false,\"attract\":{\"enable\":false,\"rotateX\":600,\"rotateY\":1200}}},\"interactivity\":{\"detect_on\":\"canvas\",\"events\":{\"onhover\":{\"enable\":true,\"mode\":\"bubble\"},\"onclick\":{\"enable\":true,\"mode\":\"repulse\"},\"resize\":true},\"modes\":{\"grab\":{\"distance\":400,\"line_linked\":{\"opacity\":0.5}},\"bubble\":{\"distance\":400,\"size\":4,\"duration\":0.3,\"opacity\":1,\"speed\":3},\"repulse\":{\"distance\":200,\"duration\":0.4},\"push\":{\"particles_nb\":4},\"remove\":{\"particles_nb\":2}}},\"retina_detect\":true}","nyan_cat":"{\"particles\":{\"number\":{\"value\":150,\"density\":{\"enable\":false,\"value_area\":800}},\"color\":{\"value\":\"#ffffff\"},\"shape\":{\"type\":\"star\",\"stroke\":{\"width\":0,\"color\":\"#000000\"},\"polygon\":{\"nb_sides\":5},\"image\":{\"src\":\"http:\/\/wiki.lexisnexis.com\/academic\/images\/f\/fb\/Itunes_podcast_icon_300.jpg\",\"width\":100,\"height\":100}},\"opacity\":{\"value\":0.5,\"random\":false,\"anim\":{\"enable\":false,\"speed\":1,\"opacity_min\":0.1,\"sync\":false}},\"size\":{\"value\":4,\"random\":true,\"anim\":{\"enable\":false,\"speed\":40,\"size_min\":0.1,\"sync\":false}},\"line_linked\":{\"enable\":false,\"distance\":150,\"color\":\"#ffffff\",\"opacity\":0.4,\"width\":1},\"move\":{\"enable\":true,\"speed\":14,\"direction\":\"left\",\"random\":false,\"straight\":true,\"out_mode\":\"out\",\"bounce\":false,\"attract\":{\"enable\":false,\"rotateX\":600,\"rotateY\":1200}}},\"interactivity\":{\"detect_on\":\"canvas\",\"events\":{\"onhover\":{\"enable\":false,\"mode\":\"grab\"},\"onclick\":{\"enable\":true,\"mode\":\"repulse\"},\"resize\":true},\"modes\":{\"grab\":{\"distance\":200,\"line_linked\":{\"opacity\":1}},\"bubble\":{\"distance\":400,\"size\":40,\"duration\":2,\"opacity\":8,\"speed\":3},\"repulse\":{\"distance\":200,\"duration\":0.4},\"push\":{\"particles_nb\":4},\"remove\":{\"particles_nb\":2}}},\"retina_detect\":true}"},"eael_login_nonce":"3a24350a5c","eael_register_nonce":"ad52da8a4a","eael_lostpassword_nonce":"38b3698115","eael_resetpassword_nonce":"6bc1c7981d"};
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/essential-addons-for-elementor-lite/assets/front-end/js/view/general.min.js?ver=5.9.7" id="eael-general-js"></script>
+<script defer type="text/javascript" src="https://stats.wp.com/e-202405.js" id="jetpack-stats-js"></script>
+<script type="text/javascript" id="jetpack-stats-js-after">
+/* <![CDATA[ */
+_stq = window._stq || [];
+_stq.push([ "view", JSON.parse("{\"v\":\"ext\",\"blog\":\"168708355\",\"post\":\"84\",\"tz\":\"-5\",\"srv\":\"clecpc.org\",\"hp\":\"atomic\",\"ac\":\"2\",\"amp\":\"0\",\"j\":\"1:13.1-a.7\"}") ]);
+_stq.push([ "clickTrackerInit", "168708355", "84" ]);
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://c0.wp.com/c/6.4.2/wp-includes/js/hoverIntent.min.js" id="hoverIntent-js"></script>
+<script type="text/javascript" id="megamenu-js-extra">
+/* <![CDATA[ */
+var megamenu = {"timeout":"300","interval":"100"};
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/megamenu/js/maxmegamenu.js?ver=3.3" id="megamenu-js"></script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/google-calendar-events/assets/generated/vendor/imagesloaded.pkgd.min.js?ver=3.3.0" id="simplecalendar-imagesloaded-js"></script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/elementor/assets/js/webpack.runtime.min.js?ver=3.19.0" id="elementor-webpack-runtime-js"></script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/elementor/assets/js/frontend-modules.min.js?ver=3.19.0" id="elementor-frontend-modules-js"></script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/elementor/assets/lib/waypoints/waypoints.min.js?ver=4.0.2" id="elementor-waypoints-js"></script>
+<script type="text/javascript" id="elementor-frontend-js-before">
+/* <![CDATA[ */
+var elementorFrontendConfig = {"environmentMode":{"edit":false,"wpPreview":false,"isScriptDebug":false},"i18n":{"shareOnFacebook":"Share on Facebook","shareOnTwitter":"Share on Twitter","pinIt":"Pin it","download":"Download","downloadImage":"Download image","fullscreen":"Fullscreen","zoom":"Zoom","share":"Share","playVideo":"Play Video","previous":"Previous","next":"Next","close":"Close","a11yCarouselWrapperAriaLabel":"Carousel | Horizontal scrolling: Arrow Left & Right","a11yCarouselPrevSlideMessage":"Previous slide","a11yCarouselNextSlideMessage":"Next slide","a11yCarouselFirstSlideMessage":"This is the first slide","a11yCarouselLastSlideMessage":"This is the last slide","a11yCarouselPaginationBulletMessage":"Go to slide"},"is_rtl":false,"breakpoints":{"xs":0,"sm":480,"md":768,"lg":1025,"xl":1440,"xxl":1600},"responsive":{"breakpoints":{"mobile":{"label":"Mobile Portrait","value":767,"default_value":767,"direction":"max","is_enabled":true},"mobile_extra":{"label":"Mobile Landscape","value":880,"default_value":880,"direction":"max","is_enabled":false},"tablet":{"label":"Tablet Portrait","value":1024,"default_value":1024,"direction":"max","is_enabled":true},"tablet_extra":{"label":"Tablet Landscape","value":1200,"default_value":1200,"direction":"max","is_enabled":false},"laptop":{"label":"Laptop","value":1366,"default_value":1366,"direction":"max","is_enabled":false},"widescreen":{"label":"Widescreen","value":2400,"default_value":2400,"direction":"min","is_enabled":false}}},"version":"3.19.0","is_static":false,"experimentalFeatures":{"e_optimized_assets_loading":true,"additional_custom_breakpoints":true,"block_editor_assets_optimize":true,"ai-layout":true,"landing-pages":true,"e_image_loading_optimization":true,"e_global_styleguide":true},"urls":{"assets":"https:\/\/clecpc.org\/wp-content\/plugins\/elementor\/assets\/"},"swiperClass":"swiper-container","settings":{"page":[],"editorPreferences":[]},"kit":{"active_breakpoints":["viewport_mobile","viewport_tablet"],"global_image_lightbox":"yes","lightbox_enable_counter":"yes","lightbox_enable_fullscreen":"yes","lightbox_enable_zoom":"yes","lightbox_enable_share":"yes","lightbox_title_src":"title","lightbox_description_src":"description"},"post":{"id":84,"title":"Calendar%20-%20Cleveland%20Community%20Police%20Commission","excerpt":"Your involvement is needed to shape how policing looks in Cleveland. Participate in CPC and community meetings to share your thoughts about policing and related issues in your community.","featuredImage":"https:\/\/i0.wp.com\/clecpc.org\/wp-content\/uploads\/Header-Image-Calendar.jpg?fit=1024%2C348&ssl=1"}};
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/elementor/assets/js/frontend.min.js?ver=3.19.0" id="elementor-frontend-js"></script>
+<script type="text/javascript" src="https://c0.wp.com/c/6.4.2/wp-includes/js/underscore.min.js" id="underscore-js"></script>
+<script type="text/javascript" id="wp-util-js-extra">
+/* <![CDATA[ */
+var _wpUtilSettings = {"ajax":{"url":"\/wp-admin\/admin-ajax.php"}};
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://c0.wp.com/c/6.4.2/wp-includes/js/wp-util.min.js" id="wp-util-js"></script>
+<script type="text/javascript" id="wpforms-elementor-js-extra">
+/* <![CDATA[ */
+var wpformsElementorVars = {"captcha_provider":"recaptcha","recaptcha_type":"v2"};
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/wpforms-lite/assets/js/integrations/elementor/frontend.min.js?ver=1.8.6.3" id="wpforms-elementor-js"></script>
+
+
+  
+  <style>
+      </style>
+
+  <script>
+    var post_grid_vars = {"siteUrl":"https:\/\/clecpc.org"}  </script>
+  
+
+  <style>
+      </style>
+
+  <style>
+      </style>
+
+            <script type="application/ld+json">
+            {
+                "@context": "http://schema.org",
+                "@type": "Event",
+                "eventStatus": "https://schema.org/EventScheduled",
+                "startDate": "2024-02-01",
+                "endDate": "2024-02-01",
+                "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+                "location":
+                {
+                    "@type": "Place",
+                                        "name": "CPC Offices",
+                    "image": "",
+                    "address": "3631 Perkins Ave., Cleveland 4th Fl"
+                                    },
+                "organizer":
+                {
+                    "@type": "Person",
+                    "name": "Cleveland Community Police Commission",
+                    "url": "http://clecpc.org"
+                },
+                "offers":
+                {
+                    "url": "https://clecpc.org/events/police-discipline-work-group/",
+                    "price": "",
+                    "priceCurrency": "USD",
+                    "availability": "https://schema.org/InStock",
+                    "validFrom": "2024-02-01T00:00"
+                },
+                "performer": "",
+                "description": "Work Group to review the police disciplinary policy, disciplinary matrix and police manual of rules ",
+                "image": "",
+                "name": "Police Discipline Work Group",
+                "url": "https://clecpc.org/events/police-discipline-work-group/"
+            }
+            </script>
+            
+
+            <script type="application/ld+json">
+            {
+                "@context": "http://schema.org",
+                "@type": "Event",
+                "eventStatus": "https://schema.org/EventScheduled",
+                "startDate": "2024-02-07",
+                "endDate": "2024-02-07",
+                "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+                "location":
+                {
+                    "@type": "Place",
+                                        "name": "CPC Office",
+                    "image": "",
+                    "address": "3631 Perkins Avenue, 4th Floor, Cleveland, OH 44114"
+                                    },
+                "organizer":
+                {
+                    "@type": "Person",
+                    "name": "Cleveland Community Police Commission",
+                    "url": "http://clecpc.org"
+                },
+                "offers":
+                {
+                    "url": "https://clecpc.org/events/rules-committee-1st-wednesday/",
+                    "price": "",
+                    "priceCurrency": "USD",
+                    "availability": "https://schema.org/InStock",
+                    "validFrom": "2024-02-07T00:00"
+                },
+                "performer": "",
+                "description": "     The Rules Committee Meeting for January has been cancelled/ Postponed. A new date will be posted when the committee reschedules.     Rules CommitteeMeeting Dates: Every 1st Wednesday of the MonthTime: 6:00pm - 8:00pmLocation: CPC Office, 3631 Perkins Avenue, 4th Floor, Cleveland, OH 44114Chair: Teri Wang Members: Shandra Benito, Charles Donaldson, Piet van Lier, Sharena ZayedThe full meeting agenda will be posted to the CPC’s website prior to the meeting. The public is invited to view the meeting live on the Community Police Commission\'s YouTube channel: www.youtube.com/@ClevelandCPC     ",
+                "image": "",
+                "name": "Cancelled: Rules Committee Meeting January 3rd",
+                "url": "https://clecpc.org/events/rules-committee-1st-wednesday/"
+            }
+            </script>
+            
+
+            <script type="application/ld+json">
+            {
+                "@context": "http://schema.org",
+                "@type": "Event",
+                "eventStatus": "https://schema.org/EventScheduled",
+                "startDate": "2024-02-08",
+                "endDate": "2024-02-08",
+                "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+                "location":
+                {
+                    "@type": "Place",
+                                        "name": "CPC Office",
+                    "image": "",
+                    "address": "3631 Perkins Avenue, 4th Floor, Cleveland, OH 44114"
+                                    },
+                "organizer":
+                {
+                    "@type": "Person",
+                    "name": "Cleveland Community Police Commission",
+                    "url": "http://clecpc.org"
+                },
+                "offers":
+                {
+                    "url": "https://clecpc.org/events/cpc-behavioral-health-crisis-intervention-work-group/",
+                    "price": "",
+                    "priceCurrency": "USD",
+                    "availability": "https://schema.org/InStock",
+                    "validFrom": "2024-02-08T00:00"
+                },
+                "performer": "",
+                "description": " CPC Behavioral Health &amp; Crisis Intervention Work Group. Chair: Commissioner Shandra Benito     January 11th Meeting has been cancelled. Regular meeting schedule:  2nd Thursday of the Month6:00pm - 8:00pm In Person or at the CPC Office 3631 Perkins Avenue, 4th Floor or Virtually on Microsoft Teams.     Work groups are a group of individuals and subject matter experts that work together on a particular project. Work groups are established by a committee and are open to the public.     ",
+                "image": "",
+                "name": "Behavioral Health &amp; Crisis Intervention Work Group- January 11th Cancelled",
+                "url": "https://clecpc.org/events/cpc-behavioral-health-crisis-intervention-work-group/"
+            }
+            </script>
+            
+
+            <script type="application/ld+json">
+            {
+                "@context": "http://schema.org",
+                "@type": "Event",
+                "eventStatus": "https://schema.org/EventScheduled",
+                "startDate": "2024-02-08",
+                "endDate": "2024-02-08",
+                "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+                "location":
+                {
+                    "@type": "Place",
+                                        "name": "CPC Offices",
+                    "image": "",
+                    "address": "3631 Perkins Ave., Cleveland 4th Fl"
+                                    },
+                "organizer":
+                {
+                    "@type": "Person",
+                    "name": "Cleveland Community Police Commission",
+                    "url": "http://clecpc.org"
+                },
+                "offers":
+                {
+                    "url": "https://clecpc.org/events/police-discipline-work-group/",
+                    "price": "",
+                    "priceCurrency": "USD",
+                    "availability": "https://schema.org/InStock",
+                    "validFrom": "2024-02-08T00:00"
+                },
+                "performer": "",
+                "description": "Work Group to review the police disciplinary policy, disciplinary matrix and police manual of rules ",
+                "image": "",
+                "name": "Police Discipline Work Group",
+                "url": "https://clecpc.org/events/police-discipline-work-group/"
+            }
+            </script>
+            
+
+            <script type="application/ld+json">
+            {
+                "@context": "http://schema.org",
+                "@type": "Event",
+                "eventStatus": "https://schema.org/EventScheduled",
+                "startDate": "2024-02-14",
+                "endDate": "2024-02-14",
+                "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+                "location":
+                {
+                    "@type": "Place",
+                                        "name": "CPC Office",
+                    "image": "",
+                    "address": "3631 Perkins Avenue, 4th Floor, Cleveland, OH 44114"
+                                    },
+                "organizer":
+                {
+                    "@type": "Person",
+                    "name": "Cleveland Community Police Commission",
+                    "url": "http://clecpc.org"
+                },
+                "offers":
+                {
+                    "url": "https://clecpc.org/events/police-training-committee/",
+                    "price": "",
+                    "priceCurrency": "USD",
+                    "availability": "https://schema.org/InStock",
+                    "validFrom": "2024-02-14T00:00"
+                },
+                "performer": "",
+                "description": " Meeting Name: CPC Police Training CommitteeDate(s): Every 2nd Wednesday of the MonthTime: 6:00pm - 8:00pmLocation: CPC Office, 3631 Perkins Avenue, 4th Floor, Cleveland, OH 44114Livestream: www.youtube.com/@ClevelandCPCChair: John AdamsMembers: James Chura, Charles Donaldson, Gregory Reaves     ",
+                "image": "",
+                "name": "Police Training Committee &#8211;",
+                "url": "https://clecpc.org/events/police-training-committee/"
+            }
+            </script>
+            
+
+            <script type="application/ld+json">
+            {
+                "@context": "http://schema.org",
+                "@type": "Event",
+                "eventStatus": "https://schema.org/EventScheduled",
+                "startDate": "2024-02-15",
+                "endDate": "2024-02-15",
+                "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+                "location":
+                {
+                    "@type": "Place",
+                                        "name": "CPC Offices",
+                    "image": "",
+                    "address": "3631 Perkins Ave., Cleveland 4th Fl"
+                                    },
+                "organizer":
+                {
+                    "@type": "Person",
+                    "name": "Cleveland Community Police Commission",
+                    "url": "http://clecpc.org"
+                },
+                "offers":
+                {
+                    "url": "https://clecpc.org/events/police-discipline-work-group/",
+                    "price": "",
+                    "priceCurrency": "USD",
+                    "availability": "https://schema.org/InStock",
+                    "validFrom": "2024-02-15T00:00"
+                },
+                "performer": "",
+                "description": "Work Group to review the police disciplinary policy, disciplinary matrix and police manual of rules ",
+                "image": "",
+                "name": "Police Discipline Work Group",
+                "url": "https://clecpc.org/events/police-discipline-work-group/"
+            }
+            </script>
+            
+
+<script>
+jQuery(document).ready(function()
+{
+    jQuery("#mec_skin_13107").mecGridView(
+    {
+        id: "13107",
+        start_date: "2024-01-29",
+        end_date: "2024-02-15",
+		offset: "1",
+		limit: "6",
+        atts: "atts%5Blabel%5D=&atts%5Bcategory%5D=689310766%2C689310747%2C689310748%2C689310776&atts%5Blocation%5D=&atts%5Borganizer%5D=&atts%5Btag%5D=&atts%5Bauthor%5D=&atts%5Bskin%5D=grid&atts%5Bshow_past_events%5D=0&atts%5Bsk-options%5D%5Blist%5D%5Bstyle%5D=classic&atts%5Bsk-options%5D%5Blist%5D%5Bstart_date_type%5D=start_current_month&atts%5Bsk-options%5D%5Blist%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Blist%5D%5Bend_date_type%5D=date&atts%5Bsk-options%5D%5Blist%5D%5Bmaximum_date_range%5D=&atts%5Bsk-options%5D%5Blist%5D%5Border_method%5D=ASC&atts%5Bsk-options%5D%5Blist%5D%5Bclassic_date_format1%5D=M+d+Y&atts%5Bsk-options%5D%5Blist%5D%5Bminimal_date_format1%5D=d&atts%5Bsk-options%5D%5Blist%5D%5Bminimal_date_format2%5D=M&atts%5Bsk-options%5D%5Blist%5D%5Bminimal_date_format3%5D=l&atts%5Bsk-options%5D%5Blist%5D%5Bmodern_date_format1%5D=d&atts%5Bsk-options%5D%5Blist%5D%5Bmodern_date_format2%5D=F&atts%5Bsk-options%5D%5Blist%5D%5Bmodern_date_format3%5D=l&atts%5Bsk-options%5D%5Blist%5D%5Bstandard_date_format1%5D=d+M&atts%5Bsk-options%5D%5Blist%5D%5Baccordion_date_format1%5D=d&atts%5Bsk-options%5D%5Blist%5D%5Baccordion_date_format2%5D=F&atts%5Bsk-options%5D%5Blist%5D%5Blimit%5D=5&atts%5Bsk-options%5D%5Blist%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Blist%5D%5Binclude_events_times%5D=1&atts%5Bsk-options%5D%5Blist%5D%5Bload_more_button%5D=1&atts%5Bsk-options%5D%5Blist%5D%5Bmonth_divider%5D=1&atts%5Bsk-options%5D%5Blist%5D%5Bdisplay_label%5D=1&atts%5Bsk-options%5D%5Blist%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Blist%5D%5Bdisplay_categories%5D=0&atts%5Bsk-options%5D%5Blist%5D%5Bdisplay_organizer%5D=0&atts%5Bsk-options%5D%5Blist%5D%5Bset_geolocation%5D=0&atts%5Bsk-options%5D%5Blist%5D%5Bset_geolocation_focus%5D=0&atts%5Bsk-options%5D%5Blist%5D%5Bcustom_data%5D=0&atts%5Bsk-options%5D%5Blist%5D%5Btoggle_month_divider%5D=0&atts%5Bsk-options%5D%5Blist%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Blist%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Bgrid%5D%5Bstyle%5D=minimal&atts%5Bsk-options%5D%5Bgrid%5D%5Bstart_date_type%5D=today&atts%5Bsk-options%5D%5Bgrid%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bgrid%5D%5Bend_date_type%5D=date&atts%5Bsk-options%5D%5Bgrid%5D%5Bmaximum_date_range%5D=&atts%5Bsk-options%5D%5Bgrid%5D%5Border_method%5D=ASC&atts%5Bsk-options%5D%5Bgrid%5D%5Bclassic_date_format1%5D=d+F+Y&atts%5Bsk-options%5D%5Bgrid%5D%5Bclean_date_format1%5D=d&atts%5Bsk-options%5D%5Bgrid%5D%5Bclean_date_format2%5D=F&atts%5Bsk-options%5D%5Bgrid%5D%5Bminimal_date_format1%5D=d&atts%5Bsk-options%5D%5Bgrid%5D%5Bminimal_date_format2%5D=M&atts%5Bsk-options%5D%5Bgrid%5D%5Bmodern_date_format1%5D=d&atts%5Bsk-options%5D%5Bgrid%5D%5Bmodern_date_format2%5D=F&atts%5Bsk-options%5D%5Bgrid%5D%5Bmodern_date_format3%5D=l&atts%5Bsk-options%5D%5Bgrid%5D%5Bsimple_date_format1%5D=M+d+Y&atts%5Bsk-options%5D%5Bgrid%5D%5Bcolorful_date_format1%5D=d&atts%5Bsk-options%5D%5Bgrid%5D%5Bcolorful_date_format2%5D=F&atts%5Bsk-options%5D%5Bgrid%5D%5Bcolorful_date_format3%5D=l&atts%5Bsk-options%5D%5Bgrid%5D%5Bnovel_date_format1%5D=d+F+Y&atts%5Bsk-options%5D%5Bgrid%5D%5Bcount%5D=2&atts%5Bsk-options%5D%5Bgrid%5D%5Blimit%5D=6&atts%5Bsk-options%5D%5Bgrid%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bgrid%5D%5Binclude_events_times%5D=1&atts%5Bsk-options%5D%5Bgrid%5D%5Bload_more_button%5D=1&atts%5Bsk-options%5D%5Bgrid%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bgrid%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bgrid%5D%5Bdisplay_categories%5D=0&atts%5Bsk-options%5D%5Bgrid%5D%5Bdisplay_organizer%5D=0&atts%5Bsk-options%5D%5Bgrid%5D%5Bset_geolocation%5D=0&atts%5Bsk-options%5D%5Bgrid%5D%5Bset_geolocation_focus%5D=0&atts%5Bsk-options%5D%5Bgrid%5D%5Bcustom_data%5D=0&atts%5Bsk-options%5D%5Bgrid%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Bgrid%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Bagenda%5D%5Bstyle%5D=clean&atts%5Bsk-options%5D%5Bagenda%5D%5Bstart_date_type%5D=today&atts%5Bsk-options%5D%5Bagenda%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bagenda%5D%5Bend_date_type%5D=date&atts%5Bsk-options%5D%5Bagenda%5D%5Bmaximum_date_range%5D=&atts%5Bsk-options%5D%5Bagenda%5D%5Border_method%5D=ASC&atts%5Bsk-options%5D%5Bagenda%5D%5Bclean_date_format1%5D=l&atts%5Bsk-options%5D%5Bagenda%5D%5Bclean_date_format2%5D=F+j&atts%5Bsk-options%5D%5Bagenda%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Bagenda%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bagenda%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bagenda%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bagenda%5D%5Bload_more_button%5D=1&atts%5Bsk-options%5D%5Bagenda%5D%5Bmonth_divider%5D=0&atts%5Bsk-options%5D%5Bagenda%5D%5Bcustom_data%5D=0&atts%5Bsk-options%5D%5Bagenda%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Bagenda%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bstart_date_type%5D=today&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bdefault_view%5D=list&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bmonthly_style%5D=clean&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Blist%5D=1&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bdate_format_list%5D=d+M&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bend_date_type_list%5D=date&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bmaximum_date_range_list%5D=&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Border_method_list%5D=ASC&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bgrid%5D=0&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bend_date_type_grid%5D=date&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bmaximum_date_range_grid%5D=&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Border_method_grid%5D=ASC&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Btile%5D=0&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Byearly%5D=0&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bdate_format_yearly_1%5D=l&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bdate_format_yearly_2%5D=F+j&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bmonthly%5D=1&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bactivate_first_date%5D=0&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bactivate_current_day%5D=1&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bweekly%5D=1&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bdaily%5D=1&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bdisplay_price%5D=0&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bcustom_data%5D=0&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Byearly_view%5D%5Bstyle%5D=modern&atts%5Bsk-options%5D%5Byearly_view%5D%5Bstart_date_type%5D=start_current_year&atts%5Bsk-options%5D%5Byearly_view%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Byearly_view%5D%5Bmodern_date_format1%5D=l&atts%5Bsk-options%5D%5Byearly_view%5D%5Bmodern_date_format2%5D=F+j&atts%5Bsk-options%5D%5Byearly_view%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Byearly_view%5D%5Bmonths%5D%5B1%5D=1&atts%5Bsk-options%5D%5Byearly_view%5D%5Bmonths%5D%5B2%5D=1&atts%5Bsk-options%5D%5Byearly_view%5D%5Bmonths%5D%5B3%5D=1&atts%5Bsk-options%5D%5Byearly_view%5D%5Bmonths%5D%5B4%5D=1&atts%5Bsk-options%5D%5Byearly_view%5D%5Bmonths%5D%5B5%5D=1&atts%5Bsk-options%5D%5Byearly_view%5D%5Bmonths%5D%5B6%5D=1&atts%5Bsk-options%5D%5Byearly_view%5D%5Bmonths%5D%5B7%5D=1&atts%5Bsk-options%5D%5Byearly_view%5D%5Bmonths%5D%5B8%5D=1&atts%5Bsk-options%5D%5Byearly_view%5D%5Bmonths%5D%5B9%5D=1&atts%5Bsk-options%5D%5Byearly_view%5D%5Bmonths%5D%5B10%5D=1&atts%5Bsk-options%5D%5Byearly_view%5D%5Bmonths%5D%5B11%5D=1&atts%5Bsk-options%5D%5Byearly_view%5D%5Bmonths%5D%5B12%5D=1&atts%5Bsk-options%5D%5Byearly_view%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Byearly_view%5D%5Bnext_previous_button%5D=1&atts%5Bsk-options%5D%5Byearly_view%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Byearly_view%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Byearly_view%5D%5Bcustom_data%5D=0&atts%5Bsk-options%5D%5Byearly_view%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Byearly_view%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bstyle%5D=classic&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bstart_date_type%5D=start_current_month&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bnext_previous_button%5D=1&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bactivate_first_date%5D=0&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bactivate_current_day%5D=1&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bdisplay_all%5D=0&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bcustom_data%5D=0&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bdetailed_time%5D=0&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Bmap%5D%5Bstart_date_type%5D=today&atts%5Bsk-options%5D%5Bmap%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bmap%5D%5Blimit%5D=200&atts%5Bsk-options%5D%5Bmap%5D%5Bgeolocation%5D=0&atts%5Bsk-options%5D%5Bmap%5D%5Bgeolocation_focus%5D=0&atts%5Bsk-options%5D%5Bdaily_view%5D%5Bstart_date_type%5D=today&atts%5Bsk-options%5D%5Bdaily_view%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bdaily_view%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Bdaily_view%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bdaily_view%5D%5Bnext_previous_button%5D=1&atts%5Bsk-options%5D%5Bdaily_view%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bdaily_view%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bdaily_view%5D%5Bdisplay_categories%5D=0&atts%5Bsk-options%5D%5Bdaily_view%5D%5Bdisplay_organizer%5D=0&atts%5Bsk-options%5D%5Bdaily_view%5D%5Bcustom_data%5D=0&atts%5Bsk-options%5D%5Bdaily_view%5D%5Bdetailed_time%5D=0&atts%5Bsk-options%5D%5Bdaily_view%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Bdaily_view%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Bweekly_view%5D%5Bstart_date_type%5D=start_current_month&atts%5Bsk-options%5D%5Bweekly_view%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bweekly_view%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Bweekly_view%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bweekly_view%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bweekly_view%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bweekly_view%5D%5Bdisplay_categories%5D=0&atts%5Bsk-options%5D%5Bweekly_view%5D%5Bdisplay_organizer%5D=0&atts%5Bsk-options%5D%5Bweekly_view%5D%5Bnext_previous_button%5D=1&atts%5Bsk-options%5D%5Bweekly_view%5D%5Bcustom_data%5D=0&atts%5Bsk-options%5D%5Bweekly_view%5D%5Bdetailed_time%5D=0&atts%5Bsk-options%5D%5Bweekly_view%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Bweekly_view%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Btimetable%5D%5Bstyle%5D=modern&atts%5Bsk-options%5D%5Btimetable%5D%5Bstart_date_type%5D=start_current_week&atts%5Bsk-options%5D%5Btimetable%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Btimetable%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Btimetable%5D%5Bnumber_of_days_modern%5D=7&atts%5Bsk-options%5D%5Btimetable%5D%5Bnumber_of_days%5D=5&atts%5Bsk-options%5D%5Btimetable%5D%5Bweek_start%5D=-1&atts%5Bsk-options%5D%5Btimetable%5D%5Bstart_time%5D=1&atts%5Bsk-options%5D%5Btimetable%5D%5Bend_time%5D=13&atts%5Bsk-options%5D%5Btimetable%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Btimetable%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Btimetable%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Btimetable%5D%5Bnext_previous_button%5D=1&atts%5Bsk-options%5D%5Btimetable%5D%5Bcustom_data%5D=0&atts%5Bsk-options%5D%5Btimetable%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Btimetable%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Bstart_date_type%5D=today&atts%5Bsk-options%5D%5Bmasonry%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bmasonry%5D%5Bend_date_type%5D=date&atts%5Bsk-options%5D%5Bmasonry%5D%5Bmaximum_date_range%5D=&atts%5Bsk-options%5D%5Bmasonry%5D%5Border_method%5D=ASC&atts%5Bsk-options%5D%5Bmasonry%5D%5Bdate_format1%5D=j&atts%5Bsk-options%5D%5Bmasonry%5D%5Bdate_format2%5D=F&atts%5Bsk-options%5D%5Bmasonry%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Bmasonry%5D%5Bfilter_by%5D=&atts%5Bsk-options%5D%5Bmasonry%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Bdisplay_categories%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Bdisplay_organizer%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Bfit_to_row%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Bmasonry_like_grid%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Bload_more_button%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Bcustom_data%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Bcover%5D%5Bstyle%5D=classic&atts%5Bsk-options%5D%5Bcover%5D%5Bdate_format_clean1%5D=d&atts%5Bsk-options%5D%5Bcover%5D%5Bdate_format_clean2%5D=M&atts%5Bsk-options%5D%5Bcover%5D%5Bdate_format_clean3%5D=Y&atts%5Bsk-options%5D%5Bcover%5D%5Bdate_format_classic1%5D=F+d&atts%5Bsk-options%5D%5Bcover%5D%5Bdate_format_classic2%5D=l&atts%5Bsk-options%5D%5Bcover%5D%5Bdate_format_modern1%5D=l%2C+F+d+Y&atts%5Bsk-options%5D%5Bcover%5D%5Bevent_id%5D=3004&atts%5Bsk-options%5D%5Bcover%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bcover%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bcover%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bcountdown%5D%5Bstyle%5D=style1&atts%5Bsk-options%5D%5Bcountdown%5D%5Bdate_format_style11%5D=j+F+Y&atts%5Bsk-options%5D%5Bcountdown%5D%5Bdate_format_style21%5D=j+F+Y&atts%5Bsk-options%5D%5Bcountdown%5D%5Bdate_format_style31%5D=j&atts%5Bsk-options%5D%5Bcountdown%5D%5Bdate_format_style32%5D=F&atts%5Bsk-options%5D%5Bcountdown%5D%5Bdate_format_style33%5D=Y&atts%5Bsk-options%5D%5Bcountdown%5D%5Bevent_id%5D=-1&atts%5Bsk-options%5D%5Bcountdown%5D%5Bbg_color%5D=%23437df9&atts%5Bsk-options%5D%5Bcountdown%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bcountdown%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bcountdown%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bavailable_spot%5D%5Bdate_format1%5D=j&atts%5Bsk-options%5D%5Bavailable_spot%5D%5Bdate_format2%5D=F&atts%5Bsk-options%5D%5Bavailable_spot%5D%5Bevent_id%5D=-1&atts%5Bsk-options%5D%5Bavailable_spot%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bavailable_spot%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bavailable_spot%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bcarousel%5D%5Bstyle%5D=type1&atts%5Bsk-options%5D%5Bcarousel%5D%5Bstart_date_type%5D=today&atts%5Bsk-options%5D%5Bcarousel%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bcarousel%5D%5Btype1_date_format1%5D=d&atts%5Bsk-options%5D%5Bcarousel%5D%5Btype1_date_format2%5D=F&atts%5Bsk-options%5D%5Bcarousel%5D%5Btype1_date_format3%5D=Y&atts%5Bsk-options%5D%5Bcarousel%5D%5Btype2_date_format1%5D=M+d%2C+Y&atts%5Bsk-options%5D%5Bcarousel%5D%5Btype3_date_format1%5D=M+d%2C+Y&atts%5Bsk-options%5D%5Bcarousel%5D%5Bcount%5D=2&atts%5Bsk-options%5D%5Bcarousel%5D%5Bcount_tablet%5D=2&atts%5Bsk-options%5D%5Bcarousel%5D%5Bcount_mobile%5D=1&atts%5Bsk-options%5D%5Bcarousel%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Bcarousel%5D%5Bautoplay_status%5D=1&atts%5Bsk-options%5D%5Bcarousel%5D%5Bautoplay%5D=&atts%5Bsk-options%5D%5Bcarousel%5D%5Bloop_status%5D=1&atts%5Bsk-options%5D%5Bcarousel%5D%5Bcustom_data%5D=0&atts%5Bsk-options%5D%5Bcarousel%5D%5Barchive_link%5D=&atts%5Bsk-options%5D%5Bcarousel%5D%5Bhead_text%5D=&atts%5Bsk-options%5D%5Bcarousel%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bcarousel%5D%5Binclude_events_times%5D=0&atts%5Bsk-options%5D%5Bcarousel%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bcarousel%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bcarousel%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Bcarousel%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Bslider%5D%5Bstyle%5D=t5&atts%5Bsk-options%5D%5Bslider%5D%5Bstart_date_type%5D=today&atts%5Bsk-options%5D%5Bslider%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bslider%5D%5Btype1_date_format1%5D=d&atts%5Bsk-options%5D%5Bslider%5D%5Btype1_date_format2%5D=F&atts%5Bsk-options%5D%5Bslider%5D%5Btype1_date_format3%5D=l&atts%5Bsk-options%5D%5Bslider%5D%5Btype2_date_format1%5D=d&atts%5Bsk-options%5D%5Bslider%5D%5Btype2_date_format2%5D=F&atts%5Bsk-options%5D%5Bslider%5D%5Btype2_date_format3%5D=l&atts%5Bsk-options%5D%5Bslider%5D%5Btype3_date_format1%5D=d&atts%5Bsk-options%5D%5Bslider%5D%5Btype3_date_format2%5D=F&atts%5Bsk-options%5D%5Bslider%5D%5Btype3_date_format3%5D=l&atts%5Bsk-options%5D%5Bslider%5D%5Btype4_date_format1%5D=d&atts%5Bsk-options%5D%5Bslider%5D%5Btype4_date_format2%5D=F&atts%5Bsk-options%5D%5Bslider%5D%5Btype4_date_format3%5D=l&atts%5Bsk-options%5D%5Bslider%5D%5Btype5_date_format1%5D=d&atts%5Bsk-options%5D%5Bslider%5D%5Btype5_date_format2%5D=F&atts%5Bsk-options%5D%5Bslider%5D%5Btype5_date_format3%5D=l&atts%5Bsk-options%5D%5Bslider%5D%5Blimit%5D=7&atts%5Bsk-options%5D%5Bslider%5D%5Bautoplay%5D=&atts%5Bsk-options%5D%5Bslider%5D%5Btransition_time%5D=250&atts%5Bsk-options%5D%5Bslider%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bslider%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bslider%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bslider%5D%5Bcustom_data%5D=0&atts%5Bsk-options%5D%5Btimeline%5D%5Bstart_date_type%5D=today&atts%5Bsk-options%5D%5Btimeline%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Btimeline%5D%5Bend_date_type%5D=date&atts%5Bsk-options%5D%5Btimeline%5D%5Bmaximum_date_range%5D=&atts%5Bsk-options%5D%5Btimeline%5D%5Border_method%5D=ASC&atts%5Bsk-options%5D%5Btimeline%5D%5Bclassic_date_format1%5D=d+F+Y&atts%5Bsk-options%5D%5Btimeline%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Btimeline%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Btimeline%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Btimeline%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Btimeline%5D%5Bdisplay_categories%5D=0&atts%5Bsk-options%5D%5Btimeline%5D%5Bdisplay_organizer%5D=0&atts%5Bsk-options%5D%5Btimeline%5D%5Bload_more_button%5D=1&atts%5Bsk-options%5D%5Btimeline%5D%5Bmonth_divider%5D=0&atts%5Bsk-options%5D%5Btimeline%5D%5Bcustom_data%5D=0&atts%5Bsk-options%5D%5Btimeline%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Btimeline%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Btile%5D%5Bstart_date_type%5D=start_current_month&atts%5Bsk-options%5D%5Btile%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Btile%5D%5Bclean_date_format1%5D=j&atts%5Bsk-options%5D%5Btile%5D%5Bclean_date_format2%5D=M&atts%5Bsk-options%5D%5Btile%5D%5Bcount%5D=4&atts%5Bsk-options%5D%5Btile%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Btile%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Btile%5D%5Bdisplay_categories%5D=0&atts%5Bsk-options%5D%5Btile%5D%5Bdisplay_organizer%5D=0&atts%5Bsk-options%5D%5Btile%5D%5Bnext_previous_button%5D=1&atts%5Bsk-options%5D%5Btile%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Btile%5D%5Bload_more_button%5D=1&atts%5Bsk-options%5D%5Btile%5D%5Bcustom_data%5D=0&atts%5Bsk-options%5D%5Btile%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Btile%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Bgeneral_calendar%5D%5Bstart_date_type%5D=start_current_month&atts%5Bsk-options%5D%5Bgeneral_calendar%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bgeneral_calendar%5D%5Bmore_event%5D=&atts%5Bsk-options%5D%5Bgeneral_calendar%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bgeneral_calendar%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bgeneral_calendar%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bgeneral_calendar%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Bgeneral_calendar%5D%5Bimage_popup%5D=0&atts%5Bsf-options%5D%5Blist%5D%5Bcategory%5D%5Btype%5D=dropdown&atts%5Bsf-options%5D%5Blist%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Blist%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Blist%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Blist%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Blist%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Blist%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Blist%5D%5Baddress_search%5D%5Bplaceholder%5D=&atts%5Bsf-options%5D%5Blist%5D%5Bevent_cost%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Blist%5D%5Bmonth_filter%5D%5Btype%5D=dropdown&atts%5Bsf-options%5D%5Blist%5D%5Btime_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Blist%5D%5Btext_search%5D%5Btype%5D=text_input&atts%5Bsf-options%5D%5Blist%5D%5Btext_search%5D%5Bplaceholder%5D=&atts%5Bsf-options%5D%5Bgrid%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Baddress_search%5D%5Bplaceholder%5D=&atts%5Bsf-options%5D%5Bgrid%5D%5Bevent_cost%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Bmonth_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Btime_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Btext_search%5D%5Bplaceholder%5D=&atts%5Bsf-options%5D%5Bagenda%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Baddress_search%5D%5Bplaceholder%5D=&atts%5Bsf-options%5D%5Bagenda%5D%5Bevent_cost%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Bmonth_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Btime_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Btext_search%5D%5Bplaceholder%5D=&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Baddress_search%5D%5Bplaceholder%5D=&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Bevent_cost%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Bmonth_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Btime_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Btext_search%5D%5Bplaceholder%5D=&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Baddress_search%5D%5Bplaceholder%5D=&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Bevent_cost%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Bmonth_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Btime_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Btext_search%5D%5Bplaceholder%5D=&atts%5Bsf-options%5D%5Byearly_view%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Baddress_search%5D%5Bplaceholder%5D=&atts%5Bsf-options%5D%5Byearly_view%5D%5Bevent_cost%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Bmonth_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Btime_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Btext_search%5D%5Bplaceholder%5D=&atts%5Bsf-options%5D%5Bmap%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmap%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmap%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmap%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmap%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmap%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmap%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmap%5D%5Baddress_search%5D%5Bplaceholder%5D=&atts%5Bsf-options%5D%5Bmap%5D%5Bevent_cost%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmap%5D%5Bmonth_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmap%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmap%5D%5Btext_search%5D%5Bplaceholder%5D=&atts%5Bsf-options%5D%5Bdaily_view%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Baddress_search%5D%5Bplaceholder%5D=&atts%5Bsf-options%5D%5Bdaily_view%5D%5Bevent_cost%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Bmonth_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Btime_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Btext_search%5D%5Bplaceholder%5D=&atts%5Bsf-options%5D%5Bweekly_view%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Baddress_search%5D%5Bplaceholder%5D=&atts%5Bsf-options%5D%5Bweekly_view%5D%5Bevent_cost%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Bmonth_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Btime_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Btext_search%5D%5Bplaceholder%5D=&atts%5Bsf-options%5D%5Btimetable%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Baddress_search%5D%5Bplaceholder%5D=&atts%5Bsf-options%5D%5Btimetable%5D%5Bevent_cost%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Bmonth_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Btime_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Btext_search%5D%5Bplaceholder%5D=&atts%5Bsf-options%5D%5Btile%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Baddress_search%5D%5Bplaceholder%5D=&atts%5Bsf-options%5D%5Btile%5D%5Bevent_cost%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Bmonth_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Btime_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Btext_search%5D%5Bplaceholder%5D=&atts%5Bsf-options%5D%5Bgeneral_calendar%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgeneral_calendar%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgeneral_calendar%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgeneral_calendar%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgeneral_calendar%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgeneral_calendar%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgeneral_calendar%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgeneral_calendar%5D%5Baddress_search%5D%5Bplaceholder%5D=&atts%5Bsf-options%5D%5Bgeneral_calendar%5D%5Bevent_cost%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgeneral_calendar%5D%5Bmonth_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgeneral_calendar%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgeneral_calendar%5D%5Btext_search%5D%5Bplaceholder%5D=&atts%5Bsf_status%5D=1&atts%5B_edit_lock%5D=1690563024%3A174275903&atts%5B_edit_last%5D=174275903&atts%5Bshow_only_past_events%5D=0&atts%5Bshow_only_ongoing_events%5D=0&atts%5Bsf_display_label%5D=0&atts%5Bsf_reset_button%5D=0&atts%5Bsf_refine%5D=0&atts%5Bshow_only_one_occurrence%5D=0&atts%5Bshow_ongoing_events%5D=0&atts%5Bid%5D=13107",
+        ajax_url: "https://clecpc.org/wp-admin/admin-ajax.php",
+        sed_method: "0",
+        image_popup: "0",
+        sf:
+        {
+            container: "#mec_search_form_13107",
+            reset: 0,
+            refine: 0,
+        },
+    });
+});
+</script>
+
+            <script type="application/ld+json">
+            {
+                "@context": "http://schema.org",
+                "@type": "Event",
+                "eventStatus": "https://schema.org/EventScheduled",
+                "startDate": "2024-02-01",
+                "endDate": "2024-02-01",
+                "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+                "location":
+                {
+                    "@type": "Place",
+                                        "name": "St. Ignatius of Antioch",
+                    "image": "",
+                    "address": "10205 Lorain Avenue, Cleveland Ohio 44111"
+                                    },
+                "organizer":
+                {
+                    "@type": "Person",
+                    "name": "Cleveland Division of Police",
+                    "url": "http://www.clevelandohio.gov/CityofCleveland/Home/Government/CityAgencies/PublicSafety/Police"
+                },
+                "offers":
+                {
+                    "url": "https://clecpc.org/events/first-district-dpc-meeting/",
+                    "price": "",
+                    "priceCurrency": "USD",
+                    "availability": "https://schema.org/InStock",
+                    "validFrom": "2024-02-01T00:00"
+                },
+                "performer": "",
+                "description": " Join the First District Police Commander, and Officers at the First District\'s monthly community meetings. Meetings are an opportunity to regularly engage with local CDP officers to identify problems, learn about available resources, and ways to be involved with activities that improve your community.     Meeting Dates: First Thursday of the MonthTime: 6:00pm - 7:00pmLocation: St. Ignatius of Antioch (Cafeteria) 10205 Lorain Ave.    If you have any questions, contact Community Relations Board rep., Tammy Hanna at: (216) 664-6634.         ",
+                "image": "",
+                "name": "1st District &#8211; District Policing Committee Meeting",
+                "url": "https://clecpc.org/events/first-district-dpc-meeting/"
+            }
+            </script>
+            
+
+            <script type="application/ld+json">
+            {
+                "@context": "http://schema.org",
+                "@type": "Event",
+                "eventStatus": "https://schema.org/EventScheduled",
+                "startDate": "2024-02-13",
+                "endDate": "2024-02-13",
+                "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+                "location":
+                {
+                    "@type": "Place",
+                                        "name": "Cleveland City Hall",
+                    "image": "https://clecpc.org/wp-content/uploads/cleveland-city-hall.jpg",
+                    "address": "601 Lakeside Ave E, Cleveland, OH 44114"
+                                    },
+                "organizer":
+                {
+                    "@type": "Person",
+                    "name": "Civilian Police Review Board (CPRB)",
+                    "url": "https://clevelandohio.gov/city-hall/departments/public-safety/divisions/police/police-oversight-accountability"
+                },
+                "offers":
+                {
+                    "url": "https://clecpc.org/events/cprb-civilian-police-review-board-meeting/",
+                    "price": "",
+                    "priceCurrency": "USD",
+                    "availability": "https://schema.org/InStock",
+                    "validFrom": "2024-02-13T00:00"
+                },
+                "performer": "",
+                "description": " Meeting Dates: Second Tuesday of the month Time: 9:00am until all cases are heardLocation: https://cityclevelandoh.webex.com/cityclevelandoh/j.php?MTID=m1d33399dc7219eb4e936d8c4d2e952c5Meetings are streamed live on YouTube: www.youtube.com/@clevelandopsThe CPRB currently meets on the second Tuesday of every month at 9:00am.  Agendas are subject to revision and are handed out the day of the meeting. For more information, call 216-664-2944, or visit the city\'s Police Oversight &amp; Accountability page on the website.         Click the link below for agenda     ",
+                "image": "",
+                "name": "Civilian Police Review Board (CPRB) Meeting",
+                "url": "https://clecpc.org/events/cprb-civilian-police-review-board-meeting/"
+            }
+            </script>
+            
+
+<script>
+jQuery(document).ready(function()
+{
+    jQuery("#mec_skin_1061").mecGridView(
+    {
+        id: "1061",
+        start_date: "2024-01-29",
+        end_date: "2024-02-13",
+		offset: "1",
+		limit: "6",
+        atts: "atts%5Blabel%5D=&atts%5Bcategory%5D=&atts%5Blocation%5D=&atts%5Borganizer%5D=&atts%5Btag%5D=&atts%5Bauthor%5D=&atts%5Bskin%5D=grid&atts%5Bshow_past_events%5D=0&atts%5Bsk-options%5D%5Blist%5D%5Bstyle%5D=classic&atts%5Bsk-options%5D%5Blist%5D%5Bstart_date_type%5D=start_current_month&atts%5Bsk-options%5D%5Blist%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Blist%5D%5Bend_date_type%5D=date&atts%5Bsk-options%5D%5Blist%5D%5Bmaximum_date_range%5D=&atts%5Bsk-options%5D%5Blist%5D%5Bclassic_date_format1%5D=M+d+Y&atts%5Bsk-options%5D%5Blist%5D%5Bminimal_date_format1%5D=d&atts%5Bsk-options%5D%5Blist%5D%5Bminimal_date_format2%5D=M&atts%5Bsk-options%5D%5Blist%5D%5Bminimal_date_format3%5D=l&atts%5Bsk-options%5D%5Blist%5D%5Bmodern_date_format1%5D=d&atts%5Bsk-options%5D%5Blist%5D%5Bmodern_date_format2%5D=F&atts%5Bsk-options%5D%5Blist%5D%5Bmodern_date_format3%5D=l&atts%5Bsk-options%5D%5Blist%5D%5Bstandard_date_format1%5D=d+M&atts%5Bsk-options%5D%5Blist%5D%5Baccordion_date_format1%5D=d&atts%5Bsk-options%5D%5Blist%5D%5Baccordion_date_format2%5D=F&atts%5Bsk-options%5D%5Blist%5D%5Blimit%5D=5&atts%5Bsk-options%5D%5Blist%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Blist%5D%5Binclude_events_times%5D=1&atts%5Bsk-options%5D%5Blist%5D%5Bload_more_button%5D=1&atts%5Bsk-options%5D%5Blist%5D%5Bmonth_divider%5D=1&atts%5Bsk-options%5D%5Blist%5D%5Bdisplay_label%5D=1&atts%5Bsk-options%5D%5Blist%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Blist%5D%5Bdisplay_categories%5D=0&atts%5Bsk-options%5D%5Blist%5D%5Bdisplay_organizer%5D=0&atts%5Bsk-options%5D%5Blist%5D%5Bset_geolocation%5D=0&atts%5Bsk-options%5D%5Blist%5D%5Bset_geolocation_focus%5D=0&atts%5Bsk-options%5D%5Blist%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Blist%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Blist%5D%5Btoggle_month_divider%5D=0&atts%5Bsk-options%5D%5Bgrid%5D%5Bstyle%5D=minimal&atts%5Bsk-options%5D%5Bgrid%5D%5Bstart_date_type%5D=today&atts%5Bsk-options%5D%5Bgrid%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bgrid%5D%5Bend_date_type%5D=date&atts%5Bsk-options%5D%5Bgrid%5D%5Bmaximum_date_range%5D=&atts%5Bsk-options%5D%5Bgrid%5D%5Bclassic_date_format1%5D=d+F+Y&atts%5Bsk-options%5D%5Bgrid%5D%5Bclean_date_format1%5D=d&atts%5Bsk-options%5D%5Bgrid%5D%5Bclean_date_format2%5D=F&atts%5Bsk-options%5D%5Bgrid%5D%5Bminimal_date_format1%5D=d&atts%5Bsk-options%5D%5Bgrid%5D%5Bminimal_date_format2%5D=M&atts%5Bsk-options%5D%5Bgrid%5D%5Bmodern_date_format1%5D=d&atts%5Bsk-options%5D%5Bgrid%5D%5Bmodern_date_format2%5D=F&atts%5Bsk-options%5D%5Bgrid%5D%5Bmodern_date_format3%5D=l&atts%5Bsk-options%5D%5Bgrid%5D%5Bsimple_date_format1%5D=M+d+Y&atts%5Bsk-options%5D%5Bgrid%5D%5Bcolorful_date_format1%5D=d&atts%5Bsk-options%5D%5Bgrid%5D%5Bcolorful_date_format2%5D=F&atts%5Bsk-options%5D%5Bgrid%5D%5Bcolorful_date_format3%5D=l&atts%5Bsk-options%5D%5Bgrid%5D%5Bnovel_date_format1%5D=d+F+Y&atts%5Bsk-options%5D%5Bgrid%5D%5Bcount%5D=2&atts%5Bsk-options%5D%5Bgrid%5D%5Blimit%5D=6&atts%5Bsk-options%5D%5Bgrid%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bgrid%5D%5Binclude_events_times%5D=1&atts%5Bsk-options%5D%5Bgrid%5D%5Bload_more_button%5D=1&atts%5Bsk-options%5D%5Bgrid%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bgrid%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bgrid%5D%5Bdisplay_categories%5D=0&atts%5Bsk-options%5D%5Bgrid%5D%5Bdisplay_organizer%5D=0&atts%5Bsk-options%5D%5Bgrid%5D%5Bset_geolocation%5D=0&atts%5Bsk-options%5D%5Bgrid%5D%5Bset_geolocation_focus%5D=0&atts%5Bsk-options%5D%5Bgrid%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Bgrid%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Bagenda%5D%5Bstyle%5D=clean&atts%5Bsk-options%5D%5Bagenda%5D%5Bstart_date_type%5D=today&atts%5Bsk-options%5D%5Bagenda%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bagenda%5D%5Bend_date_type%5D=date&atts%5Bsk-options%5D%5Bagenda%5D%5Bmaximum_date_range%5D=&atts%5Bsk-options%5D%5Bagenda%5D%5Bclean_date_format1%5D=l&atts%5Bsk-options%5D%5Bagenda%5D%5Bclean_date_format2%5D=F+j&atts%5Bsk-options%5D%5Bagenda%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Bagenda%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bagenda%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bagenda%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bagenda%5D%5Bload_more_button%5D=1&atts%5Bsk-options%5D%5Bagenda%5D%5Bmonth_divider%5D=0&atts%5Bsk-options%5D%5Bagenda%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Bagenda%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bstart_date_type%5D=today&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bdefault_view%5D=list&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bmonthly_style%5D=clean&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Blist%5D=1&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bdate_format_list%5D=d+M&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bgrid%5D=0&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Btile%5D=0&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Byearly%5D=0&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bdate_format_yearly_1%5D=l&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bdate_format_yearly_2%5D=F+j&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bmonthly%5D=1&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bweekly%5D=1&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bdaily%5D=1&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bdisplay_price%5D=0&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Byearly_view%5D%5Bstyle%5D=modern&atts%5Bsk-options%5D%5Byearly_view%5D%5Bstart_date_type%5D=start_current_year&atts%5Bsk-options%5D%5Byearly_view%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Byearly_view%5D%5Bmodern_date_format1%5D=l&atts%5Bsk-options%5D%5Byearly_view%5D%5Bmodern_date_format2%5D=F+j&atts%5Bsk-options%5D%5Byearly_view%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Byearly_view%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Byearly_view%5D%5Bnext_previous_button%5D=1&atts%5Bsk-options%5D%5Byearly_view%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Byearly_view%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Byearly_view%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Byearly_view%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bstyle%5D=classic&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bstart_date_type%5D=start_current_month&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bnext_previous_button%5D=1&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Bmap%5D%5Bstart_date_type%5D=today&atts%5Bsk-options%5D%5Bmap%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bmap%5D%5Blimit%5D=200&atts%5Bsk-options%5D%5Bmap%5D%5Bgeolocation%5D=0&atts%5Bsk-options%5D%5Bmap%5D%5Bgeolocation_focus%5D=0&atts%5Bsk-options%5D%5Bdaily_view%5D%5Bstart_date_type%5D=today&atts%5Bsk-options%5D%5Bdaily_view%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bdaily_view%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Bdaily_view%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bdaily_view%5D%5Bnext_previous_button%5D=1&atts%5Bsk-options%5D%5Bdaily_view%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bdaily_view%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bdaily_view%5D%5Bdisplay_categories%5D=0&atts%5Bsk-options%5D%5Bdaily_view%5D%5Bdisplay_organizer%5D=0&atts%5Bsk-options%5D%5Bdaily_view%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Bdaily_view%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Bweekly_view%5D%5Bstart_date_type%5D=start_current_month&atts%5Bsk-options%5D%5Bweekly_view%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bweekly_view%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Bweekly_view%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bweekly_view%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bweekly_view%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bweekly_view%5D%5Bdisplay_categories%5D=0&atts%5Bsk-options%5D%5Bweekly_view%5D%5Bdisplay_organizer%5D=0&atts%5Bsk-options%5D%5Bweekly_view%5D%5Bnext_previous_button%5D=1&atts%5Bsk-options%5D%5Bweekly_view%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Bweekly_view%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Btimetable%5D%5Bstyle%5D=modern&atts%5Bsk-options%5D%5Btimetable%5D%5Bstart_date_type%5D=start_current_week&atts%5Bsk-options%5D%5Btimetable%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Btimetable%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Btimetable%5D%5Bnumber_of_days%5D=5&atts%5Bsk-options%5D%5Btimetable%5D%5Bweek_start%5D=-1&atts%5Bsk-options%5D%5Btimetable%5D%5Bstart_time%5D=1&atts%5Bsk-options%5D%5Btimetable%5D%5Bend_time%5D=13&atts%5Bsk-options%5D%5Btimetable%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Btimetable%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Btimetable%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Btimetable%5D%5Bnext_previous_button%5D=1&atts%5Bsk-options%5D%5Btimetable%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Btimetable%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Bstart_date_type%5D=today&atts%5Bsk-options%5D%5Bmasonry%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bmasonry%5D%5Bend_date_type%5D=date&atts%5Bsk-options%5D%5Bmasonry%5D%5Bmaximum_date_range%5D=&atts%5Bsk-options%5D%5Bmasonry%5D%5Bdate_format1%5D=j&atts%5Bsk-options%5D%5Bmasonry%5D%5Bdate_format2%5D=F&atts%5Bsk-options%5D%5Bmasonry%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Bmasonry%5D%5Bfilter_by%5D=&atts%5Bsk-options%5D%5Bmasonry%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Bdisplay_categories%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Bdisplay_organizer%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Bfit_to_row%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Bmasonry_like_grid%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Bload_more_button%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Bcover%5D%5Bstyle%5D=classic&atts%5Bsk-options%5D%5Bcover%5D%5Bdate_format_clean1%5D=d&atts%5Bsk-options%5D%5Bcover%5D%5Bdate_format_clean2%5D=M&atts%5Bsk-options%5D%5Bcover%5D%5Bdate_format_clean3%5D=Y&atts%5Bsk-options%5D%5Bcover%5D%5Bdate_format_classic1%5D=F+d&atts%5Bsk-options%5D%5Bcover%5D%5Bdate_format_classic2%5D=l&atts%5Bsk-options%5D%5Bcover%5D%5Bdate_format_modern1%5D=l%2C+F+d+Y&atts%5Bsk-options%5D%5Bcover%5D%5Bevent_id%5D=3004&atts%5Bsk-options%5D%5Bcover%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bcover%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bcover%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bcountdown%5D%5Bstyle%5D=style1&atts%5Bsk-options%5D%5Bcountdown%5D%5Bdate_format_style11%5D=j+F+Y&atts%5Bsk-options%5D%5Bcountdown%5D%5Bdate_format_style21%5D=j+F+Y&atts%5Bsk-options%5D%5Bcountdown%5D%5Bdate_format_style31%5D=j&atts%5Bsk-options%5D%5Bcountdown%5D%5Bdate_format_style32%5D=F&atts%5Bsk-options%5D%5Bcountdown%5D%5Bdate_format_style33%5D=Y&atts%5Bsk-options%5D%5Bcountdown%5D%5Bevent_id%5D=-1&atts%5Bsk-options%5D%5Bcountdown%5D%5Bbg_color%5D=%23437df9&atts%5Bsk-options%5D%5Bcountdown%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bcountdown%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bcountdown%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bavailable_spot%5D%5Bdate_format1%5D=j&atts%5Bsk-options%5D%5Bavailable_spot%5D%5Bdate_format2%5D=F&atts%5Bsk-options%5D%5Bavailable_spot%5D%5Bevent_id%5D=-1&atts%5Bsk-options%5D%5Bavailable_spot%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bavailable_spot%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bavailable_spot%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bcarousel%5D%5Bstyle%5D=type1&atts%5Bsk-options%5D%5Bcarousel%5D%5Bstart_date_type%5D=today&atts%5Bsk-options%5D%5Bcarousel%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bcarousel%5D%5Btype1_date_format1%5D=d&atts%5Bsk-options%5D%5Bcarousel%5D%5Btype1_date_format2%5D=F&atts%5Bsk-options%5D%5Bcarousel%5D%5Btype1_date_format3%5D=Y&atts%5Bsk-options%5D%5Bcarousel%5D%5Btype2_date_format1%5D=M+d%2C+Y&atts%5Bsk-options%5D%5Bcarousel%5D%5Btype3_date_format1%5D=M+d%2C+Y&atts%5Bsk-options%5D%5Bcarousel%5D%5Bcount%5D=2&atts%5Bsk-options%5D%5Bcarousel%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Bcarousel%5D%5Bautoplay_status%5D=1&atts%5Bsk-options%5D%5Bcarousel%5D%5Bautoplay%5D=&atts%5Bsk-options%5D%5Bcarousel%5D%5Bloop_status%5D=1&atts%5Bsk-options%5D%5Bcarousel%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Bcarousel%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Bcarousel%5D%5Barchive_link%5D=&atts%5Bsk-options%5D%5Bcarousel%5D%5Bhead_text%5D=&atts%5Bsk-options%5D%5Bcarousel%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bcarousel%5D%5Binclude_events_times%5D=0&atts%5Bsk-options%5D%5Bcarousel%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bcarousel%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bslider%5D%5Bstyle%5D=t5&atts%5Bsk-options%5D%5Bslider%5D%5Bstart_date_type%5D=today&atts%5Bsk-options%5D%5Bslider%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bslider%5D%5Btype1_date_format1%5D=d&atts%5Bsk-options%5D%5Bslider%5D%5Btype1_date_format2%5D=F&atts%5Bsk-options%5D%5Bslider%5D%5Btype1_date_format3%5D=l&atts%5Bsk-options%5D%5Bslider%5D%5Btype2_date_format1%5D=d&atts%5Bsk-options%5D%5Bslider%5D%5Btype2_date_format2%5D=F&atts%5Bsk-options%5D%5Bslider%5D%5Btype2_date_format3%5D=l&atts%5Bsk-options%5D%5Bslider%5D%5Btype3_date_format1%5D=d&atts%5Bsk-options%5D%5Bslider%5D%5Btype3_date_format2%5D=F&atts%5Bsk-options%5D%5Bslider%5D%5Btype3_date_format3%5D=l&atts%5Bsk-options%5D%5Bslider%5D%5Btype4_date_format1%5D=d&atts%5Bsk-options%5D%5Bslider%5D%5Btype4_date_format2%5D=F&atts%5Bsk-options%5D%5Bslider%5D%5Btype4_date_format3%5D=l&atts%5Bsk-options%5D%5Bslider%5D%5Btype5_date_format1%5D=d&atts%5Bsk-options%5D%5Bslider%5D%5Btype5_date_format2%5D=F&atts%5Bsk-options%5D%5Bslider%5D%5Btype5_date_format3%5D=l&atts%5Bsk-options%5D%5Bslider%5D%5Blimit%5D=7&atts%5Bsk-options%5D%5Bslider%5D%5Bautoplay%5D=&atts%5Bsk-options%5D%5Bslider%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bslider%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bslider%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Btimeline%5D%5Bstart_date_type%5D=today&atts%5Bsk-options%5D%5Btimeline%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Btimeline%5D%5Bend_date_type%5D=date&atts%5Bsk-options%5D%5Btimeline%5D%5Bmaximum_date_range%5D=&atts%5Bsk-options%5D%5Btimeline%5D%5Bclassic_date_format1%5D=d+F+Y&atts%5Bsk-options%5D%5Btimeline%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Btimeline%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Btimeline%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Btimeline%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Btimeline%5D%5Bdisplay_categories%5D=0&atts%5Bsk-options%5D%5Btimeline%5D%5Bdisplay_organizer%5D=0&atts%5Bsk-options%5D%5Btimeline%5D%5Bload_more_button%5D=1&atts%5Bsk-options%5D%5Btimeline%5D%5Bmonth_divider%5D=0&atts%5Bsk-options%5D%5Btimeline%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Btimeline%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Btile%5D%5Bstart_date_type%5D=start_current_month&atts%5Bsk-options%5D%5Btile%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Btile%5D%5Bclean_date_format1%5D=j&atts%5Bsk-options%5D%5Btile%5D%5Bclean_date_format2%5D=M&atts%5Bsk-options%5D%5Btile%5D%5Bcount%5D=4&atts%5Bsk-options%5D%5Btile%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Btile%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Btile%5D%5Bdisplay_categories%5D=0&atts%5Bsk-options%5D%5Btile%5D%5Bdisplay_organizer%5D=0&atts%5Bsk-options%5D%5Btile%5D%5Bnext_previous_button%5D=1&atts%5Bsk-options%5D%5Btile%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Btile%5D%5Bload_more_button%5D=1&atts%5Bsk-options%5D%5Btile%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Btile%5D%5Bimage_popup%5D=0&atts%5Bsf-options%5D%5Blist%5D%5Bcategory%5D%5Btype%5D=dropdown&atts%5Bsf-options%5D%5Blist%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Blist%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Blist%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Blist%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Blist%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Blist%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Blist%5D%5Bevent_cost%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Blist%5D%5Bmonth_filter%5D%5Btype%5D=dropdown&atts%5Bsf-options%5D%5Blist%5D%5Btime_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Blist%5D%5Btext_search%5D%5Btype%5D=text_input&atts%5Bsf-options%5D%5Bgrid%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Bevent_cost%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Bmonth_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Btime_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Bevent_cost%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Bmonth_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Btime_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Bevent_cost%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Bmonth_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Btime_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Bevent_cost%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Bmonth_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Btime_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Bevent_cost%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Bmonth_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Btime_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmap%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmap%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmap%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmap%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmap%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmap%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmap%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmap%5D%5Bevent_cost%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmap%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Bevent_cost%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Bmonth_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Btime_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Bevent_cost%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Bmonth_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Btime_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Bevent_cost%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Bmonth_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Btime_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Bevent_cost%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Bmonth_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Btime_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf_status%5D=1&atts%5B_edit_lock%5D=1690562274%3A174275903&atts%5B_edit_last%5D=174275903&atts%5Bshow_only_past_events%5D=0&atts%5Bshow_only_ongoing_events%5D=0&atts%5Bid%5D=1061",
+        ajax_url: "https://clecpc.org/wp-admin/admin-ajax.php",
+        sed_method: "0",
+        image_popup: "0",
+        sf:
+        {
+            container: "#mec_search_form_1061",
+            reset: 0,
+            refine: 0,
+        },
+    });
+});
+</script>
+
+<script>
+jQuery(document).ready(function()
+{
+    jQuery("#mec_skin_1057").mecFullCalendar(
+    {
+        id: "1057",
+        atts: "atts%5Blabel%5D=&atts%5Bcategory%5D=&atts%5Blocation%5D=&atts%5Borganizer%5D=&atts%5Btag%5D=&atts%5Bauthor%5D=&atts%5Bskin%5D=full_calendar&atts%5Bshow_past_events%5D=1&atts%5Bsk-options%5D%5Blist%5D%5Bstyle%5D=minimal&atts%5Bsk-options%5D%5Blist%5D%5Bstart_date_type%5D=today&atts%5Bsk-options%5D%5Blist%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Blist%5D%5Bmaximum_date_range%5D=2020-01-31&atts%5Bsk-options%5D%5Blist%5D%5Bclassic_date_format1%5D=M+d+Y&atts%5Bsk-options%5D%5Blist%5D%5Bminimal_date_format1%5D=d&atts%5Bsk-options%5D%5Blist%5D%5Bminimal_date_format2%5D=M&atts%5Bsk-options%5D%5Blist%5D%5Bminimal_date_format3%5D=l&atts%5Bsk-options%5D%5Blist%5D%5Bmodern_date_format1%5D=d&atts%5Bsk-options%5D%5Blist%5D%5Bmodern_date_format2%5D=F&atts%5Bsk-options%5D%5Blist%5D%5Bmodern_date_format3%5D=l&atts%5Bsk-options%5D%5Blist%5D%5Bstandard_date_format1%5D=d+M&atts%5Bsk-options%5D%5Blist%5D%5Baccordion_date_format1%5D=d&atts%5Bsk-options%5D%5Blist%5D%5Baccordion_date_format2%5D=F&atts%5Bsk-options%5D%5Blist%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Blist%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Blist%5D%5Binclude_events_times%5D=0&atts%5Bsk-options%5D%5Blist%5D%5Bload_more_button%5D=1&atts%5Bsk-options%5D%5Blist%5D%5Bmonth_divider%5D=1&atts%5Bsk-options%5D%5Blist%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Blist%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Blist%5D%5Bdisplay_categories%5D=0&atts%5Bsk-options%5D%5Blist%5D%5Bset_geolocation%5D=0&atts%5Bsk-options%5D%5Blist%5D%5Bset_geolocation_focus%5D=0&atts%5Bsk-options%5D%5Blist%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Blist%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Blist%5D%5Btoggle_month_divider%5D=0&atts%5Bsk-options%5D%5Bgrid%5D%5Bstyle%5D=classic&atts%5Bsk-options%5D%5Bgrid%5D%5Bstart_date_type%5D=today&atts%5Bsk-options%5D%5Bgrid%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bgrid%5D%5Bmaximum_date_range%5D=&atts%5Bsk-options%5D%5Bgrid%5D%5Bclassic_date_format1%5D=d+F+Y&atts%5Bsk-options%5D%5Bgrid%5D%5Bclean_date_format1%5D=d&atts%5Bsk-options%5D%5Bgrid%5D%5Bclean_date_format2%5D=F&atts%5Bsk-options%5D%5Bgrid%5D%5Bminimal_date_format1%5D=d&atts%5Bsk-options%5D%5Bgrid%5D%5Bminimal_date_format2%5D=M&atts%5Bsk-options%5D%5Bgrid%5D%5Bmodern_date_format1%5D=d&atts%5Bsk-options%5D%5Bgrid%5D%5Bmodern_date_format2%5D=F&atts%5Bsk-options%5D%5Bgrid%5D%5Bmodern_date_format3%5D=l&atts%5Bsk-options%5D%5Bgrid%5D%5Bsimple_date_format1%5D=M+d+Y&atts%5Bsk-options%5D%5Bgrid%5D%5Bcolorful_date_format1%5D=d&atts%5Bsk-options%5D%5Bgrid%5D%5Bcolorful_date_format2%5D=F&atts%5Bsk-options%5D%5Bgrid%5D%5Bcolorful_date_format3%5D=l&atts%5Bsk-options%5D%5Bgrid%5D%5Bnovel_date_format1%5D=d+F+Y&atts%5Bsk-options%5D%5Bgrid%5D%5Bcount%5D=1&atts%5Bsk-options%5D%5Bgrid%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Bgrid%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bgrid%5D%5Binclude_events_times%5D=0&atts%5Bsk-options%5D%5Bgrid%5D%5Bload_more_button%5D=1&atts%5Bsk-options%5D%5Bgrid%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bgrid%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bgrid%5D%5Bdisplay_categories%5D=0&atts%5Bsk-options%5D%5Bgrid%5D%5Bset_geolocation%5D=0&atts%5Bsk-options%5D%5Bgrid%5D%5Bset_geolocation_focus%5D=0&atts%5Bsk-options%5D%5Bgrid%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Bgrid%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Bagenda%5D%5Bstyle%5D=clean&atts%5Bsk-options%5D%5Bagenda%5D%5Bstart_date_type%5D=today&atts%5Bsk-options%5D%5Bagenda%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bagenda%5D%5Bmaximum_date_range%5D=&atts%5Bsk-options%5D%5Bagenda%5D%5Bclean_date_format1%5D=l&atts%5Bsk-options%5D%5Bagenda%5D%5Bclean_date_format2%5D=F+j&atts%5Bsk-options%5D%5Bagenda%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Bagenda%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bagenda%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bagenda%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bagenda%5D%5Bload_more_button%5D=1&atts%5Bsk-options%5D%5Bagenda%5D%5Bmonth_divider%5D=0&atts%5Bsk-options%5D%5Bagenda%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Bagenda%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bstart_date_type%5D=start_current_month&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bdefault_view%5D=monthly&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bmonthly_style%5D=simple&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Blist%5D=1&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bdate_format_list%5D=d+M&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bgrid%5D=0&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Btile%5D=0&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Byearly%5D=0&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bdate_format_yearly_1%5D=l&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bdate_format_yearly_2%5D=F+j&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bmonthly%5D=1&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bweekly%5D=1&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bdaily%5D=1&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bdisplay_price%5D=0&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Byearly_view%5D%5Bstyle%5D=modern&atts%5Bsk-options%5D%5Byearly_view%5D%5Bstart_date_type%5D=start_current_year&atts%5Bsk-options%5D%5Byearly_view%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Byearly_view%5D%5Bmodern_date_format1%5D=l&atts%5Bsk-options%5D%5Byearly_view%5D%5Bmodern_date_format2%5D=F+j&atts%5Bsk-options%5D%5Byearly_view%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Byearly_view%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Byearly_view%5D%5Bnext_previous_button%5D=1&atts%5Bsk-options%5D%5Byearly_view%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Byearly_view%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Byearly_view%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Byearly_view%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bstyle%5D=classic&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bstart_date_type%5D=start_current_month&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bnext_previous_button%5D=1&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Bmap%5D%5Bstart_date_type%5D=today&atts%5Bsk-options%5D%5Bmap%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bmap%5D%5Blimit%5D=200&atts%5Bsk-options%5D%5Bmap%5D%5Bgeolocation%5D=0&atts%5Bsk-options%5D%5Bmap%5D%5Bgeolocation_focus%5D=0&atts%5Bsk-options%5D%5Bdaily_view%5D%5Bstart_date_type%5D=today&atts%5Bsk-options%5D%5Bdaily_view%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bdaily_view%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Bdaily_view%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bdaily_view%5D%5Bnext_previous_button%5D=1&atts%5Bsk-options%5D%5Bdaily_view%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bdaily_view%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bdaily_view%5D%5Bdisplay_categories%5D=0&atts%5Bsk-options%5D%5Bdaily_view%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Bdaily_view%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Bweekly_view%5D%5Bstart_date_type%5D=start_current_week&atts%5Bsk-options%5D%5Bweekly_view%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bweekly_view%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Bweekly_view%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bweekly_view%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bweekly_view%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bweekly_view%5D%5Bdisplay_categories%5D=0&atts%5Bsk-options%5D%5Bweekly_view%5D%5Bnext_previous_button%5D=1&atts%5Bsk-options%5D%5Bweekly_view%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Bweekly_view%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Btimetable%5D%5Bstyle%5D=modern&atts%5Bsk-options%5D%5Btimetable%5D%5Bstart_date_type%5D=start_current_week&atts%5Bsk-options%5D%5Btimetable%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Btimetable%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Btimetable%5D%5Bnumber_of_days%5D=5&atts%5Bsk-options%5D%5Btimetable%5D%5Bweek_start%5D=-1&atts%5Bsk-options%5D%5Btimetable%5D%5Bstart_time%5D=1&atts%5Bsk-options%5D%5Btimetable%5D%5Bend_time%5D=13&atts%5Bsk-options%5D%5Btimetable%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Btimetable%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Btimetable%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Btimetable%5D%5Bnext_previous_button%5D=1&atts%5Bsk-options%5D%5Btimetable%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Btimetable%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Bstart_date_type%5D=today&atts%5Bsk-options%5D%5Bmasonry%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bmasonry%5D%5Bmaximum_date_range%5D=&atts%5Bsk-options%5D%5Bmasonry%5D%5Bdate_format1%5D=j&atts%5Bsk-options%5D%5Bmasonry%5D%5Bdate_format2%5D=F&atts%5Bsk-options%5D%5Bmasonry%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Bmasonry%5D%5Bfilter_by%5D=&atts%5Bsk-options%5D%5Bmasonry%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Bdisplay_categories%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Bfit_to_row%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Bmasonry_like_grid%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Bload_more_button%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Bcover%5D%5Bstyle%5D=classic&atts%5Bsk-options%5D%5Bcover%5D%5Bdate_format_clean1%5D=d&atts%5Bsk-options%5D%5Bcover%5D%5Bdate_format_clean2%5D=M&atts%5Bsk-options%5D%5Bcover%5D%5Bdate_format_clean3%5D=Y&atts%5Bsk-options%5D%5Bcover%5D%5Bdate_format_classic1%5D=F+d&atts%5Bsk-options%5D%5Bcover%5D%5Bdate_format_classic2%5D=l&atts%5Bsk-options%5D%5Bcover%5D%5Bdate_format_modern1%5D=l%2C+F+d+Y&atts%5Bsk-options%5D%5Bcover%5D%5Bevent_id%5D=3395&atts%5Bsk-options%5D%5Bcover%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bcover%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bcover%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bcountdown%5D%5Bstyle%5D=style1&atts%5Bsk-options%5D%5Bcountdown%5D%5Bdate_format_style11%5D=j+F+Y&atts%5Bsk-options%5D%5Bcountdown%5D%5Bdate_format_style21%5D=j+F+Y&atts%5Bsk-options%5D%5Bcountdown%5D%5Bdate_format_style31%5D=j&atts%5Bsk-options%5D%5Bcountdown%5D%5Bdate_format_style32%5D=F&atts%5Bsk-options%5D%5Bcountdown%5D%5Bdate_format_style33%5D=Y&atts%5Bsk-options%5D%5Bcountdown%5D%5Bevent_id%5D=-1&atts%5Bsk-options%5D%5Bcountdown%5D%5Bbg_color%5D=%23437df9&atts%5Bsk-options%5D%5Bcountdown%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bcountdown%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bcountdown%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bavailable_spot%5D%5Bdate_format1%5D=j&atts%5Bsk-options%5D%5Bavailable_spot%5D%5Bdate_format2%5D=F&atts%5Bsk-options%5D%5Bavailable_spot%5D%5Bevent_id%5D=-1&atts%5Bsk-options%5D%5Bavailable_spot%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bavailable_spot%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bavailable_spot%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bcarousel%5D%5Bstyle%5D=type1&atts%5Bsk-options%5D%5Bcarousel%5D%5Bstart_date_type%5D=today&atts%5Bsk-options%5D%5Bcarousel%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bcarousel%5D%5Btype1_date_format1%5D=d&atts%5Bsk-options%5D%5Bcarousel%5D%5Btype1_date_format2%5D=F&atts%5Bsk-options%5D%5Bcarousel%5D%5Btype1_date_format3%5D=Y&atts%5Bsk-options%5D%5Bcarousel%5D%5Btype2_date_format1%5D=M+d%2C+Y&atts%5Bsk-options%5D%5Bcarousel%5D%5Btype3_date_format1%5D=M+d%2C+Y&atts%5Bsk-options%5D%5Bcarousel%5D%5Bcount%5D=2&atts%5Bsk-options%5D%5Bcarousel%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Bcarousel%5D%5Bautoplay%5D=&atts%5Bsk-options%5D%5Bcarousel%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Bcarousel%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Bcarousel%5D%5Barchive_link%5D=&atts%5Bsk-options%5D%5Bcarousel%5D%5Bhead_text%5D=&atts%5Bsk-options%5D%5Bcarousel%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bcarousel%5D%5Binclude_events_times%5D=0&atts%5Bsk-options%5D%5Bcarousel%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bcarousel%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bslider%5D%5Bstyle%5D=t1&atts%5Bsk-options%5D%5Bslider%5D%5Bstart_date_type%5D=today&atts%5Bsk-options%5D%5Bslider%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bslider%5D%5Btype1_date_format1%5D=d&atts%5Bsk-options%5D%5Bslider%5D%5Btype1_date_format2%5D=F&atts%5Bsk-options%5D%5Bslider%5D%5Btype1_date_format3%5D=l&atts%5Bsk-options%5D%5Bslider%5D%5Btype2_date_format1%5D=d&atts%5Bsk-options%5D%5Bslider%5D%5Btype2_date_format2%5D=F&atts%5Bsk-options%5D%5Bslider%5D%5Btype2_date_format3%5D=l&atts%5Bsk-options%5D%5Bslider%5D%5Btype3_date_format1%5D=d&atts%5Bsk-options%5D%5Bslider%5D%5Btype3_date_format2%5D=F&atts%5Bsk-options%5D%5Bslider%5D%5Btype3_date_format3%5D=l&atts%5Bsk-options%5D%5Bslider%5D%5Btype4_date_format1%5D=d&atts%5Bsk-options%5D%5Bslider%5D%5Btype4_date_format2%5D=F&atts%5Bsk-options%5D%5Bslider%5D%5Btype4_date_format3%5D=l&atts%5Bsk-options%5D%5Bslider%5D%5Btype5_date_format1%5D=d&atts%5Bsk-options%5D%5Bslider%5D%5Btype5_date_format2%5D=F&atts%5Bsk-options%5D%5Bslider%5D%5Btype5_date_format3%5D=l&atts%5Bsk-options%5D%5Bslider%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Bslider%5D%5Bautoplay%5D=&atts%5Bsk-options%5D%5Bslider%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bslider%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bslider%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Btimeline%5D%5Bstart_date_type%5D=today&atts%5Bsk-options%5D%5Btimeline%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Btimeline%5D%5Bmaximum_date_range%5D=&atts%5Bsk-options%5D%5Btimeline%5D%5Bclassic_date_format1%5D=d+F+Y&atts%5Bsk-options%5D%5Btimeline%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Btimeline%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Btimeline%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Btimeline%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Btimeline%5D%5Bdisplay_categories%5D=0&atts%5Bsk-options%5D%5Btimeline%5D%5Bload_more_button%5D=1&atts%5Bsk-options%5D%5Btimeline%5D%5Bmonth_divider%5D=0&atts%5Bsk-options%5D%5Btimeline%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Btimeline%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Btile%5D%5Bstart_date_type%5D=start_current_month&atts%5Bsk-options%5D%5Btile%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Btile%5D%5Bclean_date_format1%5D=j&atts%5Bsk-options%5D%5Btile%5D%5Bclean_date_format2%5D=M&atts%5Bsk-options%5D%5Btile%5D%5Bcount%5D=4&atts%5Bsk-options%5D%5Btile%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Btile%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Btile%5D%5Bdisplay_categories%5D=0&atts%5Bsk-options%5D%5Btile%5D%5Bnext_previous_button%5D=1&atts%5Bsk-options%5D%5Btile%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Btile%5D%5Bload_more_button%5D=1&atts%5Bsk-options%5D%5Btile%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Btile%5D%5Bimage_popup%5D=0&atts%5Bsf-options%5D%5Blist%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Blist%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Blist%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Blist%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Blist%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Blist%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Blist%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Blist%5D%5Bmonth_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Blist%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Bmonth_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Bmonth_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Bcategory%5D%5Btype%5D=dropdown&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Bmonth_filter%5D%5Btype%5D=dropdown&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Bcategory%5D%5Btype%5D=dropdown&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Bmonth_filter%5D%5Btype%5D=dropdown&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Btext_search%5D%5Btype%5D=text_input&atts%5Bsf-options%5D%5Byearly_view%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Bmonth_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmap%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmap%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmap%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmap%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmap%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmap%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmap%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmap%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Bmonth_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Bmonth_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Bmonth_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Bmonth_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf_status%5D=1&atts%5B_edit_lock%5D=1604947977%3A174275903&atts%5B_edit_last%5D=174275903&atts%5Bshow_only_past_events%5D=0&atts%5Bshow_only_ongoing_events%5D=0&atts%5Bid%5D=1057",
+        ajax_url: "https://clecpc.org/wp-admin/admin-ajax.php",
+        sed_method: "0",
+        image_popup: "0",
+        sf:
+        {
+            container: "#mec_search_form_1057",
+            reset: 0,
+            refine: 0,
+        },
+        skin: "monthly",
+    });
+});
+</script>
+
+            <script type="application/ld+json">
+            {
+                "@context": "http://schema.org",
+                "@type": "Event",
+                "eventStatus": "https://schema.org/EventScheduled",
+                "startDate": "2024-01-03",
+                "endDate": "2024-01-03",
+                "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+                "location":
+                {
+                    "@type": "Place",
+                                        "name": "CPC Office",
+                    "image": "",
+                    "address": "3631 Perkins Avenue, 4th Floor, Cleveland, OH 44114"
+                                    },
+                "organizer":
+                {
+                    "@type": "Person",
+                    "name": "Cleveland Community Police Commission",
+                    "url": "http://clecpc.org"
+                },
+                "offers":
+                {
+                    "url": "https://clecpc.org/events/rules-committee-1st-wednesday/",
+                    "price": "",
+                    "priceCurrency": "USD",
+                    "availability": "https://schema.org/InStock",
+                    "validFrom": "2024-01-03T00:00"
+                },
+                "performer": "",
+                "description": "     The Rules Committee Meeting for January has been cancelled/ Postponed. A new date will be posted when the committee reschedules.     Rules CommitteeMeeting Dates: Every 1st Wednesday of the MonthTime: 6:00pm - 8:00pmLocation: CPC Office, 3631 Perkins Avenue, 4th Floor, Cleveland, OH 44114Chair: Teri Wang Members: Shandra Benito, Charles Donaldson, Piet van Lier, Sharena ZayedThe full meeting agenda will be posted to the CPC’s website prior to the meeting. The public is invited to view the meeting live on the Community Police Commission\'s YouTube channel: www.youtube.com/@ClevelandCPC     ",
+                "image": "",
+                "name": "Cancelled: Rules Committee Meeting January 3rd",
+                "url": "https://clecpc.org/events/rules-committee-1st-wednesday/"
+            }
+            </script>
+            
+
+            <script type="application/ld+json">
+            {
+                "@context": "http://schema.org",
+                "@type": "Event",
+                "eventStatus": "https://schema.org/EventScheduled",
+                "startDate": "2024-01-04",
+                "endDate": "2024-01-04",
+                "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+                "location":
+                {
+                    "@type": "Place",
+                                        "name": "St. Ignatius of Antioch",
+                    "image": "",
+                    "address": "10205 Lorain Avenue, Cleveland Ohio 44111"
+                                    },
+                "organizer":
+                {
+                    "@type": "Person",
+                    "name": "Cleveland Division of Police",
+                    "url": "http://www.clevelandohio.gov/CityofCleveland/Home/Government/CityAgencies/PublicSafety/Police"
+                },
+                "offers":
+                {
+                    "url": "https://clecpc.org/events/first-district-dpc-meeting/",
+                    "price": "",
+                    "priceCurrency": "USD",
+                    "availability": "https://schema.org/InStock",
+                    "validFrom": "2024-01-04T00:00"
+                },
+                "performer": "",
+                "description": " Join the First District Police Commander, and Officers at the First District\'s monthly community meetings. Meetings are an opportunity to regularly engage with local CDP officers to identify problems, learn about available resources, and ways to be involved with activities that improve your community.     Meeting Dates: First Thursday of the MonthTime: 6:00pm - 7:00pmLocation: St. Ignatius of Antioch (Cafeteria) 10205 Lorain Ave.    If you have any questions, contact Community Relations Board rep., Tammy Hanna at: (216) 664-6634.         ",
+                "image": "",
+                "name": "1st District &#8211; District Policing Committee Meeting",
+                "url": "https://clecpc.org/events/first-district-dpc-meeting/"
+            }
+            </script>
+            
+
+            <script type="application/ld+json">
+            {
+                "@context": "http://schema.org",
+                "@type": "Event",
+                "eventStatus": "https://schema.org/EventScheduled",
+                "startDate": "2024-01-08",
+                "endDate": "2024-01-08",
+                "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+                "location":
+                {
+                    "@type": "Place",
+                                        "name": "CPC Office",
+                    "image": "",
+                    "address": "3631 Perkins Avenue, 4th Floor, Cleveland, OH 44114"
+                                    },
+                "organizer":
+                {
+                    "@type": "Person",
+                    "name": "Cleveland Community Police Commission",
+                    "url": "http://clecpc.org"
+                },
+                "offers":
+                {
+                    "url": "https://clecpc.org/events/budget-grants-committee-meeting-nov-29-2023-781/",
+                    "price": "",
+                    "priceCurrency": "USD",
+                    "availability": "https://schema.org/InStock",
+                    "validFrom": "2024-01-08T00:00"
+                },
+                "performer": "",
+                "description": " Budget &amp; Grants CommitteeDate: Monday, January 8, 2024Time: 6:30pm - 8:30pmLocation: CPC Office, 3631 Perkins Avenue, 4th Floor, Cleveland, OH 44114Public Livestream: www.youtube.com/@ClevelandCPCJan. 8th Meeting Agenda (pdf)Chair: Dr. John Adams Members: Alana Garrett-Ferguson, Cait Kennedy, Piet van Lier, Sharena ZayedThe public is invited to view the meeting live on the Community Police Commission\'s YouTube channel: www.youtube.com/@ClevelandCPC     ",
+                "image": "",
+                "name": "Budget &amp; Grants Committee Meeting",
+                "url": "https://clecpc.org/events/budget-grants-committee-meeting-nov-29-2023-781/"
+            }
+            </script>
+            
+
+            <script type="application/ld+json">
+            {
+                "@context": "http://schema.org",
+                "@type": "Event",
+                "eventStatus": "https://schema.org/EventScheduled",
+                "startDate": "2024-01-09",
+                "endDate": "2024-01-09",
+                "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+                "location":
+                {
+                    "@type": "Place",
+                                        "name": "Cleveland City Hall",
+                    "image": "https://clecpc.org/wp-content/uploads/cleveland-city-hall.jpg",
+                    "address": "601 Lakeside Ave E, Cleveland, OH 44114"
+                                    },
+                "organizer":
+                {
+                    "@type": "Person",
+                    "name": "Civilian Police Review Board (CPRB)",
+                    "url": "https://clevelandohio.gov/city-hall/departments/public-safety/divisions/police/police-oversight-accountability"
+                },
+                "offers":
+                {
+                    "url": "https://clecpc.org/events/cprb-civilian-police-review-board-meeting/",
+                    "price": "",
+                    "priceCurrency": "USD",
+                    "availability": "https://schema.org/InStock",
+                    "validFrom": "2024-01-09T00:00"
+                },
+                "performer": "",
+                "description": " Meeting Dates: Second Tuesday of the month Time: 9:00am until all cases are heardLocation: https://cityclevelandoh.webex.com/cityclevelandoh/j.php?MTID=m1d33399dc7219eb4e936d8c4d2e952c5Meetings are streamed live on YouTube: www.youtube.com/@clevelandopsThe CPRB currently meets on the second Tuesday of every month at 9:00am.  Agendas are subject to revision and are handed out the day of the meeting. For more information, call 216-664-2944, or visit the city\'s Police Oversight &amp; Accountability page on the website.         Click the link below for agenda     ",
+                "image": "",
+                "name": "Civilian Police Review Board (CPRB) Meeting",
+                "url": "https://clecpc.org/events/cprb-civilian-police-review-board-meeting/"
+            }
+            </script>
+            
+
+            <script type="application/ld+json">
+            {
+                "@context": "http://schema.org",
+                "@type": "Event",
+                "eventStatus": "https://schema.org/EventScheduled",
+                "startDate": "2024-01-09",
+                "endDate": "2024-01-09",
+                "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+                "location":
+                {
+                    "@type": "Place",
+                                        "name": "Bridge CLE",
+                    "image": "",
+                    "address": "3389 Fulton Rd Cleveland, OH 44109"
+                                    },
+                "organizer":
+                {
+                    "@type": "Person",
+                    "name": "Cleveland Division of Police",
+                    "url": "http://www.clevelandohio.gov/CityofCleveland/Home/Government/CityAgencies/PublicSafety/Police"
+                },
+                "offers":
+                {
+                    "url": "https://clecpc.org/events/second-district-dpc-meeting/",
+                    "price": "",
+                    "priceCurrency": "USD",
+                    "availability": "https://schema.org/InStock",
+                    "validFrom": "2024-01-09T00:00"
+                },
+                "performer": "",
+                "description": " Meeting Dates: Second Tuesday of the MonthTime: 6:00pmLocation: Bridge CLE - 3389 Fulton Road    Join the Second District Cleveland Police Commander, Supervisors and Officers at the Second District\'s monthly community meeting. Meetings are an opportunity to regularly engage with local CDP officers to identify problems, learn about available resources, and ways to be involved with activities that improve your community. These meetings are open to the public. All are welcome!      ",
+                "image": "",
+                "name": "2nd District &#8211; District Policing Committee Meeting",
+                "url": "https://clecpc.org/events/second-district-dpc-meeting/"
+            }
+            </script>
+            
+
+            <script type="application/ld+json">
+            {
+                "@context": "http://schema.org",
+                "@type": "Event",
+                "eventStatus": "https://schema.org/EventScheduled",
+                "startDate": "2024-01-10",
+                "endDate": "2024-01-10",
+                "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+                "location":
+                {
+                    "@type": "Place",
+                                        "name": "CPC Office",
+                    "image": "",
+                    "address": "3631 Perkins Avenue, 4th Floor, Cleveland, OH 44114"
+                                    },
+                "organizer":
+                {
+                    "@type": "Person",
+                    "name": "Cleveland Community Police Commission",
+                    "url": "http://clecpc.org"
+                },
+                "offers":
+                {
+                    "url": "https://clecpc.org/events/police-training-committee/",
+                    "price": "",
+                    "priceCurrency": "USD",
+                    "availability": "https://schema.org/InStock",
+                    "validFrom": "2024-01-10T00:00"
+                },
+                "performer": "",
+                "description": " Meeting Name: CPC Police Training CommitteeDate(s): Every 2nd Wednesday of the MonthTime: 6:00pm - 8:00pmLocation: CPC Office, 3631 Perkins Avenue, 4th Floor, Cleveland, OH 44114Livestream: www.youtube.com/@ClevelandCPCChair: John AdamsMembers: James Chura, Charles Donaldson, Gregory Reaves     ",
+                "image": "",
+                "name": "Police Training Committee &#8211;",
+                "url": "https://clecpc.org/events/police-training-committee/"
+            }
+            </script>
+            
+
+            <script type="application/ld+json">
+            {
+                "@context": "http://schema.org",
+                "@type": "Event",
+                "eventStatus": "https://schema.org/EventScheduled",
+                "startDate": "2024-01-11",
+                "endDate": "2024-01-11",
+                "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+                "location":
+                {
+                    "@type": "Place",
+                                        "name": "CPC Office",
+                    "image": "",
+                    "address": "3631 Perkins Avenue, 4th Floor, Cleveland, OH 44114"
+                                    },
+                "organizer":
+                {
+                    "@type": "Person",
+                    "name": "Cleveland Community Police Commission",
+                    "url": "http://clecpc.org"
+                },
+                "offers":
+                {
+                    "url": "https://clecpc.org/events/cpc-behavioral-health-crisis-intervention-work-group/",
+                    "price": "",
+                    "priceCurrency": "USD",
+                    "availability": "https://schema.org/InStock",
+                    "validFrom": "2024-01-11T00:00"
+                },
+                "performer": "",
+                "description": " CPC Behavioral Health &amp; Crisis Intervention Work Group. Chair: Commissioner Shandra Benito     January 11th Meeting has been cancelled. Regular meeting schedule:  2nd Thursday of the Month6:00pm - 8:00pm In Person or at the CPC Office 3631 Perkins Avenue, 4th Floor or Virtually on Microsoft Teams.     Work groups are a group of individuals and subject matter experts that work together on a particular project. Work groups are established by a committee and are open to the public.     ",
+                "image": "",
+                "name": "Behavioral Health &amp; Crisis Intervention Work Group- January 11th Cancelled",
+                "url": "https://clecpc.org/events/cpc-behavioral-health-crisis-intervention-work-group/"
+            }
+            </script>
+            
+
+            <script type="application/ld+json">
+            {
+                "@context": "http://schema.org",
+                "@type": "Event",
+                "eventStatus": "https://schema.org/EventScheduled",
+                "startDate": "2024-01-16",
+                "endDate": "2024-01-16",
+                "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+                "location":
+                {
+                    "@type": "Place",
+                                        "name": "Third District Police Station",
+                    "image": "",
+                    "address": "4501 Chester Avenue, Cleveland Ohio 44103"
+                                    },
+                "organizer":
+                {
+                    "@type": "Person",
+                    "name": "Cleveland Division of Police",
+                    "url": "http://www.clevelandohio.gov/CityofCleveland/Home/Government/CityAgencies/PublicSafety/Police"
+                },
+                "offers":
+                {
+                    "url": "https://clecpc.org/events/3rd-district-dpc-meeting/",
+                    "price": "",
+                    "priceCurrency": "USD",
+                    "availability": "https://schema.org/InStock",
+                    "validFrom": "2024-01-16T00:00"
+                },
+                "performer": "",
+                "description": " Join the Third District Cleveland Police Commander, Supervisors and Officers at the Third District’s monthly community meetings. Meetings are an opportunity to regularly engage with local CDP officers to identify problems, learn about available resources, and ways to be involved with activities that improve your community.     Meeting Dates:&nbsp;Third Tuesday of the MonthTime:&nbsp;6:00pm – 7:00pmLocation:&nbsp;3rd Neighborhood Police District Community Room - 4501 Chester Ave. Cleveland, OH 44103If you have any questions, contact the Third District Commander\'s office at: 216-623-5305     ",
+                "image": "",
+                "name": "3rd District – District Policing Committee Meeting",
+                "url": "https://clecpc.org/events/3rd-district-dpc-meeting/"
+            }
+            </script>
+            
+
+            <script type="application/ld+json">
+            {
+                "@context": "http://schema.org",
+                "@type": "Event",
+                "eventStatus": "https://schema.org/EventScheduled",
+                "startDate": "2024-01-16",
+                "endDate": "2024-01-16",
+                "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+                "location":
+                {
+                    "@type": "Place",
+                                        "name": "CPC Office",
+                    "image": "",
+                    "address": "3631 Perkins Avenue, 4th Floor, Cleveland, OH 44114"
+                                    },
+                "organizer":
+                {
+                    "@type": "Person",
+                    "name": "Cleveland Community Police Commission",
+                    "url": "http://clecpc.org"
+                },
+                "offers":
+                {
+                    "url": "https://clecpc.org/events/police-accountability-committee-sept-19-2023/",
+                    "price": "",
+                    "priceCurrency": "USD",
+                    "availability": "https://schema.org/InStock",
+                    "validFrom": "2024-01-16T00:00"
+                },
+                "performer": "",
+                "description": " Police Accountability CommitteeDate: Tuesday, January 16, 2024Time: 6:00pm - 8:00pmLocation: CPC Office, 3631 Perkins Avenue, 4th Floor, Cleveland, OH 44114Livestream: www.youtube.com/@ClevelandCPCChair: Teri WangMembers: John Adams, Shandra Benito, James Chura, Sharena Zayed     ",
+                "image": "",
+                "name": "Police Accountability Committee",
+                "url": "https://clecpc.org/events/police-accountability-committee-sept-19-2023/"
+            }
+            </script>
+            
+
+            <script type="application/ld+json">
+            {
+                "@context": "http://schema.org",
+                "@type": "Event",
+                "eventStatus": "https://schema.org/EventScheduled",
+                "startDate": "2024-01-17",
+                "endDate": "2024-01-17",
+                "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+                "location":
+                {
+                    "@type": "Place",
+                                        "name": "Five Pointe Community Center",
+                    "image": "",
+                    "address": "813 E. 152nd Street, Cleveland, OH 44110"
+                                    },
+                "organizer":
+                {
+                    "@type": "Person",
+                    "name": "Cleveland Division of Police",
+                    "url": "http://www.clevelandohio.gov/CityofCleveland/Home/Government/CityAgencies/PublicSafety/Police"
+                },
+                "offers":
+                {
+                    "url": "https://clecpc.org/events/fifth-district-dpc-meeting/",
+                    "price": "",
+                    "priceCurrency": "USD",
+                    "availability": "https://schema.org/InStock",
+                    "validFrom": "2024-01-17T00:00"
+                },
+                "performer": "",
+                "description": " Meeting Dates:&nbsp;Third Wednesday of the MonthTime:&nbsp;6:00pm – 7:00pmLocation:&nbsp;Five Pointe Community Center, 813 E. 152nd Street, Cleveland, OH 44110    Join the Fifth District Cleveland Police Commander, Supervisors and Officers at the 5th District\'s monthly community meetings.  This is an opportunity to learn about available resources and ways to be involved with activities that improve your community.      Call the 5th District Commander\'s office with any questions at 216-623-5505 or Theasha Daniely at 216-664-2277.         ",
+                "image": "",
+                "name": "5th District Policing Committee Meeting",
+                "url": "https://clecpc.org/events/fifth-district-dpc-meeting/"
+            }
+            </script>
+            
+
+            <script type="application/ld+json">
+            {
+                "@context": "http://schema.org",
+                "@type": "Event",
+                "eventStatus": "https://schema.org/EventScheduled",
+                "startDate": "2024-01-17",
+                "endDate": "2024-01-17",
+                "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+                "location":
+                {
+                    "@type": "Place",
+                                        "name": "CPC Office",
+                    "image": "",
+                    "address": "3631 Perkins Avenue, 4th Floor, Cleveland, OH 44114"
+                                    },
+                "organizer":
+                {
+                    "@type": "Person",
+                    "name": "Cleveland Community Police Commission",
+                    "url": "http://clecpc.org"
+                },
+                "offers":
+                {
+                    "url": "https://clecpc.org/events/police-policy-committee-meeting/",
+                    "price": "",
+                    "priceCurrency": "USD",
+                    "availability": "https://schema.org/InStock",
+                    "validFrom": "2024-01-17T00:00"
+                },
+                "performer": "",
+                "description": " Police Policy CommitteeDate(s): Every 3rd Wednesday of the MonthTime: 6:00pm - 8:00pmLocation: CPC Office, 3631 Perkins Avenue, 4th Floor, Cleveland, OH 44114Livestream: www.youtube.com/@ClevelandCPC* The November meeting has been moved to Thursday, Nov. 9th * Meeting AgendaChair: Piet van LierMembers: Shandra Benito, Kyle Early, Alana Garrett-Ferguson, Teri Wang     ",
+                "image": "",
+                "name": "Police Policy Committee",
+                "url": "https://clecpc.org/events/police-policy-committee-meeting/"
+            }
+            </script>
+            
+
+            <script type="application/ld+json">
+            {
+                "@context": "http://schema.org",
+                "@type": "Event",
+                "eventStatus": "https://schema.org/EventScheduled",
+                "startDate": "2024-01-24",
+                "endDate": "2024-01-24",
+                "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+                "location":
+                {
+                    "@type": "Place",
+                                        "name": "3631 Perkins Avenue Cleveland, OH 44114",
+                    "image": "",
+                    "address": "3631 Perkins Avenue Cleveland, OH 44114"
+                                    },
+                "organizer":
+                {
+                    "@type": "Person",
+                    "name": "Cleveland Community Police Commission",
+                    "url": "http://clecpc.org"
+                },
+                "offers":
+                {
+                    "url": "https://clecpc.org/events/full-commission-meeting/",
+                    "price": "",
+                    "priceCurrency": "USD",
+                    "availability": "https://schema.org/InStock",
+                    "validFrom": "2024-01-24T00:00"
+                },
+                "performer": "",
+                "description": " Full Commission Meeting January 24th.     6 p.m. - 8:30 p.m.    3631 Perkins Ave. 4th Floor    Agenda to be Determined  ",
+                "image": "",
+                "name": "Full Commission Meeting",
+                "url": "https://clecpc.org/events/full-commission-meeting/"
+            }
+            </script>
+            
+
+            <script type="application/ld+json">
+            {
+                "@context": "http://schema.org",
+                "@type": "Event",
+                "eventStatus": "https://schema.org/EventScheduled",
+                "startDate": "2024-01-24",
+                "endDate": "2024-01-24",
+                "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+                "location":
+                {
+                    "@type": "Place",
+                                        "name": "Covenant Community Church of Cleveland",
+                    "image": "",
+                    "address": "3342 E. 119th Street, Cleveland Ohio 44120"
+                                    },
+                "organizer":
+                {
+                    "@type": "Person",
+                    "name": "Cleveland Division of Police",
+                    "url": "http://www.clevelandohio.gov/CityofCleveland/Home/Government/CityAgencies/PublicSafety/Police"
+                },
+                "offers":
+                {
+                    "url": "https://clecpc.org/events/fourth-district-dpc-meeting/",
+                    "price": "",
+                    "priceCurrency": "USD",
+                    "availability": "https://schema.org/InStock",
+                    "validFrom": "2024-01-24T00:00"
+                },
+                "performer": "",
+                "description": " Join the Fourth District Cleveland Police Commander, Supervisors and Officers at the 4th District’s monthly community meetings. Meetings are an opportunity to regularly engage with local CDP officers to identify problems, learn about available resources, and ways to be involved with activities that improve your community.    Meeting Dates: Fourth Wednesday of the MonthTime: 7:00pm – 8:30pmLocation: Covenant Community Church, 3342 E 119th St, Cleveland, OH 44120* The Oct 25th Meeting is Cancelled * The next meeting date is January 24, 2024. Questions? Please email: bbarnes3@clevelandohio.gov or sharder@clevelandohio.gov.      ",
+                "image": "",
+                "name": "4th District Policing Committee Meeting",
+                "url": "https://clecpc.org/events/fourth-district-dpc-meeting/"
+            }
+            </script>
+            
+
+            <script type="application/ld+json">
+            {
+                "@context": "http://schema.org",
+                "@type": "Event",
+                "eventStatus": "https://schema.org/EventScheduled",
+                "startDate": "2024-01-25",
+                "endDate": "2024-01-25",
+                "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+                "location":
+                {
+                    "@type": "Place",
+                                        "name": "CPC Office",
+                    "image": "",
+                    "address": "3631 Perkins Avenue, 4th Floor, Cleveland, OH 44114"
+                                    },
+                "organizer":
+                {
+                    "@type": "Person",
+                    "name": "Cleveland Community Police Commission",
+                    "url": "http://clecpc.org"
+                },
+                "offers":
+                {
+                    "url": "https://clecpc.org/events/cpc-behavioral-health-crisis-intervention-work-group/",
+                    "price": "",
+                    "priceCurrency": "USD",
+                    "availability": "https://schema.org/InStock",
+                    "validFrom": "2024-01-25T00:00"
+                },
+                "performer": "",
+                "description": " CPC Behavioral Health &amp; Crisis Intervention Work Group. Chair: Commissioner Shandra Benito     January 11th Meeting has been cancelled. Regular meeting schedule:  2nd Thursday of the Month6:00pm - 8:00pm In Person or at the CPC Office 3631 Perkins Avenue, 4th Floor or Virtually on Microsoft Teams.     Work groups are a group of individuals and subject matter experts that work together on a particular project. Work groups are established by a committee and are open to the public.     ",
+                "image": "",
+                "name": "Behavioral Health &amp; Crisis Intervention Work Group- January 11th Cancelled",
+                "url": "https://clecpc.org/events/cpc-behavioral-health-crisis-intervention-work-group/"
+            }
+            </script>
+            
+
+            <script type="application/ld+json">
+            {
+                "@context": "http://schema.org",
+                "@type": "Event",
+                "eventStatus": "https://schema.org/EventScheduled",
+                "startDate": "2024-01-25",
+                "endDate": "2024-01-25",
+                "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+                "location":
+                {
+                    "@type": "Place",
+                                        "name": "CPC Offices",
+                    "image": "",
+                    "address": "3631 Perkins Ave., Cleveland 4th Fl"
+                                    },
+                "organizer":
+                {
+                    "@type": "Person",
+                    "name": "Cleveland Community Police Commission",
+                    "url": "http://clecpc.org"
+                },
+                "offers":
+                {
+                    "url": "https://clecpc.org/events/police-discipline-work-group/",
+                    "price": "",
+                    "priceCurrency": "USD",
+                    "availability": "https://schema.org/InStock",
+                    "validFrom": "2024-01-25T00:00"
+                },
+                "performer": "",
+                "description": "Work Group to review the police disciplinary policy, disciplinary matrix and police manual of rules ",
+                "image": "",
+                "name": "Police Discipline Work Group",
+                "url": "https://clecpc.org/events/police-discipline-work-group/"
+            }
+            </script>
+            
+
+<script>
+jQuery(document).ready(function()
+{
+    jQuery("#mec_monthly_view_month_1057_202401").mecMonthlyView(
+    {
+        id: "1057",
+        today: "20240129",
+        display_all: "0",
+        month_id: "202401",
+        active_month: {year: "2024", month: "01"},
+        next_month: {year: "2024", month: "02"},
+        events_label: "Events",
+        event_label: "Event",
+        month_navigator: 1,
+        atts: "atts%5Blabel%5D=&atts%5Bcategory%5D=&atts%5Blocation%5D=&atts%5Borganizer%5D=&atts%5Btag%5D=&atts%5Bauthor%5D=&atts%5Bskin%5D=full_calendar&atts%5Bshow_past_events%5D=1&atts%5Bsk-options%5D%5Blist%5D%5Bstyle%5D=minimal&atts%5Bsk-options%5D%5Blist%5D%5Bstart_date_type%5D=today&atts%5Bsk-options%5D%5Blist%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Blist%5D%5Bmaximum_date_range%5D=2020-01-31&atts%5Bsk-options%5D%5Blist%5D%5Bclassic_date_format1%5D=M+d+Y&atts%5Bsk-options%5D%5Blist%5D%5Bminimal_date_format1%5D=d&atts%5Bsk-options%5D%5Blist%5D%5Bminimal_date_format2%5D=M&atts%5Bsk-options%5D%5Blist%5D%5Bminimal_date_format3%5D=l&atts%5Bsk-options%5D%5Blist%5D%5Bmodern_date_format1%5D=d&atts%5Bsk-options%5D%5Blist%5D%5Bmodern_date_format2%5D=F&atts%5Bsk-options%5D%5Blist%5D%5Bmodern_date_format3%5D=l&atts%5Bsk-options%5D%5Blist%5D%5Bstandard_date_format1%5D=d+M&atts%5Bsk-options%5D%5Blist%5D%5Baccordion_date_format1%5D=d&atts%5Bsk-options%5D%5Blist%5D%5Baccordion_date_format2%5D=F&atts%5Bsk-options%5D%5Blist%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Blist%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Blist%5D%5Binclude_events_times%5D=0&atts%5Bsk-options%5D%5Blist%5D%5Bload_more_button%5D=1&atts%5Bsk-options%5D%5Blist%5D%5Bmonth_divider%5D=1&atts%5Bsk-options%5D%5Blist%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Blist%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Blist%5D%5Bdisplay_categories%5D=0&atts%5Bsk-options%5D%5Blist%5D%5Bset_geolocation%5D=0&atts%5Bsk-options%5D%5Blist%5D%5Bset_geolocation_focus%5D=0&atts%5Bsk-options%5D%5Blist%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Blist%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Blist%5D%5Btoggle_month_divider%5D=0&atts%5Bsk-options%5D%5Bgrid%5D%5Bstyle%5D=classic&atts%5Bsk-options%5D%5Bgrid%5D%5Bstart_date_type%5D=today&atts%5Bsk-options%5D%5Bgrid%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bgrid%5D%5Bmaximum_date_range%5D=&atts%5Bsk-options%5D%5Bgrid%5D%5Bclassic_date_format1%5D=d+F+Y&atts%5Bsk-options%5D%5Bgrid%5D%5Bclean_date_format1%5D=d&atts%5Bsk-options%5D%5Bgrid%5D%5Bclean_date_format2%5D=F&atts%5Bsk-options%5D%5Bgrid%5D%5Bminimal_date_format1%5D=d&atts%5Bsk-options%5D%5Bgrid%5D%5Bminimal_date_format2%5D=M&atts%5Bsk-options%5D%5Bgrid%5D%5Bmodern_date_format1%5D=d&atts%5Bsk-options%5D%5Bgrid%5D%5Bmodern_date_format2%5D=F&atts%5Bsk-options%5D%5Bgrid%5D%5Bmodern_date_format3%5D=l&atts%5Bsk-options%5D%5Bgrid%5D%5Bsimple_date_format1%5D=M+d+Y&atts%5Bsk-options%5D%5Bgrid%5D%5Bcolorful_date_format1%5D=d&atts%5Bsk-options%5D%5Bgrid%5D%5Bcolorful_date_format2%5D=F&atts%5Bsk-options%5D%5Bgrid%5D%5Bcolorful_date_format3%5D=l&atts%5Bsk-options%5D%5Bgrid%5D%5Bnovel_date_format1%5D=d+F+Y&atts%5Bsk-options%5D%5Bgrid%5D%5Bcount%5D=1&atts%5Bsk-options%5D%5Bgrid%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Bgrid%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bgrid%5D%5Binclude_events_times%5D=0&atts%5Bsk-options%5D%5Bgrid%5D%5Bload_more_button%5D=1&atts%5Bsk-options%5D%5Bgrid%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bgrid%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bgrid%5D%5Bdisplay_categories%5D=0&atts%5Bsk-options%5D%5Bgrid%5D%5Bset_geolocation%5D=0&atts%5Bsk-options%5D%5Bgrid%5D%5Bset_geolocation_focus%5D=0&atts%5Bsk-options%5D%5Bgrid%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Bgrid%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Bagenda%5D%5Bstyle%5D=clean&atts%5Bsk-options%5D%5Bagenda%5D%5Bstart_date_type%5D=today&atts%5Bsk-options%5D%5Bagenda%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bagenda%5D%5Bmaximum_date_range%5D=&atts%5Bsk-options%5D%5Bagenda%5D%5Bclean_date_format1%5D=l&atts%5Bsk-options%5D%5Bagenda%5D%5Bclean_date_format2%5D=F+j&atts%5Bsk-options%5D%5Bagenda%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Bagenda%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bagenda%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bagenda%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bagenda%5D%5Bload_more_button%5D=1&atts%5Bsk-options%5D%5Bagenda%5D%5Bmonth_divider%5D=0&atts%5Bsk-options%5D%5Bagenda%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Bagenda%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bstart_date_type%5D=start_current_month&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bdefault_view%5D=monthly&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bmonthly_style%5D=simple&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Blist%5D=1&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bdate_format_list%5D=d+M&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bgrid%5D=0&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Btile%5D=0&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Byearly%5D=0&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bdate_format_yearly_1%5D=l&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bdate_format_yearly_2%5D=F+j&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bmonthly%5D=1&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bweekly%5D=1&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bdaily%5D=1&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bdisplay_price%5D=0&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Bfull_calendar%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Byearly_view%5D%5Bstyle%5D=modern&atts%5Bsk-options%5D%5Byearly_view%5D%5Bstart_date_type%5D=start_current_year&atts%5Bsk-options%5D%5Byearly_view%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Byearly_view%5D%5Bmodern_date_format1%5D=l&atts%5Bsk-options%5D%5Byearly_view%5D%5Bmodern_date_format2%5D=F+j&atts%5Bsk-options%5D%5Byearly_view%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Byearly_view%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Byearly_view%5D%5Bnext_previous_button%5D=1&atts%5Bsk-options%5D%5Byearly_view%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Byearly_view%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Byearly_view%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Byearly_view%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bstyle%5D=simple&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bstart_date_type%5D=start_current_month&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bnext_previous_button%5D=1&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bdisplay_price%5D=0&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bactivate_first_date%5D=0&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bactivate_current_day%5D=1&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bbooking_button%5D=0&atts%5Bsk-options%5D%5Bmonthly_view%5D%5Bfrom_fc%5D=1&atts%5Bsk-options%5D%5Bmap%5D%5Bstart_date_type%5D=today&atts%5Bsk-options%5D%5Bmap%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bmap%5D%5Blimit%5D=200&atts%5Bsk-options%5D%5Bmap%5D%5Bgeolocation%5D=0&atts%5Bsk-options%5D%5Bmap%5D%5Bgeolocation_focus%5D=0&atts%5Bsk-options%5D%5Bdaily_view%5D%5Bstart_date_type%5D=today&atts%5Bsk-options%5D%5Bdaily_view%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bdaily_view%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Bdaily_view%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bdaily_view%5D%5Bnext_previous_button%5D=1&atts%5Bsk-options%5D%5Bdaily_view%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bdaily_view%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bdaily_view%5D%5Bdisplay_categories%5D=0&atts%5Bsk-options%5D%5Bdaily_view%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Bdaily_view%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Bweekly_view%5D%5Bstart_date_type%5D=start_current_week&atts%5Bsk-options%5D%5Bweekly_view%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bweekly_view%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Bweekly_view%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bweekly_view%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bweekly_view%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bweekly_view%5D%5Bdisplay_categories%5D=0&atts%5Bsk-options%5D%5Bweekly_view%5D%5Bnext_previous_button%5D=1&atts%5Bsk-options%5D%5Bweekly_view%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Bweekly_view%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Btimetable%5D%5Bstyle%5D=modern&atts%5Bsk-options%5D%5Btimetable%5D%5Bstart_date_type%5D=start_current_week&atts%5Bsk-options%5D%5Btimetable%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Btimetable%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Btimetable%5D%5Bnumber_of_days%5D=5&atts%5Bsk-options%5D%5Btimetable%5D%5Bweek_start%5D=-1&atts%5Bsk-options%5D%5Btimetable%5D%5Bstart_time%5D=1&atts%5Bsk-options%5D%5Btimetable%5D%5Bend_time%5D=13&atts%5Bsk-options%5D%5Btimetable%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Btimetable%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Btimetable%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Btimetable%5D%5Bnext_previous_button%5D=1&atts%5Bsk-options%5D%5Btimetable%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Btimetable%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Bstart_date_type%5D=today&atts%5Bsk-options%5D%5Bmasonry%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bmasonry%5D%5Bmaximum_date_range%5D=&atts%5Bsk-options%5D%5Bmasonry%5D%5Bdate_format1%5D=j&atts%5Bsk-options%5D%5Bmasonry%5D%5Bdate_format2%5D=F&atts%5Bsk-options%5D%5Bmasonry%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Bmasonry%5D%5Bfilter_by%5D=&atts%5Bsk-options%5D%5Bmasonry%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Bdisplay_categories%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Bfit_to_row%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Bmasonry_like_grid%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Bload_more_button%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Bmasonry%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Bcover%5D%5Bstyle%5D=classic&atts%5Bsk-options%5D%5Bcover%5D%5Bdate_format_clean1%5D=d&atts%5Bsk-options%5D%5Bcover%5D%5Bdate_format_clean2%5D=M&atts%5Bsk-options%5D%5Bcover%5D%5Bdate_format_clean3%5D=Y&atts%5Bsk-options%5D%5Bcover%5D%5Bdate_format_classic1%5D=F+d&atts%5Bsk-options%5D%5Bcover%5D%5Bdate_format_classic2%5D=l&atts%5Bsk-options%5D%5Bcover%5D%5Bdate_format_modern1%5D=l%2C+F+d+Y&atts%5Bsk-options%5D%5Bcover%5D%5Bevent_id%5D=3395&atts%5Bsk-options%5D%5Bcover%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bcover%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bcover%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bcountdown%5D%5Bstyle%5D=style1&atts%5Bsk-options%5D%5Bcountdown%5D%5Bdate_format_style11%5D=j+F+Y&atts%5Bsk-options%5D%5Bcountdown%5D%5Bdate_format_style21%5D=j+F+Y&atts%5Bsk-options%5D%5Bcountdown%5D%5Bdate_format_style31%5D=j&atts%5Bsk-options%5D%5Bcountdown%5D%5Bdate_format_style32%5D=F&atts%5Bsk-options%5D%5Bcountdown%5D%5Bdate_format_style33%5D=Y&atts%5Bsk-options%5D%5Bcountdown%5D%5Bevent_id%5D=-1&atts%5Bsk-options%5D%5Bcountdown%5D%5Bbg_color%5D=%23437df9&atts%5Bsk-options%5D%5Bcountdown%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bcountdown%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bcountdown%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bavailable_spot%5D%5Bdate_format1%5D=j&atts%5Bsk-options%5D%5Bavailable_spot%5D%5Bdate_format2%5D=F&atts%5Bsk-options%5D%5Bavailable_spot%5D%5Bevent_id%5D=-1&atts%5Bsk-options%5D%5Bavailable_spot%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bavailable_spot%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bavailable_spot%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bcarousel%5D%5Bstyle%5D=type1&atts%5Bsk-options%5D%5Bcarousel%5D%5Bstart_date_type%5D=today&atts%5Bsk-options%5D%5Bcarousel%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bcarousel%5D%5Btype1_date_format1%5D=d&atts%5Bsk-options%5D%5Bcarousel%5D%5Btype1_date_format2%5D=F&atts%5Bsk-options%5D%5Bcarousel%5D%5Btype1_date_format3%5D=Y&atts%5Bsk-options%5D%5Bcarousel%5D%5Btype2_date_format1%5D=M+d%2C+Y&atts%5Bsk-options%5D%5Bcarousel%5D%5Btype3_date_format1%5D=M+d%2C+Y&atts%5Bsk-options%5D%5Bcarousel%5D%5Bcount%5D=2&atts%5Bsk-options%5D%5Bcarousel%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Bcarousel%5D%5Bautoplay%5D=&atts%5Bsk-options%5D%5Bcarousel%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Bcarousel%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Bcarousel%5D%5Barchive_link%5D=&atts%5Bsk-options%5D%5Bcarousel%5D%5Bhead_text%5D=&atts%5Bsk-options%5D%5Bcarousel%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bcarousel%5D%5Binclude_events_times%5D=0&atts%5Bsk-options%5D%5Bcarousel%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bcarousel%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Bslider%5D%5Bstyle%5D=t1&atts%5Bsk-options%5D%5Bslider%5D%5Bstart_date_type%5D=today&atts%5Bsk-options%5D%5Bslider%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Bslider%5D%5Btype1_date_format1%5D=d&atts%5Bsk-options%5D%5Bslider%5D%5Btype1_date_format2%5D=F&atts%5Bsk-options%5D%5Bslider%5D%5Btype1_date_format3%5D=l&atts%5Bsk-options%5D%5Bslider%5D%5Btype2_date_format1%5D=d&atts%5Bsk-options%5D%5Bslider%5D%5Btype2_date_format2%5D=F&atts%5Bsk-options%5D%5Bslider%5D%5Btype2_date_format3%5D=l&atts%5Bsk-options%5D%5Bslider%5D%5Btype3_date_format1%5D=d&atts%5Bsk-options%5D%5Bslider%5D%5Btype3_date_format2%5D=F&atts%5Bsk-options%5D%5Bslider%5D%5Btype3_date_format3%5D=l&atts%5Bsk-options%5D%5Bslider%5D%5Btype4_date_format1%5D=d&atts%5Bsk-options%5D%5Bslider%5D%5Btype4_date_format2%5D=F&atts%5Bsk-options%5D%5Bslider%5D%5Btype4_date_format3%5D=l&atts%5Bsk-options%5D%5Bslider%5D%5Btype5_date_format1%5D=d&atts%5Bsk-options%5D%5Bslider%5D%5Btype5_date_format2%5D=F&atts%5Bsk-options%5D%5Bslider%5D%5Btype5_date_format3%5D=l&atts%5Bsk-options%5D%5Bslider%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Bslider%5D%5Bautoplay%5D=&atts%5Bsk-options%5D%5Bslider%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Bslider%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Bslider%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Btimeline%5D%5Bstart_date_type%5D=today&atts%5Bsk-options%5D%5Btimeline%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Btimeline%5D%5Bmaximum_date_range%5D=&atts%5Bsk-options%5D%5Btimeline%5D%5Bclassic_date_format1%5D=d+F+Y&atts%5Bsk-options%5D%5Btimeline%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Btimeline%5D%5Binclude_local_time%5D=0&atts%5Bsk-options%5D%5Btimeline%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Btimeline%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Btimeline%5D%5Bdisplay_categories%5D=0&atts%5Bsk-options%5D%5Btimeline%5D%5Bload_more_button%5D=1&atts%5Bsk-options%5D%5Btimeline%5D%5Bmonth_divider%5D=0&atts%5Bsk-options%5D%5Btimeline%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Btimeline%5D%5Bimage_popup%5D=0&atts%5Bsk-options%5D%5Btile%5D%5Bstart_date_type%5D=start_current_month&atts%5Bsk-options%5D%5Btile%5D%5Bstart_date%5D=&atts%5Bsk-options%5D%5Btile%5D%5Bclean_date_format1%5D=j&atts%5Bsk-options%5D%5Btile%5D%5Bclean_date_format2%5D=M&atts%5Bsk-options%5D%5Btile%5D%5Bcount%5D=4&atts%5Bsk-options%5D%5Btile%5D%5Bdisplay_label%5D=0&atts%5Bsk-options%5D%5Btile%5D%5Breason_for_cancellation%5D=0&atts%5Bsk-options%5D%5Btile%5D%5Bdisplay_categories%5D=0&atts%5Bsk-options%5D%5Btile%5D%5Bnext_previous_button%5D=1&atts%5Bsk-options%5D%5Btile%5D%5Blimit%5D=&atts%5Bsk-options%5D%5Btile%5D%5Bload_more_button%5D=1&atts%5Bsk-options%5D%5Btile%5D%5Bsed_method%5D=0&atts%5Bsk-options%5D%5Btile%5D%5Bimage_popup%5D=0&atts%5Bsf-options%5D%5Blist%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Blist%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Blist%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Blist%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Blist%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Blist%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Blist%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Blist%5D%5Bmonth_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Blist%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Bmonth_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bgrid%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Bmonth_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bagenda%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Bcategory%5D%5Btype%5D=dropdown&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Bmonth_filter%5D%5Btype%5D=dropdown&atts%5Bsf-options%5D%5Bfull_calendar%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Bcategory%5D%5Btype%5D=dropdown&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Bmonth_filter%5D%5Btype%5D=dropdown&atts%5Bsf-options%5D%5Bmonthly_view%5D%5Btext_search%5D%5Btype%5D=text_input&atts%5Bsf-options%5D%5Byearly_view%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Bmonth_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Byearly_view%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmap%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmap%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmap%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmap%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmap%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmap%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmap%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bmap%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Bmonth_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bdaily_view%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Bmonth_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Bweekly_view%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Bmonth_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btimetable%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Bcategory%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Blocation%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Borganizer%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Bspeaker%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Btag%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Blabel%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Baddress_search%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Bmonth_filter%5D%5Btype%5D=0&atts%5Bsf-options%5D%5Btile%5D%5Btext_search%5D%5Btype%5D=0&atts%5Bsf_status%5D=0&atts%5B_edit_lock%5D=1604947977%3A174275903&atts%5B_edit_last%5D=174275903&atts%5Bshow_only_past_events%5D=0&atts%5Bshow_only_ongoing_events%5D=0&atts%5Bid%5D=1057",
+        style: "simple",
+        ajax_url: "https://clecpc.org/wp-admin/admin-ajax.php",
+        sed_method: "0",
+        image_popup: "0",
+        sf:
+        {
+            container: "",
+            reset: 0,
+            refine: 0,
+        },
+    });
+});
+</script>
+<svg style="position: absolute; width: 0; height: 0; overflow: hidden;" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<symbol id="icon-500px" viewBox="0 0 24 24">
+<path d="M6.94026,15.1412c.00437.01213.108.29862.168.44064a6.55008,6.55008,0,1,0,6.03191-9.09557,6.68654,6.68654,0,0,0-2.58357.51467A8.53914,8.53914,0,0,0,8.21268,8.61344L8.209,8.61725V3.22948l9.0504-.00008c.32934-.0036.32934-.46353.32934-.61466s0-.61091-.33035-.61467L7.47248,2a.43.43,0,0,0-.43131.42692v7.58355c0,.24466.30476.42131.58793.4819.553.11812.68074-.05864.81617-.2457l.018-.02481A10.52673,10.52673,0,0,1,9.32258,9.258a5.35268,5.35268,0,1,1,7.58985,7.54976,5.417,5.417,0,0,1-3.80867,1.56365,5.17483,5.17483,0,0,1-2.69822-.74478l.00342-4.61111a2.79372,2.79372,0,0,1,.71372-1.78792,2.61611,2.61611,0,0,1,1.98282-.89477,2.75683,2.75683,0,0,1,1.95525.79477,2.66867,2.66867,0,0,1,.79656,1.909,2.724,2.724,0,0,1-2.75849,2.748,4.94651,4.94651,0,0,1-.86254-.13719c-.31234-.093-.44519.34058-.48892.48349-.16811.54966.08453.65862.13687.67489a3.75751,3.75751,0,0,0,1.25234.18375,3.94634,3.94634,0,1,0-2.82444-6.742,3.67478,3.67478,0,0,0-1.13028,2.584l-.00041.02323c-.0035.11667-.00579,2.881-.00644,3.78811l-.00407-.00451a6.18521,6.18521,0,0,1-1.0851-1.86092c-.10544-.27856-.34358-.22925-.66857-.12917-.14192.04372-.57386.17677-.47833.489Zm4.65165-1.08338a.51346.51346,0,0,0,.19513.31818l.02276.022a.52945.52945,0,0,0,.3517.18416.24242.24242,0,0,0,.16577-.0611c.05473-.05082.67382-.67812.73287-.738l.69041.68819a.28978.28978,0,0,0,.21437.11032.53239.53239,0,0,0,.35708-.19486c.29792-.30419.14885-.46821.07676-.54751l-.69954-.69975.72952-.73469c.16-.17311.01874-.35708-.12218-.498-.20461-.20461-.402-.25742-.52855-.14083l-.7254.72665-.73354-.73375a.20128.20128,0,0,0-.14179-.05695.54135.54135,0,0,0-.34379.19648c-.22561.22555-.274.38149-.15656.5059l.73374.7315-.72942.73072A.26589.26589,0,0,0,11.59191,14.05782Zm1.59866-9.915A8.86081,8.86081,0,0,0,9.854,4.776a.26169.26169,0,0,0-.16938.22759.92978.92978,0,0,0,.08619.42094c.05682.14524.20779.531.50006.41955a8.40969,8.40969,0,0,1,2.91968-.55484,7.87875,7.87875,0,0,1,3.086.62286,8.61817,8.61817,0,0,1,2.30562,1.49315.2781.2781,0,0,0,.18318.07586c.15529,0,.30425-.15253.43167-.29551.21268-.23861.35873-.4369.1492-.63538a8.50425,8.50425,0,0,0-2.62312-1.694A9.0177,9.0177,0,0,0,13.19058,4.14283ZM19.50945,18.6236h0a.93171.93171,0,0,0-.36642-.25406.26589.26589,0,0,0-.27613.06613l-.06943.06929A7.90606,7.90606,0,0,1,7.60639,18.505a7.57284,7.57284,0,0,1-1.696-2.51537,8.58715,8.58715,0,0,1-.5147-1.77754l-.00871-.04864c-.04939-.25873-.28755-.27684-.62981-.22448-.14234.02178-.5755.088-.53426.39969l.001.00712a9.08807,9.08807,0,0,0,15.406,4.99094c.00193-.00192.04753-.04718.0725-.07436C19.79425,19.16234,19.87422,18.98728,19.50945,18.6236Z"/>
+</symbol>
+<symbol id="icon-amazon" viewBox="0 0 24 24">
+<path d="M13.582,8.182C11.934,8.367,9.78,8.49,8.238,9.166c-1.781,0.769-3.03,2.337-3.03,4.644 c0,2.953,1.86,4.429,4.253,4.429c2.02,0,3.125-0.477,4.685-2.065c0.516,0.747,0.685,1.109,1.629,1.894 c0.212,0.114,0.483,0.103,0.672-0.066l0.006,0.006c0.567-0.505,1.599-1.401,2.18-1.888c0.231-0.188,0.19-0.496,0.009-0.754 c-0.52-0.718-1.072-1.303-1.072-2.634V8.305c0-1.876,0.133-3.599-1.249-4.891C15.23,2.369,13.422,2,12.04,2 C9.336,2,6.318,3.01,5.686,6.351C5.618,6.706,5.877,6.893,6.109,6.945l2.754,0.298C9.121,7.23,9.308,6.977,9.357,6.72 c0.236-1.151,1.2-1.706,2.284-1.706c0.584,0,1.249,0.215,1.595,0.738c0.398,0.584,0.346,1.384,0.346,2.061V8.182z M13.049,14.088 c-0.451,0.8-1.169,1.291-1.967,1.291c-1.09,0-1.728-0.83-1.728-2.061c0-2.42,2.171-2.86,4.227-2.86v0.615 C13.582,12.181,13.608,13.104,13.049,14.088z M20.683,19.339C18.329,21.076,14.917,22,11.979,22c-4.118,0-7.826-1.522-10.632-4.057 c-0.22-0.199-0.024-0.471,0.241-0.317c3.027,1.762,6.771,2.823,10.639,2.823c2.608,0,5.476-0.541,8.115-1.66 C20.739,18.62,21.072,19.051,20.683,19.339z M21.336,21.043c-0.194,0.163-0.379,0.076-0.293-0.139 c0.284-0.71,0.92-2.298,0.619-2.684c-0.301-0.386-1.99-0.183-2.749-0.092c-0.23,0.027-0.266-0.173-0.059-0.319 c1.348-0.946,3.555-0.673,3.811-0.356C22.925,17.773,22.599,19.986,21.336,21.043z"/>
+</symbol>
+<symbol id="icon-apple" viewBox="0 0 24 24">
+<path d="M20.07,17.586a10.874,10.874,0,0,1-1.075,1.933,9.822,9.822,0,0,1-1.385,1.674,2.687,2.687,0,0,1-1.78.784,4.462,4.462,0,0,1-1.644-.393,4.718,4.718,0,0,0-1.77-.391,4.878,4.878,0,0,0-1.82.391A4.9,4.9,0,0,1,9.021,22a2.53,2.53,0,0,1-1.82-.8A10.314,10.314,0,0,1,5.752,19.46,11.987,11.987,0,0,1,4.22,16.417a11.143,11.143,0,0,1-.643-3.627,6.623,6.623,0,0,1,.87-3.465A5.1,5.1,0,0,1,6.268,7.483a4.9,4.9,0,0,1,2.463-.695,5.8,5.8,0,0,1,1.9.443,6.123,6.123,0,0,0,1.511.444,9.04,9.04,0,0,0,1.675-.523,5.537,5.537,0,0,1,2.277-.4,4.835,4.835,0,0,1,3.788,1.994,4.213,4.213,0,0,0-2.235,3.827,4.222,4.222,0,0,0,1.386,3.181,4.556,4.556,0,0,0,1.385.909q-.167.483-.353.927ZM16.211,2.4a4.267,4.267,0,0,1-1.094,2.8,3.726,3.726,0,0,1-3.1,1.528A3.114,3.114,0,0,1,12,6.347a4.384,4.384,0,0,1,1.16-2.828,4.467,4.467,0,0,1,1.414-1.061A4.215,4.215,0,0,1,16.19,2a3.633,3.633,0,0,1,.021.4Z"/>
+</symbol>
+<symbol id="icon-bandcamp" viewBox="0 0 24 24">
+<path d="M15.27 17.289 3 17.289 8.73 6.711 21 6.711 15.27 17.289"/>
+</symbol>
+<symbol id="icon-behance" viewBox="0 0 24 24">
+<path d="M7.799,5.698c0.589,0,1.12,0.051,1.606,0.156c0.482,0.102,0.894,0.273,1.241,0.507c0.344,0.235,0.612,0.546,0.804,0.938 c0.188,0.387,0.281,0.871,0.281,1.443c0,0.619-0.141,1.137-0.421,1.551c-0.284,0.413-0.7,0.751-1.255,1.014 c0.756,0.218,1.317,0.601,1.689,1.146c0.374,0.549,0.557,1.205,0.557,1.975c0,0.623-0.12,1.161-0.359,1.612 c-0.241,0.457-0.569,0.828-0.973,1.114c-0.408,0.288-0.876,0.5-1.399,0.637C9.052,17.931,8.514,18,7.963,18H2V5.698H7.799 M7.449,10.668c0.481,0,0.878-0.114,1.192-0.345c0.311-0.228,0.463-0.603,0.463-1.119c0-0.286-0.051-0.523-0.152-0.707 C8.848,8.315,8.711,8.171,8.536,8.07C8.362,7.966,8.166,7.894,7.94,7.854c-0.224-0.044-0.457-0.06-0.697-0.06H4.709v2.874H7.449z M7.6,15.905c0.267,0,0.521-0.024,0.759-0.077c0.243-0.053,0.457-0.137,0.637-0.261c0.182-0.12,0.332-0.283,0.441-0.491 C9.547,14.87,9.6,14.602,9.6,14.278c0-0.633-0.18-1.084-0.533-1.357c-0.356-0.27-0.83-0.404-1.413-0.404H4.709v3.388L7.6,15.905z M16.162,15.864c0.367,0.358,0.897,0.538,1.583,0.538c0.493,0,0.92-0.125,1.277-0.374c0.354-0.248,0.571-0.514,0.654-0.79h2.155 c-0.347,1.072-0.872,1.838-1.589,2.299C19.534,18,18.67,18.23,17.662,18.23c-0.701,0-1.332-0.113-1.899-0.337 c-0.567-0.227-1.041-0.544-1.439-0.958c-0.389-0.415-0.689-0.907-0.904-1.484c-0.213-0.574-0.32-1.21-0.32-1.899 c0-0.666,0.11-1.288,0.329-1.863c0.222-0.577,0.529-1.075,0.933-1.492c0.406-0.42,0.885-0.751,1.444-0.994 c0.558-0.241,1.175-0.363,1.857-0.363c0.754,0,1.414,0.145,1.98,0.44c0.563,0.291,1.026,0.686,1.389,1.181 c0.363,0.493,0.622,1.057,0.783,1.69c0.16,0.632,0.217,1.292,0.171,1.983h-6.428C15.557,14.84,15.795,15.506,16.162,15.864 M18.973,11.184c-0.291-0.321-0.783-0.496-1.384-0.496c-0.39,0-0.714,0.066-0.973,0.2c-0.254,0.132-0.461,0.297-0.621,0.491 c-0.157,0.197-0.265,0.405-0.328,0.628c-0.063,0.217-0.101,0.413-0.111,0.587h3.98C19.478,11.969,19.265,11.509,18.973,11.184z M15.057,7.738h4.985V6.524h-4.985L15.057,7.738z"/>
+</symbol>
+<symbol id="icon-blogger" viewBox="0 0 24 24">
+<path d="M14.722,14.019c0,0.361-0.293,0.654-0.654,0.654H9.977c-0.361,0-0.654-0.293-0.654-0.654s0.293-0.654,0.654-0.654h4.091C14.429,13.365,14.722,13.658,14.722,14.019z M9.981,10.698h2.038c0.382,0,0.692-0.31,0.692-0.692c0-0.382-0.31-0.692-0.692-0.692H9.981c-0.382,0-0.692,0.31-0.692,0.692C9.289,10.388,9.599,10.698,9.981,10.698z M21,5v14c0,1.105-0.895,2-2,2H5c-1.105,0-2-0.895-2-2V5c0-1.105,0.895-2,2-2h14C20.105,3,21,3.895,21,5z M17.544,11.39c0-0.398-0.322-0.72-0.72-0.72h-0.607l-0.013,0.001c-0.38,0-0.692-0.295-0.718-0.668l-0.001-0.008c0-1.988-1.611-3.599-3.599-3.599h-1.816c-1.988,0-3.599,1.611-3.599,3.599v3.947c0,1.987,1.611,3.599,3.599,3.599h3.874c1.988,0,3.599-1.611,3.599-3.599L17.544,11.39z"/>
+</symbol>
+<symbol id="icon-bluesky" viewBox="0 0 24 24">
+<path d="M21.2 3.3C20.7 3.1 19.8 2.8 17.6 4.3C15.4 6 12.9 9.2 12 11C11.1 9.2 8.6 6 6.3 4.3C4.1 2.7 3.3 3 2.7 3.3C2.1 3.6 2 4.6 2 5.1C2 5.6 2.3 9.8 2.5 10.5C3.2 12.8 5.6 13.6 7.8 13.3C4.5 13.8 1.6 15 5.4 19.2C9.6 23.5 11.1 18.3 11.9 15.6C12.7 18.3 13.6 23.3 18.3 19.2C21.9 15.6 19.3 13.8 16 13.3C18.2 13.5 20.6 12.8 21.3 10.5C21.7 9.8 22 5.7 22 5.1C22 4.6 21.9 3.6 21.2 3.3Z" />
+</symbol>
+<symbol id="icon-chain" viewBox="0 0 24 24">
+<path d="M19.647,16.706a1.134,1.134,0,0,0-.343-.833l-2.549-2.549a1.134,1.134,0,0,0-.833-.343,1.168,1.168,0,0,0-.883.392l.233.226q.2.189.264.264a2.922,2.922,0,0,1,.184.233.986.986,0,0,1,.159.312,1.242,1.242,0,0,1,.043.337,1.172,1.172,0,0,1-1.176,1.176,1.237,1.237,0,0,1-.337-.043,1,1,0,0,1-.312-.159,2.76,2.76,0,0,1-.233-.184q-.073-.068-.264-.264l-.226-.233a1.19,1.19,0,0,0-.4.895,1.134,1.134,0,0,0,.343.833L15.837,19.3a1.13,1.13,0,0,0,.833.331,1.18,1.18,0,0,0,.833-.318l1.8-1.789a1.12,1.12,0,0,0,.343-.821Zm-8.615-8.64a1.134,1.134,0,0,0-.343-.833L8.163,4.7a1.134,1.134,0,0,0-.833-.343,1.184,1.184,0,0,0-.833.331L4.7,6.473a1.12,1.12,0,0,0-.343.821,1.134,1.134,0,0,0,.343.833l2.549,2.549a1.13,1.13,0,0,0,.833.331,1.184,1.184,0,0,0,.883-.38L8.728,10.4q-.2-.189-.264-.264A2.922,2.922,0,0,1,8.28,9.9a.986.986,0,0,1-.159-.312,1.242,1.242,0,0,1-.043-.337A1.172,1.172,0,0,1,9.254,8.079a1.237,1.237,0,0,1,.337.043,1,1,0,0,1,.312.159,2.761,2.761,0,0,1,.233.184q.073.068.264.264l.226.233a1.19,1.19,0,0,0,.4-.895ZM22,16.706a3.343,3.343,0,0,1-1.042,2.488l-1.8,1.789a3.536,3.536,0,0,1-4.988-.025l-2.525-2.537a3.384,3.384,0,0,1-1.017-2.488,3.448,3.448,0,0,1,1.078-2.561l-1.078-1.078a3.434,3.434,0,0,1-2.549,1.078,3.4,3.4,0,0,1-2.5-1.029L3.029,9.794A3.4,3.4,0,0,1,2,7.294,3.343,3.343,0,0,1,3.042,4.806l1.8-1.789A3.384,3.384,0,0,1,7.331,2a3.357,3.357,0,0,1,2.5,1.042l2.525,2.537a3.384,3.384,0,0,1,1.017,2.488,3.448,3.448,0,0,1-1.078,2.561l1.078,1.078a3.551,3.551,0,0,1,5.049-.049l2.549,2.549A3.4,3.4,0,0,1,22,16.706Z"/>
+</symbol>
+<symbol id="icon-codepen" viewBox="0 0 24 24">
+<path d="M22.016,8.84c-0.002-0.013-0.005-0.025-0.007-0.037c-0.005-0.025-0.008-0.048-0.015-0.072 c-0.003-0.015-0.01-0.028-0.013-0.042c-0.008-0.02-0.015-0.04-0.023-0.062c-0.007-0.015-0.013-0.028-0.02-0.042 c-0.008-0.02-0.018-0.037-0.03-0.057c-0.007-0.013-0.017-0.027-0.025-0.038c-0.012-0.018-0.023-0.035-0.035-0.052 c-0.01-0.013-0.02-0.025-0.03-0.037c-0.015-0.017-0.028-0.032-0.043-0.045c-0.01-0.012-0.022-0.023-0.035-0.035 c-0.015-0.015-0.032-0.028-0.048-0.04c-0.012-0.01-0.025-0.02-0.037-0.03c-0.005-0.003-0.01-0.008-0.015-0.012l-9.161-6.096 c-0.289-0.192-0.666-0.192-0.955,0L2.359,8.237C2.354,8.24,2.349,8.245,2.344,8.249L2.306,8.277 c-0.017,0.013-0.033,0.027-0.048,0.04C2.246,8.331,2.234,8.342,2.222,8.352c-0.015,0.015-0.028,0.03-0.042,0.047 c-0.012,0.013-0.022,0.023-0.03,0.037C2.139,8.453,2.125,8.471,2.115,8.488C2.107,8.501,2.099,8.514,2.09,8.526 C2.079,8.548,2.069,8.565,2.06,8.585C2.054,8.6,2.047,8.613,2.04,8.626C2.032,8.648,2.025,8.67,2.019,8.69 c-0.005,0.013-0.01,0.027-0.013,0.042C1.999,8.755,1.995,8.778,1.99,8.803C1.989,8.817,1.985,8.828,1.984,8.84 C1.978,8.879,1.975,8.915,1.975,8.954v6.093c0,0.037,0.003,0.075,0.008,0.112c0.002,0.012,0.005,0.025,0.007,0.038 c0.005,0.023,0.008,0.047,0.015,0.072c0.003,0.015,0.008,0.028,0.013,0.04c0.007,0.022,0.013,0.042,0.022,0.063 c0.007,0.015,0.013,0.028,0.02,0.04c0.008,0.02,0.018,0.038,0.03,0.058c0.007,0.013,0.015,0.027,0.025,0.038 c0.012,0.018,0.023,0.035,0.035,0.052c0.01,0.013,0.02,0.025,0.03,0.037c0.013,0.015,0.028,0.032,0.042,0.045 c0.012,0.012,0.023,0.023,0.035,0.035c0.015,0.013,0.032,0.028,0.048,0.04l0.038,0.03c0.005,0.003,0.01,0.007,0.013,0.01 l9.163,6.095C11.668,21.953,11.833,22,12,22c0.167,0,0.332-0.047,0.478-0.144l9.163-6.095l0.015-0.01 c0.013-0.01,0.027-0.02,0.037-0.03c0.018-0.013,0.035-0.028,0.048-0.04c0.013-0.012,0.025-0.023,0.035-0.035 c0.017-0.015,0.03-0.032,0.043-0.045c0.01-0.013,0.02-0.025,0.03-0.037c0.013-0.018,0.025-0.035,0.035-0.052 c0.008-0.013,0.018-0.027,0.025-0.038c0.012-0.02,0.022-0.038,0.03-0.058c0.007-0.013,0.013-0.027,0.02-0.04 c0.008-0.022,0.015-0.042,0.023-0.063c0.003-0.013,0.01-0.027,0.013-0.04c0.007-0.025,0.01-0.048,0.015-0.072 c0.002-0.013,0.005-0.027,0.007-0.037c0.003-0.042,0.007-0.079,0.007-0.117V8.954C22.025,8.915,22.022,8.879,22.016,8.84z M12.862,4.464l6.751,4.49l-3.016,2.013l-3.735-2.492V4.464z M11.138,4.464v4.009l-3.735,2.494L4.389,8.954L11.138,4.464z M3.699,10.562L5.853,12l-2.155,1.438V10.562z M11.138,19.536l-6.749-4.491l3.015-2.011l3.735,2.492V19.536z M12,14.035L8.953,12 L12,9.966L15.047,12L12,14.035z M12.862,19.536v-4.009l3.735-2.492l3.016,2.011L12.862,19.536z M20.303,13.438L18.147,12 l2.156-1.438L20.303,13.438z"/>
+</symbol>
+<symbol id="icon-deviantart" viewBox="0 0 24 24">
+<path d="M 18.19 5.636 18.19 2 18.188 2 14.553 2 14.19 2.366 12.474 5.636 11.935 6 5.81 6 5.81 10.994 9.177 10.994 9.477 11.357 5.81 18.363 5.81 22 5.811 22 9.447 22 9.81 21.634 11.526 18.364 12.065 18 18.19 18 18.19 13.006 14.823 13.006 14.523 12.641 18.19 5.636z"/>
+</symbol>
+<symbol id="icon-digg" viewBox="0 0 24 24">
+<path d="M4.5,5.4h2.2V16H1V8.5h3.5V5.4L4.5,5.4z M4.5,14.2v-4H3.2v4H4.5z M7.6,8.5V16h2.2V8.5C9.8,8.5,7.6,8.5,7.6,8.5z M7.6,5.4 v2.2h2.2V5.4C9.8,5.4,7.6,5.4,7.6,5.4z M10.7,8.5h5.7v10.1h-5.7v-1.8h3.5V16h-3.5C10.7,16,10.7,8.5,10.7,8.5z M14.2,14.2v-4h-1.3v4 H14.2z M17.3,8.5H23v10.1h-5.7v-1.8h3.5V16h-3.5C17.3,16,17.3,8.5,17.3,8.5z M20.8,14.2v-4h-1.3v4H20.8z"/>
+</symbol>
+<symbol id="icon-discord" viewBox="0 0 24 24">
+<path d="M10.227 9.957c-.559 0-1 .48-1 1.063 0 .585.453 1.066 1 1.066.558 0 1-.48 1-1.066.007-.582-.442-1.063-1-1.063zm3.574 0c-.559 0-.996.48-.996 1.063 0 .585.449 1.066.996 1.066.558 0 1-.48 1-1.066 0-.582-.442-1.063-1-1.063zm0 0 M18.563 1.918H5.438c-1.11 0-2.008.879-2.008 1.973v12.957c0 1.093.898 1.972 2.007 1.972h11.11l-.52-1.773 1.254 1.14 1.184 1.075 2.105 1.82V3.891c0-1.094-.898-1.973-2.008-1.973zM14.78 14.434s-.351-.414-.644-.778c1.281-.355 1.773-1.14 1.773-1.14a5.745 5.745 0 0 1-1.129.566c-.488.2-.96.336-1.418.41a7.07 7.07 0 0 1-2.539-.008 8.133 8.133 0 0 1-1.441-.414 6.219 6.219 0 0 1-.715-.324c-.027-.02-.059-.027-.086-.047a.113.113 0 0 1-.039-.031c-.176-.094-.273-.16-.273-.16s.468.765 1.71 1.129c-.293.363-.656.797-.656.797-2.164-.067-2.984-1.457-2.984-1.457 0-3.086 1.41-5.586 1.41-5.586 1.41-1.036 2.75-1.008 2.75-1.008l.098.113c-1.762.5-2.575 1.258-2.575 1.258s.215-.117.579-.277c1.046-.454 1.878-.579 2.222-.606.059-.008.11-.02.168-.02a8.728 8.728 0 0 1 1.977-.019c.933.106 1.93.375 2.949.922 0 0-.773-.719-2.438-1.219l.137-.152s1.34-.028 2.75 1.008c0 0 1.414 2.5 1.414 5.586 0 0-.836 1.39-3 1.457zm0 0"/>
+</symbol>
+<symbol id="icon-dribbble" viewBox="0 0 24 24">
+<path d="M12,22C6.486,22,2,17.514,2,12S6.486,2,12,2c5.514,0,10,4.486,10,10S17.514,22,12,22z M20.434,13.369 c-0.292-0.092-2.644-0.794-5.32-0.365c1.117,3.07,1.572,5.57,1.659,6.09C18.689,17.798,20.053,15.745,20.434,13.369z M15.336,19.876c-0.127-0.749-0.623-3.361-1.822-6.477c-0.019,0.006-0.038,0.013-0.056,0.019c-4.818,1.679-6.547,5.02-6.701,5.334 c1.448,1.129,3.268,1.803,5.243,1.803C13.183,20.555,14.311,20.313,15.336,19.876z M5.654,17.724 c0.193-0.331,2.538-4.213,6.943-5.637c0.111-0.036,0.224-0.07,0.337-0.102c-0.214-0.485-0.448-0.971-0.692-1.45 c-4.266,1.277-8.405,1.223-8.778,1.216c-0.003,0.087-0.004,0.174-0.004,0.261C3.458,14.207,4.29,16.21,5.654,17.724z M3.639,10.264 c0.382,0.005,3.901,0.02,7.897-1.041c-1.415-2.516-2.942-4.631-3.167-4.94C5.979,5.41,4.193,7.613,3.639,10.264z M9.998,3.709 c0.236,0.316,1.787,2.429,3.187,5c3.037-1.138,4.323-2.867,4.477-3.085C16.154,4.286,14.17,3.471,12,3.471 C11.311,3.471,10.641,3.554,9.998,3.709z M18.612,6.612C18.432,6.855,17,8.69,13.842,9.979c0.199,0.407,0.389,0.821,0.567,1.237 c0.063,0.148,0.124,0.295,0.184,0.441c2.842-0.357,5.666,0.215,5.948,0.275C20.522,9.916,19.801,8.065,18.612,6.612z"/>
+</symbol>
+<symbol id="icon-dropbox" viewBox="0 0 24 24">
+<path d="M12,6.134L6.069,9.797L2,6.54l5.883-3.843L12,6.134z M2,13.054l5.883,3.843L12,13.459L6.069,9.797L2,13.054z M12,13.459 l4.116,3.439L22,13.054l-4.069-3.257L12,13.459z M22,6.54l-5.884-3.843L12,6.134l5.931,3.663L22,6.54z M12.011,14.2l-4.129,3.426 l-1.767-1.153v1.291l5.896,3.539l5.897-3.539v-1.291l-1.769,1.153L12.011,14.2z"/>
+</symbol>
+<symbol id="icon-etsy" viewBox="0 0 24 24">
+<path d="M9.16033,4.038c0-.27174.02717-.43478.48913-.43478h6.22283c1.087,0,1.68478.92391,2.11957,2.663l.35326,1.38587h1.05978C19.59511,3.712,19.75815,2,19.75815,2s-2.663.29891-4.23913.29891h-7.962L3.29076,2.163v1.1413L4.731,3.57609c1.00543.19022,1.25.40761,1.33152,1.33152,0,0,.08152,2.71739.08152,7.20109s-.08152,7.17391-.08152,7.17391c0,.81522-.32609,1.11413-1.33152,1.30435l-1.44022.27174V22l4.2663-.13587h7.11957c1.60326,0,5.32609.13587,5.32609.13587.08152-.97826.625-5.40761.70652-5.89674H19.7038L18.644,18.52174c-.84239,1.90217-2.06522,2.038-3.42391,2.038H11.1712c-1.3587,0-2.01087-.54348-2.01087-1.712V12.65217s3.0163,0,3.99457.08152c.76087.05435,1.22283.27174,1.46739,1.33152l.32609,1.413h1.16848l-.08152-3.55978.163-3.587H15.02989l-.38043,1.57609c-.24457,1.03261-.40761,1.22283-1.46739,1.33152-1.38587.13587-4.02174.1087-4.02174.1087Z"/>
+</symbol>
+<symbol id="icon-eventbrite" viewBox="0 0 24 24">
+<path style="fill-rule:evenodd;clip-rule:evenodd;" d="M18.041,3.931L5.959,3C4.325,3,3,4.325,3,5.959v12.083C3,19.675,4.325,21,5.959,21l12.083-0.931C19.699,19.983,21,18.744,21,17.11V6.89C21,5.256,19.741,4.027,18.041,3.931zM16.933,8.17c-0.082,0.215-0.192,0.432-0.378,0.551c-0.188,0.122-0.489,0.132-0.799,0.132c-1.521,0-3.062-0.048-4.607-0.048c-0.152,0.708-0.304,1.416-0.451,2.128c0.932-0.004,1.873,0.005,2.81,0.005c0.726,0,1.462-0.069,1.586,0.525c0.04,0.189-0.001,0.426-0.052,0.615c-0.105,0.38-0.258,0.676-0.625,0.783c-0.185,0.054-0.408,0.058-0.646,0.058c-1.145,0-2.345,0.017-3.493,0.02c-0.169,0.772-0.328,1.553-0.489,2.333c1.57-0.005,3.067-0.041,4.633-0.058c0.627-0.007,1.085,0.194,1.009,0.85c-0.031,0.262-0.098,0.497-0.211,0.725c-0.102,0.208-0.248,0.376-0.488,0.452c-0.237,0.075-0.541,0.064-0.862,0.078c-0.304,0.014-0.614,0.008-0.924,0.016c-0.309,0.009-0.619,0.022-0.919,0.022c-1.253,0-2.429,0.08-3.683,0.073c-0.603-0.004-1.014-0.249-1.124-0.757c-0.059-0.273-0.018-0.58,0.036-0.841c0.541-2.592,1.083-5.176,1.629-7.763c0.056-0.265,0.114-0.511,0.225-0.714C9.279,7.051,9.534,6.834,9.9,6.735c0.368-0.099,0.883-0.047,1.344-0.047c0.305,0,0.612,0.008,0.914,0.016c0.925,0.026,1.817,0.03,2.747,0.053c0.304,0.007,0.615,0.016,0.915,0.016c0.621,0,1.17,0.073,1.245,0.614C17.104,7.675,17.014,7.954,16.933,8.17z"/>
+</symbol>
+<symbol id="icon-facebook" viewBox="0 0 24 24">
+<path d="M12,2C6.5,2,2,6.5,2,12c0,5,3.7,9.1,8.4,9.9v-7H7.9V12h2.5V9.8c0-2.5,1.5-3.9,3.8-3.9c1.1,0,2.2,0.2,2.2,0.2v2.5h-1.3 c-1.2,0-1.6,0.8-1.6,1.6V12h2.8l-0.4,2.9h-2.3v7C18.3,21.1,22,17,22,12C22,6.5,17.5,2,12,2z"/>
+</symbol>
+<symbol id="icon-feed" viewBox="0 0 24 24">
+<path d="M2,8.667V12c5.515,0,10,4.485,10,10h3.333C15.333,14.637,9.363,8.667,2,8.667z M2,2v3.333 c9.19,0,16.667,7.477,16.667,16.667H22C22,10.955,13.045,2,2,2z M4.5,17C3.118,17,2,18.12,2,19.5S3.118,22,4.5,22S7,20.88,7,19.5 S5.882,17,4.5,17z"/>
+</symbol>
+<symbol id="icon-fediverse" viewBox="0 0 24 24">
+<path d="M5.85081 8.88733C5.63868 9.29358 5.30628 9.62442 4.89905 9.83466L10.1241 15.0801L11.3838 14.4417L5.85081 8.88733ZM12.7428 15.8059L11.4831 16.4443L14.1306 19.1022C14.3428 18.6958 14.6752 18.3649 15.0825 18.1547L12.7428 15.8059ZM18.788 10.9628L15.83 12.4619L16.0481 13.857L19.3951 12.1608C19.0742 11.8335 18.8622 11.4151 18.788 10.9628ZM14.1128 13.3322L7.11871 16.8768C7.43963 17.2041 7.65166 17.6225 7.72582 18.0748L14.3309 14.7273L14.1128 13.3322ZM11.8635 4.60095L8.48868 11.1895L9.48512 12.1898L13.0584 5.21403C12.6065 5.13759 12.1892 4.92348 11.8635 4.60095ZM7.61092 12.9031L5.90146 16.2403C6.35333 16.3168 6.77058 16.5309 7.0962 16.8534L8.60729 13.9033L7.61092 12.9031ZM4.87004 9.8493C4.52582 10.0216 4.14278 10.1017 3.75836 10.0817C3.68642 10.0777 3.61473 10.0702 3.54352 10.0593L4.54173 16.444C4.88595 16.2717 5.26899 16.1916 5.65342 16.2116C5.7253 16.2156 5.79694 16.2231 5.86809 16.2341L4.87004 9.8493ZM7.73111 18.1064C7.75395 18.2547 7.76177 18.4049 7.75437 18.5547C7.73734 18.8604 7.65743 19.1592 7.51964 19.4326L13.9033 20.457C13.8805 20.3087 13.8727 20.1585 13.88 20.0087C13.897 19.703 13.977 19.4042 14.1148 19.1308L7.73111 18.1064ZM19.4175 12.1841L16.471 17.9364C16.923 18.0128 17.3403 18.227 17.666 18.5496L20.6124 12.7973C20.1604 12.7208 19.7431 12.5067 19.4175 12.1841ZM15.3989 4.04834C15.1867 4.45466 14.8542 4.78556 14.4469 4.99581L19.01 9.57651C19.2221 9.17019 19.5546 8.83929 19.9619 8.62904L15.3989 4.04834ZM11.234 3.37973L5.46578 6.30295C5.78666 6.63022 5.99866 7.04859 6.07282 7.50088L11.841 4.57753C11.5202 4.25029 11.3082 3.83197 11.234 3.37973ZM14.4364 5.0011C14.0876 5.17976 13.6978 5.26314 13.3064 5.24282C13.2412 5.23884 13.1762 5.23202 13.1116 5.22237L13.6226 8.49422L15.0168 8.71794L14.4364 5.0011ZM13.9196 10.3964L15.1276 18.132C15.4678 17.9652 15.8448 17.888 16.2231 17.9077C16.3011 17.9121 16.3788 17.9207 16.4559 17.9333L15.3138 10.62L13.9196 10.3964ZM6.07692 7.52543C6.10063 7.67596 6.10884 7.82852 6.10141 7.98072C6.08459 8.28399 6.00588 8.5806 5.87013 8.85231L9.1445 9.37821L9.78804 8.12143L6.07692 7.52543ZM11.6889 8.42664L11.0452 9.68356L18.7819 10.9261C18.7596 10.7795 18.7521 10.631 18.7594 10.483C18.7766 10.1755 18.8575 9.87496 18.9968 9.60035L11.6889 8.42664Z"/>
+<path d="M13.3174 5.04077C14.433 5.10157 15.3867 4.24642 15.4474 3.13079C15.5082 2.01516 14.6531 1.06149 13.5374 1.00073C12.4218 0.93994 11.4682 1.79509 11.4074 2.91072C11.3466 4.02635 12.2018 4.98002 13.3174 5.04077ZM20.8714 12.6241C21.987 12.6848 22.9407 11.8297 23.0015 10.714C23.0623 9.59842 22.2071 8.64478 21.0915 8.58399C19.9759 8.52323 19.0222 9.37838 18.9614 10.494C18.9006 11.6096 19.7558 12.5633 20.8714 12.6241ZM15.992 22.1497C17.1076 22.2105 18.0613 21.3554 18.1221 20.2398C18.1828 19.1241 17.3277 18.1705 16.2121 18.1097C15.0965 18.0489 14.1428 18.9041 14.082 20.0197C14.0212 21.1353 14.8764 22.089 15.992 22.1497ZM5.42232 20.4537C6.53795 20.5144 7.49162 19.6593 7.55238 18.5437C7.61317 17.428 6.75802 16.4744 5.64239 16.4136C4.52677 16.3529 3.5731 17.208 3.51234 18.3236C3.45158 19.4392 4.3067 20.3929 5.42232 20.4537ZM3.76933 9.87973C4.88496 9.94052 5.83863 9.08537 5.89938 7.96974C5.96014 6.85411 5.10503 5.90045 3.98937 5.83969C2.87374 5.77893 1.9201 6.63405 1.85931 7.74967C1.79855 8.8653 2.6537 9.81897 3.76933 9.87973Z"/>
+</symbol>
+<symbol id="icon-flickr" viewBox="0 0 24 24">
+<path d="M6.5,7c-2.75,0-5,2.25-5,5s2.25,5,5,5s5-2.25,5-5S9.25,7,6.5,7z M17.5,7c-2.75,0-5,2.25-5,5s2.25,5,5,5s5-2.25,5-5 S20.25,7,17.5,7z"/>
+</symbol>
+<symbol id="icon-foursquare" viewBox="0 0 24 24">
+<path d="M17.573,2c0,0-9.197,0-10.668,0S5,3.107,5,3.805s0,16.948,0,16.948c0,0.785,0.422,1.077,0.66,1.172 c0.238,0.097,0.892,0.177,1.285-0.275c0,0,5.035-5.843,5.122-5.93c0.132-0.132,0.132-0.132,0.262-0.132h3.26 c1.368,0,1.588-0.977,1.732-1.552c0.078-0.318,0.692-3.428,1.225-6.122l0.675-3.368C19.56,2.893,19.14,2,17.573,2z M16.495,7.22 c-0.053,0.252-0.372,0.518-0.665,0.518c-0.293,0-4.157,0-4.157,0c-0.467,0-0.802,0.318-0.802,0.787v0.508 c0,0.467,0.337,0.798,0.805,0.798c0,0,3.197,0,3.528,0s0.655,0.362,0.583,0.715c-0.072,0.353-0.407,2.102-0.448,2.295 c-0.04,0.193-0.262,0.523-0.655,0.523c-0.33,0-2.88,0-2.88,0c-0.523,0-0.683,0.068-1.033,0.503 c-0.35,0.437-3.505,4.223-3.505,4.223c-0.032,0.035-0.063,0.027-0.063-0.015V4.852c0-0.298,0.26-0.648,0.648-0.648 c0,0,8.228,0,8.562,0c0.315,0,0.61,0.297,0.528,0.683L16.495,7.22z"/>
+</symbol>
+<symbol id="icon-ghost" viewBox="0 0 24 24">
+<path d="M10.203,20.997H3.005v-3.599h7.198V20.997z M20.995,17.398h-7.193v3.599h7.193V17.398z M20.998,10.2H3v3.599h17.998V10.2zM13.803,3.003H3.005v3.599h10.798V3.003z M21,3.003h-3.599v3.599H21V3.003z"/>
+</symbol>
+<symbol id="icon-goodreads" viewBox="0 0 24 24">
+<path d="M17.3,17.5c-0.2,0.8-0.5,1.4-1,1.9c-0.4,0.5-1,0.9-1.7,1.2C13.9,20.9,13.1,21,12,21c-0.6,0-1.3-0.1-1.9-0.2 c-0.6-0.1-1.1-0.4-1.6-0.7c-0.5-0.3-0.9-0.7-1.2-1.2c-0.3-0.5-0.5-1.1-0.5-1.7h1.5c0.1,0.5,0.2,0.9,0.5,1.2 c0.2,0.3,0.5,0.6,0.9,0.8c0.3,0.2,0.7,0.3,1.1,0.4c0.4,0.1,0.8,0.1,1.2,0.1c1.4,0,2.5-0.4,3.1-1.2c0.6-0.8,1-2,1-3.5v-1.7h0 c-0.4,0.8-0.9,1.4-1.6,1.9c-0.7,0.5-1.5,0.7-2.4,0.7c-1,0-1.9-0.2-2.6-0.5C8.7,15,8.1,14.5,7.7,14c-0.5-0.6-0.8-1.3-1-2.1 c-0.2-0.8-0.3-1.6-0.3-2.5c0-0.9,0.1-1.7,0.4-2.5c0.3-0.8,0.6-1.5,1.1-2c0.5-0.6,1.1-1,1.8-1.4C10.3,3.2,11.1,3,12,3 c0.5,0,0.9,0.1,1.3,0.2c0.4,0.1,0.8,0.3,1.1,0.5c0.3,0.2,0.6,0.5,0.9,0.8c0.3,0.3,0.5,0.6,0.6,1h0V3.4h1.5V15 C17.6,15.9,17.5,16.7,17.3,17.5z M13.8,14.1c0.5-0.3,0.9-0.7,1.3-1.1c0.3-0.5,0.6-1,0.8-1.6c0.2-0.6,0.3-1.2,0.3-1.9 c0-0.6-0.1-1.2-0.2-1.9c-0.1-0.6-0.4-1.2-0.7-1.7c-0.3-0.5-0.7-0.9-1.3-1.2c-0.5-0.3-1.1-0.5-1.9-0.5s-1.4,0.2-1.9,0.5 c-0.5,0.3-1,0.7-1.3,1.2C8.5,6.4,8.3,7,8.1,7.6C8,8.2,7.9,8.9,7.9,9.5c0,0.6,0.1,1.3,0.2,1.9C8.3,12,8.6,12.5,8.9,13 c0.3,0.5,0.8,0.8,1.3,1.1c0.5,0.3,1.1,0.4,1.9,0.4C12.7,14.5,13.3,14.4,13.8,14.1z"/>
+</symbol>
+<symbol id="icon-google" viewBox="0 0 24 24">
+<path d="M12.02,10.18v3.72v0.01h5.51c-0.26,1.57-1.67,4.22-5.5,4.22c-3.31,0-6.01-2.75-6.01-6.12s2.7-6.12,6.01-6.12 c1.87,0,3.13,0.8,3.85,1.48l2.84-2.76C16.99,2.99,14.73,2,12.03,2c-5.52,0-10,4.48-10,10s4.48,10,10,10c5.77,0,9.6-4.06,9.6-9.77 c0-0.83-0.11-1.42-0.25-2.05H12.02z"/>
+</symbol>
+<symbol id="icon-github" viewBox="0 0 24 24">
+<path d="M12,2C6.477,2,2,6.477,2,12c0,4.419,2.865,8.166,6.839,9.489c0.5,0.09,0.682-0.218,0.682-0.484 c0-0.236-0.009-0.866-0.014-1.699c-2.782,0.602-3.369-1.34-3.369-1.34c-0.455-1.157-1.11-1.465-1.11-1.465 c-0.909-0.62,0.069-0.608,0.069-0.608c1.004,0.071,1.532,1.03,1.532,1.03c0.891,1.529,2.341,1.089,2.91,0.833
+c0.091-0.647,0.349-1.086,0.635-1.337c-2.22-0.251-4.555-1.111-4.555-4.943c0-1.091,0.39-1.984,1.03-2.682 C6.546,8.54,6.202,7.524,6.746,6.148c0,0,0.84-0.269,2.75,1.025C10.295,6.95,11.15,6.84,12,6.836 c0.85,0.004,1.705,0.114,2.504,0.336c1.909-1.294,2.748-1.025,2.748-1.025c0.546,1.376,0.202,2.394,0.1,2.646 c0.64,0.699,1.026,1.591,1.026,2.682c0,3.841-2.337,4.687-4.565,4.935c0.359,0.307,0.679,0.917,0.679,1.852 c0,1.335-0.012,2.415-0.012,2.741c0,0.269,0.18,0.579,0.688,0.481C19.138,20.161,22,16.416,22,12C22,6.477,17.523,2,12,2z"/>
+</symbol>
+<symbol id="icon-instagram" viewBox="0 0 24 24">
+<path d="M12,4.622c2.403,0,2.688,0.009,3.637,0.052c0.877,0.04,1.354,0.187,1.671,0.31c0.42,0.163,0.72,0.358,1.035,0.673 c0.315,0.315,0.51,0.615,0.673,1.035c0.123,0.317,0.27,0.794,0.31,1.671c0.043,0.949,0.052,1.234,0.052,3.637 s-0.009,2.688-0.052,3.637c-0.04,0.877-0.187,1.354-0.31,1.671c-0.163,0.42-0.358,0.72-0.673,1.035 c-0.315,0.315-0.615,0.51-1.035,0.673c-0.317,0.123-0.794,0.27-1.671,0.31c-0.949,0.043-1.233,0.052-3.637,0.052 s-2.688-0.009-3.637-0.052c-0.877-0.04-1.354-0.187-1.671-0.31c-0.42-0.163-0.72-0.358-1.035-0.673 c-0.315-0.315-0.51-0.615-0.673-1.035c-0.123-0.317-0.27-0.794-0.31-1.671C4.631,14.688,4.622,14.403,4.622,12 s0.009-2.688,0.052-3.637c0.04-0.877,0.187-1.354,0.31-1.671c0.163-0.42,0.358-0.72,0.673-1.035 c0.315-0.315,0.615-0.51,1.035-0.673c0.317-0.123,0.794-0.27,1.671-0.31C9.312,4.631,9.597,4.622,12,4.622 M12,3 C9.556,3,9.249,3.01,8.289,3.054C7.331,3.098,6.677,3.25,6.105,3.472C5.513,3.702,5.011,4.01,4.511,4.511 c-0.5,0.5-0.808,1.002-1.038,1.594C3.25,6.677,3.098,7.331,3.054,8.289C3.01,9.249,3,9.556,3,12c0,2.444,0.01,2.751,0.054,3.711 c0.044,0.958,0.196,1.612,0.418,2.185c0.23,0.592,0.538,1.094,1.038,1.594c0.5,0.5,1.002,0.808,1.594,1.038 c0.572,0.222,1.227,0.375,2.185,0.418C9.249,20.99,9.556,21,12,21s2.751-0.01,3.711-0.054c0.958-0.044,1.612-0.196,2.185-0.418 c0.592-0.23,1.094-0.538,1.594-1.038c0.5-0.5,0.808-1.002,1.038-1.594c0.222-0.572,0.375-1.227,0.418-2.185 C20.99,14.751,21,14.444,21,12s-0.01-2.751-0.054-3.711c-0.044-0.958-0.196-1.612-0.418-2.185c-0.23-0.592-0.538-1.094-1.038-1.594 c-0.5-0.5-1.002-0.808-1.594-1.038c-0.572-0.222-1.227-0.375-2.185-0.418C14.751,3.01,14.444,3,12,3L12,3z M12,7.378 c-2.552,0-4.622,2.069-4.622,4.622S9.448,16.622,12,16.622s4.622-2.069,4.622-4.622S14.552,7.378,12,7.378z M12,15 c-1.657,0-3-1.343-3-3s1.343-3,3-3s3,1.343,3,3S13.657,15,12,15z M16.804,6.116c-0.596,0-1.08,0.484-1.08,1.08 s0.484,1.08,1.08,1.08c0.596,0,1.08-0.484,1.08-1.08S17.401,6.116,16.804,6.116z"/>
+</symbol>
+<symbol id="icon-linkedin" viewBox="0 0 24 24">
+<path d="M19.7,3H4.3C3.582,3,3,3.582,3,4.3v15.4C3,20.418,3.582,21,4.3,21h15.4c0.718,0,1.3-0.582,1.3-1.3V4.3 C21,3.582,20.418,3,19.7,3z M8.339,18.338H5.667v-8.59h2.672V18.338z M7.004,8.574c-0.857,0-1.549-0.694-1.549-1.548 c0-0.855,0.691-1.548,1.549-1.548c0.854,0,1.547,0.694,1.547,1.548C8.551,7.881,7.858,8.574,7.004,8.574z M18.339,18.338h-2.669 v-4.177c0-0.996-0.017-2.278-1.387-2.278c-1.389,0-1.601,1.086-1.601,2.206v4.249h-2.667v-8.59h2.559v1.174h0.037 c0.356-0.675,1.227-1.387,2.526-1.387c2.703,0,3.203,1.779,3.203,4.092V18.338z"/>
+</symbol>
+<symbol id="icon-mail" viewBox="0 0 24 24">
+<path d="M20,4H4C2.895,4,2,4.895,2,6v12c0,1.105,0.895,2,2,2h16c1.105,0,2-0.895,2-2V6C22,4.895,21.105,4,20,4z M20,8.236l-8,4.882 L4,8.236V6h16V8.236z"/>
+</symbol>
+<symbol id="icon-mastodon" viewBox="0 0 24 24">
+<path style="fill-rule:evenodd" d="M20.617 13.92c-.265 1.36-2.37 2.85-4.788 3.14-1.262.15-2.503.288-3.827.228-2.165-.1-3.873-.517-3.873-.517 0 .212.013.412.04.6.28 2.136 2.118 2.264 3.858 2.324 1.756.06 3.32-.433 3.32-.433l.072 1.59s-1.228.658-3.417.78c-1.207.066-2.705-.03-4.45-.493-3.785-1-4.436-5.036-4.536-9.13-.03-1.215-.01-2.36-.01-3.32 0-4.186 2.74-5.413 2.74-5.413 1.384-.635 3.757-.902 6.225-.923h.06c2.467.022 4.842.29 6.225.924 0 0 2.742 1.227 2.742 5.413 0 0 .034 3.09-.383 5.233zm-2.854-4.91v5.07h-2.008V9.16c0-1.037-.436-1.563-1.31-1.563-.964 0-1.447.624-1.447 1.86v2.692h-1.996V9.455c0-1.235-.484-1.86-1.45-1.86-.872 0-1.308.527-1.308 1.564v4.92H6.236V9.01c0-1.034.263-1.858.793-2.467.546-.61 1.26-.92 2.15-.92 1.027 0 1.805.394 2.32 1.184l.5.84.5-.84c.514-.79 1.292-1.185 2.32-1.185.888 0 1.604.312 2.15.92.53.61.793 1.434.793 2.47z"/>
+</symbol>
+<symbol id="icon-meetup" viewBox="0 0 24 24">
+<path d="M19.24775,14.722a3.57032,3.57032,0,0,1-2.94457,3.52073,3.61886,3.61886,0,0,1-.64652.05634c-.07314-.0008-.10187.02846-.12507.09547A2.38881,2.38881,0,0,1,13.49453,20.094a2.33092,2.33092,0,0,1-1.827-.50716.13635.13635,0,0,0-.19878-.00408,3.191,3.191,0,0,1-2.104.60248,3.26309,3.26309,0,0,1-3.00324-2.71993,2.19076,2.19076,0,0,1-.03512-.30865c-.00156-.08579-.03413-.1189-.11608-.13493a2.86421,2.86421,0,0,1-1.23189-.56111,2.945,2.945,0,0,1-1.166-2.05749,2.97484,2.97484,0,0,1,.87524-2.50774.112.112,0,0,0,.02091-.16107,2.7213,2.7213,0,0,1-.36648-1.48A2.81256,2.81256,0,0,1,6.57673,7.58838a.35764.35764,0,0,0,.28869-.22819,4.2208,4.2208,0,0,1,6.02892-1.90111.25161.25161,0,0,0,.22023.0243,3.65608,3.65608,0,0,1,3.76031.90678A3.57244,3.57244,0,0,1,17.95918,8.626a2.97339,2.97339,0,0,1,.01829.57356.10637.10637,0,0,0,.0853.12792,1.97669,1.97669,0,0,1,1.27939,1.33733,2.00266,2.00266,0,0,1-.57112,2.12652c-.05284.05166-.04168.08328-.01173.13489A3.51189,3.51189,0,0,1,19.24775,14.722Zm-6.35959-.27836a1.6984,1.6984,0,0,0,1.14556,1.61113,3.82039,3.82039,0,0,0,1.036.17935,1.46888,1.46888,0,0,0,.73509-.12255.44082.44082,0,0,0,.26057-.44274.45312.45312,0,0,0-.29211-.43375.97191.97191,0,0,0-.20678-.063c-.21326-.03806-.42754-.0701-.63973-.11215a.54787.54787,0,0,1-.50172-.60926,2.75864,2.75864,0,0,1,.1773-.901c.1763-.535.414-1.045.64183-1.55913A12.686,12.686,0,0,0,15.85,10.47863a1.58461,1.58461,0,0,0,.04861-.87208,1.04531,1.04531,0,0,0-.85432-.83981,1.60658,1.60658,0,0,0-1.23654.16594.27593.27593,0,0,1-.36286-.03413c-.085-.0747-.16594-.15379-.24918-.23055a.98682.98682,0,0,0-1.33577-.04933,6.1468,6.1468,0,0,1-.4989.41615.47762.47762,0,0,1-.51535.03566c-.17448-.09307-.35512-.175-.53531-.25665a1.74949,1.74949,0,0,0-.56476-.2016,1.69943,1.69943,0,0,0-1.61654.91787,8.05815,8.05815,0,0,0-.32952.80126c-.45471,1.2557-.82507,2.53825-1.20838,3.81639a1.24151,1.24151,0,0,0,.51532,1.44389,1.42659,1.42659,0,0,0,1.22008.17166,1.09728,1.09728,0,0,0,.66994-.69764c.44145-1.04111.839-2.09989,1.25981-3.14926.11581-.28876.22792-.57874.35078-.86438a.44548.44548,0,0,1,.69189-.19539.50521.50521,0,0,1,.15044.43836,1.75625,1.75625,0,0,1-.14731.50453c-.27379.69219-.55265,1.38236-.82766,2.074a2.0836,2.0836,0,0,0-.14038.42876.50719.50719,0,0,0,.27082.57722.87236.87236,0,0,0,.66145.02739.99137.99137,0,0,0,.53406-.532q.61571-1.20914,1.228-2.42031.28423-.55863.57585-1.1133a.87189.87189,0,0,1,.29055-.35253.34987.34987,0,0,1,.37634-.01265.30291.30291,0,0,1,.12434.31459.56716.56716,0,0,1-.04655.1915c-.05318.12739-.10286.25669-.16183.38156-.34118.71775-.68754,1.43273-1.02568,2.152A2.00213,2.00213,0,0,0,12.88816,14.44366Zm4.78568,5.28972a.88573.88573,0,0,0-1.77139.00465.8857.8857,0,0,0,1.77139-.00465Zm-14.83838-7.296a.84329.84329,0,1,0,.00827-1.68655.8433.8433,0,0,0-.00827,1.68655Zm10.366-9.43673a.83506.83506,0,1,0-.0091,1.67.83505.83505,0,0,0,.0091-1.67Zm6.85014,5.22a.71651.71651,0,0,0-1.433.0093.71656.71656,0,0,0,1.433-.0093ZM5.37528,6.17908A.63823.63823,0,1,0,6.015,5.54483.62292.62292,0,0,0,5.37528,6.17908Zm6.68214,14.80843a.54949.54949,0,1,0-.55052.541A.54556.54556,0,0,0,12.05742,20.98752Zm8.53235-8.49689a.54777.54777,0,0,0-.54027.54023.53327.53327,0,0,0,.532.52293.51548.51548,0,0,0,.53272-.5237A.53187.53187,0,0,0,20.58977,12.49063ZM7.82846,2.4715a.44927.44927,0,1,0,.44484.44766A.43821.43821,0,0,0,7.82846,2.4715Zm13.775,7.60492a.41186.41186,0,0,0-.40065.39623.40178.40178,0,0,0,.40168.40168A.38994.38994,0,0,0,22,10.48172.39946.39946,0,0,0,21.60349,10.07642ZM5.79193,17.96207a.40469.40469,0,0,0-.397-.39646.399.399,0,0,0-.396.405.39234.39234,0,0,0,.39939.389A.39857.39857,0,0,0,5.79193,17.96207Z"/>
+</symbol>
+<symbol id="icon-medium" viewBox="0 0 24 24">
+<path d="M5.727 8.027a.623.623 0 0 0-.204-.527L4.02 5.687v-.273H8.69l3.614 7.926 3.175-7.926h4.457v.274l-1.285 1.234a.367.367 0 0 0-.144.36v9.066a.374.374 0 0 0 .144.363l1.258 1.234v.27h-6.324v-.27l1.3-1.265c.13-.13.13-.164.13-.36V8.988l-3.621 9.196h-.489L6.691 8.988v6.164c-.035.258.051.52.235.707l1.691 2.055v.27h-4.8v-.27l1.69-2.055a.814.814 0 0 0 .22-.707zm0 0"/>
+</symbol>
+<symbol id="icon-nextdoor" viewBox="0 0 24 24">
+<path d="M11.8615 0.651877C6.11188 0.714092 1.22843 5.12326 0.698031 10.9732C0.132369 17.213 4.73317 22.7304 10.9732 23.2962C17.213 23.8619 22.7304 19.2611 23.2962 13.0211C23.8619 6.78111 19.2611 1.26369 13.0211 0.69803C12.6356 0.663073 12.2486 0.647668 11.8615 0.651877ZM12.5886 7.09625C15.2249 7.09625 17.2615 8.96861 17.2615 11.3538V16.3385C17.2615 16.4649 17.1572 16.5692 17.0308 16.5692H14.9365C14.8755 16.5684 14.8173 16.5438 14.7742 16.5007C14.7311 16.4576 14.7065 16.3994 14.7057 16.3385V11.7C14.7057 10.6698 13.9102 9.49606 12.5884 9.49606C11.2093 9.49606 10.4712 10.6698 10.4712 11.7V16.3385C10.4712 16.4649 10.3669 16.5692 10.2404 16.5692H8.14615C8.02062 16.5692 7.92111 16.464 7.92111 16.3385V11.8442C7.92111 11.7076 7.82345 11.5924 7.69034 11.5615C5.26634 11.0206 4.89988 9.66277 4.85188 7.66154C4.85095 7.60025 4.87809 7.53785 4.92111 7.49428C4.96412 7.45052 5.02135 7.42505 5.08265 7.42505L7.24043 7.43649C7.36228 7.43834 7.45957 7.53415 7.46529 7.65581C7.48929 8.47551 7.54615 9.39231 8.28462 9.39231C8.43785 9.39231 8.55102 9.17464 8.61932 9.07495C9.43348 7.87864 10.8864 7.09625 12.5886 7.09625Z"/>
+</symbol>
+<symbol id="icon-patreon" viewBox="0 0 24 24">
+<path d="M20 7.40755C19.9969 5.10922 18.2543 3.22555 16.2097 2.54588C13.6708 1.70188 10.3222 1.82421 7.89775 2.99921C4.95932 4.42355 4.03626 7.54355 4.00186 10.6552C3.97363 13.2136 4.2222 19.9517 7.92225 19.9997C10.6715 20.0356 11.0809 16.3967 12.3529 14.6442C13.258 13.3974 14.4233 13.0452 15.8578 12.6806C18.3233 12.0537 20.0036 10.0551 20 7.40755Z"/>
+</symbol>
+<symbol id="icon-pinterest" viewBox="0 0 24 24">
+<path d="M12.289,2C6.617,2,3.606,5.648,3.606,9.622c0,1.846,1.025,4.146,2.666,4.878c0.25,0.111,0.381,0.063,0.439-0.169 c0.044-0.175,0.267-1.029,0.365-1.428c0.032-0.128,0.017-0.237-0.091-0.362C6.445,11.911,6.01,10.75,6.01,9.668 c0-2.777,2.194-5.464,5.933-5.464c3.23,0,5.49,2.108,5.49,5.122c0,3.407-1.794,5.768-4.13,5.768c-1.291,0-2.257-1.021-1.948-2.277 c0.372-1.495,1.089-3.112,1.089-4.191c0-0.967-0.542-1.775-1.663-1.775c-1.319,0-2.379,1.309-2.379,3.059 c0,1.115,0.394,1.869,0.394,1.869s-1.302,5.279-1.54,6.261c-0.405,1.666,0.053,4.368,0.094,4.604 c0.021,0.126,0.167,0.169,0.25,0.063c0.129-0.165,1.699-2.419,2.142-4.051c0.158-0.59,0.817-2.995,0.817-2.995 c0.43,0.784,1.681,1.446,3.013,1.446c3.963,0,6.822-3.494,6.822-7.833C20.394,5.112,16.849,2,12.289,2"/>
+</symbol>
+<symbol id="icon-pocket" viewBox="0 0 24 24">
+<path d="M21.927,4.194C21.667,3.48,20.982,3,20.222,3h-0.01h-1.721H3.839C3.092,3,2.411,3.47,2.145,4.17 C2.066,4.378,2.026,4.594,2.026,4.814v6.035l0.069,1.2c0.29,2.73,1.707,5.115,3.899,6.778c0.039,0.03,0.079,0.059,0.119,0.089 l0.025,0.018c1.175,0.859,2.491,1.441,3.91,1.727c0.655,0.132,1.325,0.2,1.991,0.2c0.615,0,1.232-0.057,1.839-0.17 c0.073-0.014,0.145-0.028,0.219-0.044c0.02-0.004,0.042-0.012,0.064-0.023c1.359-0.297,2.621-0.864,3.753-1.691l0.025-0.018 c0.04-0.029,0.08-0.058,0.119-0.089c2.192-1.664,3.609-4.049,3.898-6.778l0.069-1.2V4.814C22.026,4.605,22,4.398,21.927,4.194z M17.692,10.481l-4.704,4.512c-0.266,0.254-0.608,0.382-0.949,0.382c-0.342,0-0.684-0.128-0.949-0.382l-4.705-4.512 C5.838,9.957,5.82,9.089,6.344,8.542c0.524-0.547,1.392-0.565,1.939-0.04l3.756,3.601l3.755-3.601 c0.547-0.524,1.415-0.506,1.939,0.04C18.256,9.089,18.238,9.956,17.692,10.481z"/>
+</symbol>
+<symbol id="icon-ravelry" viewBox="0 0 23 20">
+<path d="M12.098 19.34a.25.25 0 01-.118-.043 13.986 13.986 0 01-.394-.258c-.164-.11-.477-.352-.934-.723-.46-.375-.882-.761-1.27-1.168-.39-.406-.796-.925-1.218-1.562a8.521 8.521 0 01-.976-1.926c-.125-.023-.758-.16-1.907-.414A8.785 8.785 0 007.84 17.29a8.152 8.152 0 004.258 2.05zm-6.98-6.762l1.831.313A13.424 13.424 0 016.5 11.02a16.216 16.216 0 01-.207-1.622l-.043-.593c-.61.61-1.047 1.445-1.316 2.5.035.484.097.91.183 1.273zm1.198-6.797a9.064 9.064 0 00-.84 1.653c.32-.344.59-.598.81-.758zm15.649 4.844a8.8 8.8 0 00-.676-3.426 8.85 8.85 0 00-1.824-2.812 8.614 8.614 0 00-2.727-1.883 8.115 8.115 0 00-3.312-.695 8.131 8.131 0 00-3.059.586A8.412 8.412 0 007.754 4.05c-.219.433-.383 1.027-.488 1.785a5.407 5.407 0 011.554-.93 7.481 7.481 0 011.727-.48 16.642 16.642 0 011.558-.153c.489-.02.883-.015 1.18.012l.438.035c.238.008.43.063.574.172a.66.66 0 01.27.367c.03.141.054.278.07.414a.8.8 0 01-.012.317 12.781 12.781 0 00-2.477-.004 7.093 7.093 0 00-1.992.484 9.6 9.6 0 00-1.554.801A12.46 12.46 0 007.176 7.97c.031.27.07.613.125 1.031.054.422.183 1.082.386 1.988.204.903.43 1.57.676 2.004.895.043 1.793-.012 2.696-.164.902-.152 1.683-.351 2.336-.598a20.681 20.681 0 001.77-.746c.526-.254.925-.472 1.19-.66l.407-.265c.156-.121.3-.196.43-.23a.367.367 0 01.331.058c.094.07.157.199.184.383.102.722-.039 1.171-.426 1.351-1.508.723-3.203 1.219-5.086 1.496-.976.149-2.129.207-3.449.176a7.673 7.673 0 001.195 1.973c.504.597 1 1.07 1.493 1.418.496.343.968.636 1.421.878.454.243.825.407 1.106.489l.426.133c1.039.171 1.992.113 2.863-.168 1.414-.739 2.555-1.813 3.418-3.227.867-1.414 1.297-2.969 1.297-4.664zm.805-.414c-.102 1.004-.247 1.793-.434 2.367-.508 1.547-1.168 2.836-1.977 3.867-.808 1.032-1.964 1.973-3.468 2.828-.348.247-.645.41-.895.493-.52.195-1.113.254-1.773.18-.262.019-.528.03-.797.03-2.055 0-3.883-.64-5.492-1.93-1.61-1.288-2.68-2.929-3.22-4.933-.007 0-.019 0-.042-.004-.024-.004-.04-.007-.055-.007-.043.375-.035.793.028 1.257.062.465.156.891.285 1.282.125.39.254.757.39 1.093.133.34.25.606.344.801l.152.29c.059.09.254.394.586.913a4.327 4.327 0 01-1.355-1.187 5.669 5.669 0 01-.856-1.563 14.087 14.087 0 01-.43-1.531 9.012 9.012 0 01-.19-1.2l-.02-.468c-.035-.016-.16-.059-.367-.137-.207-.078-.383-.148-.528-.203-.144-.054-.336-.133-.578-.226a9.221 9.221 0 01-.625-.282c-.176-.09-.36-.183-.543-.285-.187-.097-.34-.199-.465-.3a1.27 1.27 0 01-.27-.286c.138.075.321.172.548.285.23.118.64.286 1.23.508.594.223 1.121.364 1.586.426l.023-.36c.079-1.109.418-2.187 1.024-3.234A9.226 9.226 0 016.5 4.621c.203-.855.5-1.652.883-2.39.11-.208.226-.376.347-.5.125-.13.305-.247.536-.36 1.148-.55 2.25-.937 3.304-1.16A9.935 9.935 0 0114.86.09c1.136.14 2.25.5 3.34 1.082 1.593.855 2.804 2.105 3.624 3.75.82 1.644 1.137 3.406.946 5.289zm0 0"/>
+</symbol>
+<symbol id="icon-reddit" viewBox="0 0 24 24">
+<path d="M22,11.816c0-1.256-1.021-2.277-2.277-2.277c-0.593,0-1.122,0.24-1.526,0.614c-1.481-0.965-3.455-1.594-5.647-1.69 l1.171-3.702l3.18,0.748c0.008,1.028,0.846,1.862,1.876,1.862c1.035,0,1.877-0.842,1.877-1.878c0-1.035-0.842-1.877-1.877-1.877 c-0.769,0-1.431,0.466-1.72,1.13l-3.508-0.826c-0.203-0.047-0.399,0.067-0.46,0.261l-1.35,4.268 c-2.316,0.038-4.411,0.67-5.97,1.671C5.368,9.765,4.853,9.539,4.277,9.539C3.021,9.539,2,10.56,2,11.816 c0,0.814,0.433,1.523,1.078,1.925c-0.037,0.221-0.061,0.444-0.061,0.672c0,3.292,4.011,5.97,8.941,5.97s8.941-2.678,8.941-5.97 c0-0.214-0.02-0.424-0.053-0.632C21.533,13.39,22,12.661,22,11.816z M18.776,4.394c0.606,0,1.1,0.493,1.1,1.1s-0.493,1.1-1.1,1.1 s-1.1-0.494-1.1-1.1S18.169,4.394,18.776,4.394z M2.777,11.816c0-0.827,0.672-1.5,1.499-1.5c0.313,0,0.598,0.103,0.838,0.269 c-0.851,0.676-1.477,1.479-1.812,2.36C2.983,12.672,2.777,12.27,2.777,11.816z M11.959,19.606c-4.501,0-8.164-2.329-8.164-5.193 S7.457,9.22,11.959,9.22s8.164,2.329,8.164,5.193S16.46,19.606,11.959,19.606z M20.636,13.001c-0.326-0.89-0.948-1.701-1.797-2.384 c0.248-0.186,0.55-0.301,0.883-0.301c0.827,0,1.5,0.673,1.5,1.5C21.223,12.299,20.992,12.727,20.636,13.001z M8.996,14.704 c-0.76,0-1.397-0.616-1.397-1.376c0-0.76,0.637-1.397,1.397-1.397c0.76,0,1.376,0.637,1.376,1.397 C10.372,14.088,9.756,14.704,8.996,14.704z M16.401,13.328c0,0.76-0.616,1.376-1.376,1.376c-0.76,0-1.399-0.616-1.399-1.376 c0-0.76,0.639-1.397,1.399-1.397C15.785,11.931,16.401,12.568,16.401,13.328z M15.229,16.708c0.152,0.152,0.152,0.398,0,0.55 c-0.674,0.674-1.727,1.002-3.219,1.002c-0.004,0-0.007-0.002-0.011-0.002c-0.004,0-0.007,0.002-0.011,0.002 c-1.492,0-2.544-0.328-3.218-1.002c-0.152-0.152-0.152-0.398,0-0.55c0.152-0.152,0.399-0.151,0.55,0 c0.521,0.521,1.394,0.775,2.669,0.775c0.004,0,0.007,0.002,0.011,0.002c0.004,0,0.007-0.002,0.011-0.002 c1.275,0,2.148-0.253,2.669-0.775C14.831,16.556,15.078,16.556,15.229,16.708z"/>
+</symbol>
+<symbol id="icon-skype" viewBox="0 0 24 24">
+<path d="M10.113,2.699c0.033-0.006,0.067-0.013,0.1-0.02c0.033,0.017,0.066,0.033,0.098,0.051L10.113,2.699z M2.72,10.223 c-0.006,0.034-0.011,0.069-0.017,0.103c0.018,0.032,0.033,0.064,0.051,0.095L2.72,10.223z M21.275,13.771 c0.007-0.035,0.011-0.071,0.018-0.106c-0.018-0.031-0.033-0.064-0.052-0.095L21.275,13.771z M13.563,21.199 c0.032,0.019,0.065,0.035,0.096,0.053c0.036-0.006,0.071-0.011,0.105-0.017L13.563,21.199z M22,16.386 c0,1.494-0.581,2.898-1.637,3.953c-1.056,1.057-2.459,1.637-3.953,1.637c-0.967,0-1.914-0.251-2.75-0.725 c0.036-0.006,0.071-0.011,0.105-0.017l-0.202-0.035c0.032,0.019,0.065,0.035,0.096,0.053c-0.543,0.096-1.099,0.147-1.654,0.147 c-1.275,0-2.512-0.25-3.676-0.743c-1.125-0.474-2.135-1.156-3.002-2.023c-0.867-0.867-1.548-1.877-2.023-3.002 c-0.493-1.164-0.743-2.401-0.743-3.676c0-0.546,0.049-1.093,0.142-1.628c0.018,0.032,0.033,0.064,0.051,0.095L2.72,10.223 c-0.006,0.034-0.011,0.069-0.017,0.103C2.244,9.5,2,8.566,2,7.615c0-1.493,0.582-2.898,1.637-3.953 c1.056-1.056,2.46-1.638,3.953-1.638c0.915,0,1.818,0.228,2.622,0.655c-0.033,0.007-0.067,0.013-0.1,0.02l0.199,0.031 c-0.032-0.018-0.066-0.034-0.098-0.051c0.002,0,0.003-0.001,0.004-0.001c0.586-0.112,1.187-0.169,1.788-0.169 c1.275,0,2.512,0.249,3.676,0.742c1.124,0.476,2.135,1.156,3.002,2.024c0.868,0.867,1.548,1.877,2.024,3.002 c0.493,1.164,0.743,2.401,0.743,3.676c0,0.575-0.054,1.15-0.157,1.712c-0.018-0.031-0.033-0.064-0.052-0.095l0.034,0.201 c0.007-0.035,0.011-0.071,0.018-0.106C21.754,14.494,22,15.432,22,16.386z M16.817,14.138c0-1.331-0.613-2.743-3.033-3.282 l-2.209-0.49c-0.84-0.192-1.807-0.444-1.807-1.237c0-0.794,0.679-1.348,1.903-1.348c2.468,0,2.243,1.696,3.468,1.696 c0.645,0,1.209-0.379,1.209-1.031c0-1.521-2.435-2.663-4.5-2.663c-2.242,0-4.63,0.952-4.63,3.488c0,1.221,0.436,2.521,2.839,3.123 l2.984,0.745c0.903,0.223,1.129,0.731,1.129,1.189c0,0.762-0.758,1.507-2.129,1.507c-2.679,0-2.307-2.062-3.743-2.062 c-0.645,0-1.113,0.444-1.113,1.078c0,1.236,1.501,2.886,4.856,2.886C15.236,17.737,16.817,16.199,16.817,14.138z"/>
+</symbol>
+<symbol id="icon-slideshare" viewBox="0 0 24 24">
+<path d="M11.738,10.232a2.142,2.142,0,0,1-.721,1.619,2.556,2.556,0,0,1-3.464,0,2.183,2.183,0,0,1,0-3.243,2.572,2.572,0,0,1,3.464,0A2.136,2.136,0,0,1,11.738,10.232Zm5.7,0a2.15,2.15,0,0,1-.715,1.619,2.563,2.563,0,0,1-3.469,0,2.183,2.183,0,0,1,0-3.243,2.58,2.58,0,0,1,3.469,0A2.144,2.144,0,0,1,17.439,10.232Zm2.555,2.045V4.7a2.128,2.128,0,0,0-.363-1.4,1.614,1.614,0,0,0-1.261-.415H5.742a1.656,1.656,0,0,0-1.278.386A2.246,2.246,0,0,0,4.129,4.7v7.643a8.212,8.212,0,0,0,1,.454q.516.193.92.318a6.847,6.847,0,0,0,.92.21q.516.085.806.125a6.615,6.615,0,0,0,.795.045l.665.006q.16,0,.642-.023t.506-.023a1.438,1.438,0,0,1,1.079.307,1.134,1.134,0,0,0,.114.1,7.215,7.215,0,0,0,.693.579q.079-1.033,1.34-.988.057,0,.415.017l.488.023q.13.006.517.011t.6-.011l.619-.051a5.419,5.419,0,0,0,.693-.1l.7-.153a5.353,5.353,0,0,0,.761-.221q.345-.131.766-.307a8.727,8.727,0,0,0,.818-.392Zm1.851-.057a10.4,10.4,0,0,1-4.225,2.862,6.5,6.5,0,0,1-.261,5.281,3.524,3.524,0,0,1-2.078,1.681,2.452,2.452,0,0,1-2.067-.17,1.915,1.915,0,0,1-.931-1.863l-.011-3.7V16.3l-.279-.068q-.188-.045-.267-.057l-.011,3.839a1.9,1.9,0,0,1-.943,1.863,2.481,2.481,0,0,1-2.078.17,3.519,3.519,0,0,1-2.067-1.7,6.546,6.546,0,0,1-.25-5.258A10.4,10.4,0,0,1,2.152,12.22a.56.56,0,0,1-.045-.715q.238-.3.681.011l.125.079a.767.767,0,0,1,.125.091V3.8a1.987,1.987,0,0,1,.534-1.4,1.7,1.7,0,0,1,1.295-.579H19.141a1.7,1.7,0,0,1,1.295.579,1.985,1.985,0,0,1,.534,1.4v7.882l.238-.17q.443-.307.681-.011a.56.56,0,0,1-.045.715Z"/>
+</symbol>
+<symbol id="icon-snapchat" viewBox="0 0 24 24">
+<path d="M12.065,2a5.526,5.526,0,0,1,3.132.892A5.854,5.854,0,0,1,17.326,5.4a5.821,5.821,0,0,1,.351,2.33q0,.612-.117,2.487a.809.809,0,0,0,.365.091,1.93,1.93,0,0,0,.664-.176,1.93,1.93,0,0,1,.664-.176,1.3,1.3,0,0,1,.729.234.7.7,0,0,1,.351.6.839.839,0,0,1-.41.7,2.732,2.732,0,0,1-.9.41,3.192,3.192,0,0,0-.9.378.728.728,0,0,0-.41.618,1.575,1.575,0,0,0,.156.56,6.9,6.9,0,0,0,1.334,1.953,5.6,5.6,0,0,0,1.881,1.315,5.875,5.875,0,0,0,1.042.3.42.42,0,0,1,.365.456q0,.911-2.852,1.341a1.379,1.379,0,0,0-.143.507,1.8,1.8,0,0,1-.182.605.451.451,0,0,1-.429.241,5.878,5.878,0,0,1-.807-.085,5.917,5.917,0,0,0-.833-.085,4.217,4.217,0,0,0-.807.065,2.42,2.42,0,0,0-.82.293,6.682,6.682,0,0,0-.755.5q-.351.267-.755.527a3.886,3.886,0,0,1-.989.436A4.471,4.471,0,0,1,11.831,22a4.307,4.307,0,0,1-1.256-.176,3.784,3.784,0,0,1-.976-.436q-.4-.26-.749-.527a6.682,6.682,0,0,0-.755-.5,2.422,2.422,0,0,0-.807-.293,4.432,4.432,0,0,0-.82-.065,5.089,5.089,0,0,0-.853.1,5,5,0,0,1-.762.1.474.474,0,0,1-.456-.241,1.819,1.819,0,0,1-.182-.618,1.411,1.411,0,0,0-.143-.521q-2.852-.429-2.852-1.341a.42.42,0,0,1,.365-.456,5.793,5.793,0,0,0,1.042-.3,5.524,5.524,0,0,0,1.881-1.315,6.789,6.789,0,0,0,1.334-1.953A1.575,1.575,0,0,0,6,12.9a.728.728,0,0,0-.41-.618,3.323,3.323,0,0,0-.9-.384,2.912,2.912,0,0,1-.9-.41.814.814,0,0,1-.41-.684.71.71,0,0,1,.338-.593,1.208,1.208,0,0,1,.716-.241,1.976,1.976,0,0,1,.625.169,2.008,2.008,0,0,0,.69.169.919.919,0,0,0,.416-.091q-.117-1.849-.117-2.474A5.861,5.861,0,0,1,6.385,5.4,5.516,5.516,0,0,1,8.625,2.819,7.075,7.075,0,0,1,12.062,2Z"/>
+</symbol>
+<symbol id="icon-soundcloud" viewBox="0 0 24 24">
+<path d="M8.9,16.1L9,14L8.9,9.5c0-0.1,0-0.1-0.1-0.1c0,0-0.1-0.1-0.1-0.1c-0.1,0-0.1,0-0.1,0.1c0,0-0.1,0.1-0.1,0.1L8.3,14l0.1,2.1 c0,0.1,0,0.1,0.1,0.1c0,0,0.1,0.1,0.1,0.1C8.8,16.3,8.9,16.3,8.9,16.1z M11.4,15.9l0.1-1.8L11.4,9c0-0.1,0-0.2-0.1-0.2 c0,0-0.1,0-0.1,0s-0.1,0-0.1,0c-0.1,0-0.1,0.1-0.1,0.2l0,0.1l-0.1,5c0,0,0,0.7,0.1,2v0c0,0.1,0,0.1,0.1,0.1c0.1,0.1,0.1,0.1,0.2,0.1 c0.1,0,0.1,0,0.2-0.1c0.1,0,0.1-0.1,0.1-0.2L11.4,15.9z M2.4,12.9L2.5,14l-0.2,1.1c0,0.1,0,0.1-0.1,0.1c0,0-0.1,0-0.1-0.1L2.1,14 l0.1-1.1C2.2,12.9,2.3,12.9,2.4,12.9C2.3,12.9,2.4,12.9,2.4,12.9z M3.1,12.2L3.3,14l-0.2,1.8c0,0.1,0,0.1-0.1,0.1 c-0.1,0-0.1,0-0.1-0.1L2.8,14L3,12.2C3,12.2,3,12.2,3.1,12.2C3.1,12.2,3.1,12.2,3.1,12.2z M3.9,11.9L4.1,14l-0.2,2.1 c0,0.1,0,0.1-0.1,0.1c-0.1,0-0.1,0-0.1-0.1L3.5,14l0.2-2.1c0-0.1,0-0.1,0.1-0.1C3.9,11.8,3.9,11.8,3.9,11.9z M4.7,11.9L4.9,14 l-0.2,2.1c0,0.1-0.1,0.1-0.1,0.1c-0.1,0-0.1,0-0.1-0.1L4.3,14l0.2-2.2c0-0.1,0-0.1,0.1-0.1C4.7,11.7,4.7,11.8,4.7,11.9z M5.6,12 l0.2,2l-0.2,2.1c0,0.1-0.1,0.1-0.1,0.1c0,0-0.1,0-0.1,0c0,0,0-0.1,0-0.1L5.1,14l0.2-2c0,0,0-0.1,0-0.1s0.1,0,0.1,0 C5.5,11.9,5.5,11.9,5.6,12L5.6,12z M6.4,10.7L6.6,14l-0.2,2.1c0,0,0,0.1,0,0.1c0,0-0.1,0-0.1,0c-0.1,0-0.1-0.1-0.2-0.2L5.9,14 l0.2-3.3c0-0.1,0.1-0.2,0.2-0.2c0,0,0.1,0,0.1,0C6.4,10.7,6.4,10.7,6.4,10.7z M7.2,10l0.2,4.1l-0.2,2.1c0,0,0,0.1,0,0.1 c0,0-0.1,0-0.1,0c-0.1,0-0.2-0.1-0.2-0.2l-0.1-2.1L6.8,10c0-0.1,0.1-0.2,0.2-0.2c0,0,0.1,0,0.1,0S7.2,9.9,7.2,10z M8,9.6L8.2,14 L8,16.1c0,0.1-0.1,0.2-0.2,0.2c-0.1,0-0.2-0.1-0.2-0.2L7.5,14l0.1-4.4c0-0.1,0-0.1,0.1-0.1c0,0,0.1-0.1,0.1-0.1c0.1,0,0.1,0,0.1,0.1 C8,9.6,8,9.6,8,9.6z M11.4,16.1L11.4,16.1L11.4,16.1z M9.7,9.6L9.8,14l-0.1,2.1c0,0.1,0,0.1-0.1,0.2s-0.1,0.1-0.2,0.1 c-0.1,0-0.1,0-0.1-0.1s-0.1-0.1-0.1-0.2L9.2,14l0.1-4.4c0-0.1,0-0.1,0.1-0.2s0.1-0.1,0.2-0.1c0.1,0,0.1,0,0.2,0.1S9.7,9.5,9.7,9.6 L9.7,9.6z M10.6,9.8l0.1,4.3l-0.1,2c0,0.1,0,0.1-0.1,0.2c0,0-0.1,0.1-0.2,0.1c-0.1,0-0.1,0-0.2-0.1c0,0-0.1-0.1-0.1-0.2L10,14 l0.1-4.3c0-0.1,0-0.1,0.1-0.2c0,0,0.1-0.1,0.2-0.1c0.1,0,0.1,0,0.2,0.1S10.6,9.7,10.6,9.8z M12.4,14l-0.1,2c0,0.1,0,0.1-0.1,0.2 c-0.1,0.1-0.1,0.1-0.2,0.1c-0.1,0-0.1,0-0.2-0.1c-0.1-0.1-0.1-0.1-0.1-0.2l-0.1-1l-0.1-1l0.1-5.5v0c0-0.1,0-0.2,0.1-0.2 c0.1,0,0.1-0.1,0.2-0.1c0,0,0.1,0,0.1,0c0.1,0,0.1,0.1,0.1,0.2L12.4,14z M22.1,13.9c0,0.7-0.2,1.3-0.7,1.7c-0.5,0.5-1.1,0.7-1.7,0.7 h-6.8c-0.1,0-0.1,0-0.2-0.1c-0.1-0.1-0.1-0.1-0.1-0.2V8.2c0-0.1,0.1-0.2,0.2-0.3c0.5-0.2,1-0.3,1.6-0.3c1.1,0,2.1,0.4,2.9,1.1 c0.8,0.8,1.3,1.7,1.4,2.8c0.3-0.1,0.6-0.2,1-0.2c0.7,0,1.3,0.2,1.7,0.7C21.8,12.6,22.1,13.2,22.1,13.9L22.1,13.9z"/>
+</symbol>
+<symbol id="icon-spotify" viewBox="0 0 24 24">
+<path d="M12,2C6.477,2,2,6.477,2,12c0,5.523,4.477,10,10,10c5.523,0,10-4.477,10-10C22,6.477,17.523,2,12,2 M16.586,16.424 c-0.18,0.295-0.563,0.387-0.857,0.207c-2.348-1.435-5.304-1.76-8.785-0.964c-0.335,0.077-0.67-0.133-0.746-0.469 c-0.077-0.335,0.132-0.67,0.469-0.746c3.809-0.871,7.077-0.496,9.713,1.115C16.673,15.746,16.766,16.13,16.586,16.424 M17.81,13.7 c-0.226,0.367-0.706,0.482-1.072,0.257c-2.687-1.652-6.785-2.131-9.965-1.166C6.36,12.917,5.925,12.684,5.8,12.273 C5.675,11.86,5.908,11.425,6.32,11.3c3.632-1.102,8.147-0.568,11.234,1.328C17.92,12.854,18.035,13.335,17.81,13.7 M17.915,10.865 c-3.223-1.914-8.54-2.09-11.618-1.156C5.804,9.859,5.281,9.58,5.131,9.086C4.982,8.591,5.26,8.069,5.755,7.919 c3.532-1.072,9.404-0.865,13.115,1.338c0.445,0.264,0.59,0.838,0.327,1.282C18.933,10.983,18.359,11.129,17.915,10.865"/>
+</symbol>
+<symbol id="icon-stackoverflow" viewBox="0 0 24 24">
+<path d="m 17.817128,20.228605 v -5.337217 h 1.771431 V 22 H 3.6 v -7.108612 h 1.771401 v 5.337217 z" />
+<path d="m 7.3267845,14.385359 8.6959295,1.817316 0.368168,-1.748385 -8.6959318,-1.817319 z m 1.1503197,-4.140944 8.0517968,3.749872 0.73617,-1.610385 -8.0518344,-3.7728517 z m 2.2315078,-3.9569154 6.832405,5.6822664 1.12738,-1.357316 -6.832576,-5.6822636 z m 4.417,-4.2099019 -1.426448,1.0581864 5.291191,7.1316119 1.426412,-1.0582745 z M 7.1427296,18.434189 h 8.8799844 v -1.7713 H 7.1427296 Z" />
+<path d="m 17.817128,20.228605 v -5.337217 h 1.771431 V 22 H 3.6 v -7.108612 h 1.771401 v 5.337217 z" />
+<path d="m 7.3267845,14.385359 8.6959295,1.817316 0.368168,-1.748385 -8.6959318,-1.817319 z m 1.1503197,-4.140944 8.0517968,3.749872 0.73617,-1.610385 -8.0518344,-3.7728517 z m 2.2315078,-3.9569154 6.832405,5.6822664 1.12738,-1.357316 -6.832576,-5.6822636 z m 4.417,-4.2099019 -1.426448,1.0581864 5.291191,7.1316119 1.426412,-1.0582745 z M 7.1427296,18.434189 h 8.8799844 v -1.7713 H 7.1427296 Z" />
+</symbol>
+<symbol id="icon-strava" viewBox="0 0 24 24">
+<path d="M15.387 17.944l-2.089-4.116h-3.065L15.387 24l5.15-10.172h-3.066m-7.008-5.599l2.836 5.598h4.172L10.463 0l-7 13.828h4.169"/>
+</symbol>
+<symbol id="icon-stumbleupon" viewBox="0 0 24 24">
+<path d="M12,4.294c-2.469,0-4.471,2.002-4.471,4.471v6.353c0,0.585-0.474,1.059-1.059,1.059c-0.585,0-1.059-0.474-1.059-1.059 v-2.824H2v2.941c0,2.469,2.002,4.471,4.471,4.471c2.469,0,4.471-2.002,4.471-4.471V8.765c0-0.585,0.474-1.059,1.059-1.059 s1.059,0.474,1.059,1.059v1.294l1.412,0.647l2-0.647V8.765C16.471,6.296,14.469,4.294,12,4.294z M13.059,12.353v2.882 c0,2.469,2.002,4.471,4.471,4.471S22,17.704,22,15.235v-2.824h-3.412v2.824c0,0.585-0.474,1.059-1.059,1.059 c-0.585,0-1.059-0.474-1.059-1.059v-2.882l-2,0.647L13.059,12.353z"/>
+</symbol>
+<symbol id="icon-threads" viewBox="0 0 24 24">
+<path d="M16.0671 11.1235C15.9632 11.0737 15.8583 11.0261 15.7524 10.9806C15.5671 7.56725 13.702 5.61312 10.5702 5.59312H10.5278C8.6545 5.59312 7.09663 6.39262 6.13775 7.84762L7.86012 9.02913C8.57637 7.94225 9.70062 7.71063 10.5286 7.71063H10.5573C11.5884 7.71725 12.3665 8.01713 12.8701 8.60175C13.2366 9.02738 13.4817 9.61562 13.6031 10.358C12.6889 10.2026 11.7001 10.1547 10.6431 10.2155C7.66562 10.3869 5.75138 12.1235 5.88 14.5365C5.94525 15.7605 6.555 16.8135 7.59688 17.5014C8.47775 18.0829 9.61238 18.3673 10.7915 18.3029C12.3488 18.2175 13.5704 17.6234 14.4226 16.537C15.0699 15.712 15.4792 14.6429 15.66 13.2957C16.4021 13.7436 16.9521 14.333 17.2559 15.0415C17.7724 16.2459 17.8025 18.225 16.1876 19.8385C14.7728 21.252 13.072 21.8635 10.5016 21.8824C7.6505 21.8613 5.49412 20.9469 4.09225 19.1646C2.7795 17.4958 2.101 15.0852 2.07562 12C2.101 8.91475 2.77937 6.50425 4.09225 4.83537C5.49425 3.05312 7.6505 2.13875 10.5016 2.1175C13.3735 2.13875 15.5674 3.0575 17.023 4.84837C17.7368 5.72662 18.2749 6.83087 18.6296 8.11862L20.648 7.58012C20.218 5.99512 19.5414 4.62937 18.6206 3.49662C16.7545 1.20088 14.0252 0.024375 10.5087 0H10.4946C6.98525 0.02425 4.2865 1.20525 2.4735 3.51C0.86025 5.56063 0.0280001 8.41437 0.000125051 11.9915L0 12V12.0084C0.028 15.5855 0.86025 18.4393 2.4735 20.4901C4.2865 22.7948 6.98525 23.9757 10.4946 24H10.5087C13.6287 23.9784 15.828 23.1615 17.6397 21.3514C20.0101 18.9833 19.9387 16.0149 19.1575 14.1926C18.597 12.8859 17.5284 11.8245 16.0671 11.1235ZM10.68 16.1884C9.375 16.2619 8.01925 15.6761 7.9525 14.4215C7.90288 13.4913 8.6145 12.4533 10.7601 12.3296C11.0059 12.3154 11.247 12.3085 11.4839 12.3085C12.2633 12.3085 12.9924 12.3843 13.6552 12.5291C13.408 15.6169 11.9578 16.1183 10.68 16.1884Z" />
+</symbol>
+<symbol id="icon-telegram" viewBox="0 0 24 24">
+<path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm3.08 14.757s-.25.625-.936.325l-2.541-1.949-1.63 1.486s-.127.096-.266.036c0 0-.12-.011-.27-.486-.15-.475-.911-2.972-.911-2.972L6 12.349s-.387-.137-.425-.438c-.037-.3.437-.462.437-.462l10.03-3.934s.824-.362.824.238l-1.786 9.004z"/>
+</symbol>
+<symbol id="icon-tiktok" viewBox="0 0 24 24">
+<path d="M12.22 2H15.64C15.64 2 15.4502 6.39351 20.3898 6.70186V10.0981C20.3898 10.0981 17.7537 10.2636 15.64 8.64957L15.6769 15.6615C15.6769 16.9151 15.3052 18.1406 14.6087 19.1829C13.9123 20.2253 12.9224 21.0377 11.7642 21.5175C10.606 21.9972 9.33162 22.1228 8.10209 21.8782C6.87257 21.6337 5.74316 21.0301 4.85669 20.1437C3.97022 19.2573 3.3665 18.1279 3.12186 16.8984C2.87723 15.6689 3.00267 14.3945 3.48233 13.2363C3.96199 12.0781 4.77432 11.0881 5.8166 10.3916C6.85888 9.69502 8.0843 9.32318 9.33791 9.32307H10.2271V12.7231V12.7954C9.64757 12.6147 9.02578 12.6217 8.45043 12.8152C7.87508 13.0088 7.37556 13.3792 7.02314 13.8734C6.67071 14.3677 6.48338 14.9606 6.48786 15.5677C6.49235 16.1747 6.68842 16.7648 7.04811 17.2538C7.40781 17.7428 7.91274 18.1057 8.49089 18.2908C9.06903 18.4758 9.69086 18.4736 10.2676 18.2843C10.8444 18.0951 11.3467 17.7285 11.7029 17.2369C12.059 16.7454 12.2508 16.1538 12.2509 15.5468L12.22 2Z"/>
+</symbol>
+<symbol id="icon-tumblr" viewBox="0 0 24 24">
+<path d="M16.749,17.396c-0.357,0.17-1.041,0.319-1.551,0.332c-1.539,0.041-1.837-1.081-1.85-1.896V9.847h3.861V6.937h-3.847V2.039 c0,0-2.77,0-2.817,0c-0.046,0-0.127,0.041-0.138,0.144c-0.165,1.499-0.867,4.13-3.783,5.181v2.484h1.945v6.282 c0,2.151,1.587,5.206,5.775,5.135c1.413-0.024,2.982-0.616,3.329-1.126L16.749,17.396z"/>
+</symbol>
+<symbol id="icon-twitch" viewBox="0 0 24 24">
+<path d="M16.499,8.089h-1.636v4.91h1.636V8.089z M12,8.089h-1.637v4.91H12V8.089z M4.228,3.178L3,6.451v13.092h4.499V22h2.456 l2.454-2.456h3.681L21,14.636V3.178H4.228z M19.364,13.816l-2.864,2.865H12l-2.453,2.453V16.68H5.863V4.814h13.501V13.816z"/>
+</symbol>
+<symbol id="icon-twitter" viewBox="0 0 24 24">
+<path d="M22.23,5.924c-0.736,0.326-1.527,0.547-2.357,0.646c0.847-0.508,1.498-1.312,1.804-2.27 c-0.793,0.47-1.671,0.812-2.606,0.996C18.324,4.498,17.257,4,16.077,4c-2.266,0-4.103,1.837-4.103,4.103 c0,0.322,0.036,0.635,0.106,0.935C8.67,8.867,5.647,7.234,3.623,4.751C3.27,5.357,3.067,6.062,3.067,6.814 c0,1.424,0.724,2.679,1.825,3.415c-0.673-0.021-1.305-0.206-1.859-0.513c0,0.017,0,0.034,0,0.052c0,1.988,1.414,3.647,3.292,4.023 c-0.344,0.094-0.707,0.144-1.081,0.144c-0.264,0-0.521-0.026-0.772-0.074c0.522,1.63,2.038,2.816,3.833,2.85 c-1.404,1.1-3.174,1.756-5.096,1.756c-0.331,0-0.658-0.019-0.979-0.057c1.816,1.164,3.973,1.843,6.29,1.843 c7.547,0,11.675-6.252,11.675-11.675c0-0.178-0.004-0.355-0.012-0.531C20.985,7.47,21.68,6.747,22.23,5.924z"/>
+</symbol>
+<symbol id="icon-vimeo" viewBox="0 0 24 24">
+<path d="M22.396,7.164c-0.093,2.026-1.507,4.799-4.245,8.32C15.322,19.161,12.928,21,10.97,21c-1.214,0-2.24-1.119-3.079-3.359 c-0.56-2.053-1.119-4.106-1.68-6.159C5.588,9.243,4.921,8.122,4.206,8.122c-0.156,0-0.701,0.328-1.634,0.98L1.594,7.841 c1.027-0.902,2.04-1.805,3.037-2.708C6.001,3.95,7.03,3.327,7.715,3.264c1.619-0.156,2.616,0.951,2.99,3.321 c0.404,2.557,0.685,4.147,0.841,4.769c0.467,2.121,0.981,3.181,1.542,3.181c0.435,0,1.09-0.688,1.963-2.065 c0.871-1.376,1.338-2.422,1.401-3.142c0.125-1.187-0.343-1.782-1.401-1.782c-0.498,0-1.012,0.115-1.541,0.341 c1.023-3.35,2.977-4.977,5.862-4.884C21.511,3.066,22.52,4.453,22.396,7.164z"/>
+</symbol>
+<symbol id="icon-vk" viewBox="0 0 24 24">
+<path d="M22,7.1c0.2,0.4-0.4,1.5-1.6,3.1c-0.2,0.2-0.4,0.5-0.7,0.9c-0.5,0.7-0.9,1.1-0.9,1.4c-0.1,0.3-0.1,0.6,0.1,0.8 c0.1,0.1,0.4,0.4,0.8,0.9h0l0,0c1,0.9,1.6,1.7,2,2.3c0,0,0,0.1,0.1,0.1c0,0.1,0,0.1,0.1,0.3c0,0.1,0,0.2,0,0.4 c0,0.1-0.1,0.2-0.3,0.3c-0.1,0.1-0.4,0.1-0.6,0.1l-2.7,0c-0.2,0-0.4,0-0.6-0.1c-0.2-0.1-0.4-0.1-0.5-0.2l-0.2-0.1 c-0.2-0.1-0.5-0.4-0.7-0.7s-0.5-0.6-0.7-0.8c-0.2-0.2-0.4-0.4-0.6-0.6C14.8,15,14.6,15,14.4,15c0,0,0,0-0.1,0c0,0-0.1,0.1-0.2,0.2 c-0.1,0.1-0.2,0.2-0.2,0.3c-0.1,0.1-0.1,0.3-0.2,0.5c-0.1,0.2-0.1,0.5-0.1,0.8c0,0.1,0,0.2,0,0.3c0,0.1-0.1,0.2-0.1,0.2l0,0.1 c-0.1,0.1-0.3,0.2-0.6,0.2h-1.2c-0.5,0-1,0-1.5-0.2c-0.5-0.1-1-0.3-1.4-0.6s-0.7-0.5-1.1-0.7s-0.6-0.4-0.7-0.6l-0.3-0.3 c-0.1-0.1-0.2-0.2-0.3-0.3s-0.4-0.5-0.7-0.9s-0.7-1-1.1-1.6c-0.4-0.6-0.8-1.3-1.3-2.2C2.9,9.4,2.5,8.5,2.1,7.5C2,7.4,2,7.3,2,7.2 c0-0.1,0-0.1,0-0.2l0-0.1c0.1-0.1,0.3-0.2,0.6-0.2l2.9,0c0.1,0,0.2,0,0.2,0.1S5.9,6.9,5.9,7L6,7c0.1,0.1,0.2,0.2,0.3,0.3 C6.4,7.7,6.5,8,6.7,8.4C6.9,8.8,7,9,7.1,9.2l0.2,0.3c0.2,0.4,0.4,0.8,0.6,1.1c0.2,0.3,0.4,0.5,0.5,0.7s0.3,0.3,0.4,0.4 c0.1,0.1,0.3,0.1,0.4,0.1c0.1,0,0.2,0,0.3-0.1c0,0,0,0,0.1-0.1c0,0,0.1-0.1,0.1-0.2c0.1-0.1,0.1-0.3,0.1-0.5c0-0.2,0.1-0.5,0.1-0.8 c0-0.4,0-0.8,0-1.3c0-0.3,0-0.5-0.1-0.8c0-0.2-0.1-0.4-0.1-0.5L9.6,7.6C9.4,7.3,9.1,7.2,8.7,7.1C8.6,7.1,8.6,7,8.7,6.9 C8.9,6.7,9,6.6,9.1,6.5c0.4-0.2,1.2-0.3,2.5-0.3c0.6,0,1,0.1,1.4,0.1c0.1,0,0.3,0.1,0.3,0.1c0.1,0.1,0.2,0.1,0.2,0.3 c0,0.1,0.1,0.2,0.1,0.3s0,0.3,0,0.5c0,0.2,0,0.4,0,0.6c0,0.2,0,0.4,0,0.7c0,0.3,0,0.6,0,0.9c0,0.1,0,0.2,0,0.4c0,0.2,0,0.4,0,0.5 c0,0.1,0,0.3,0,0.4s0.1,0.3,0.1,0.4c0.1,0.1,0.1,0.2,0.2,0.3c0.1,0,0.1,0,0.2,0c0.1,0,0.2,0,0.3-0.1c0.1-0.1,0.2-0.2,0.4-0.4 s0.3-0.4,0.5-0.7c0.2-0.3,0.5-0.7,0.7-1.1c0.4-0.7,0.8-1.5,1.1-2.3c0-0.1,0.1-0.1,0.1-0.2c0-0.1,0.1-0.1,0.1-0.1l0,0l0.1,0 c0,0,0,0,0.1,0s0.2,0,0.2,0l3,0c0.3,0,0.5,0,0.7,0S21.9,7,21.9,7L22,7.1z"/>
+</symbol>
+<symbol id="icon-whatsapp" viewBox="0 0 24 24">
+<path d="M2.048,22l1.406-5.136c-0.867-1.503-1.324-3.208-1.323-4.955C2.133,6.446,6.579,2,12.042,2c2.651,0.001,5.14,1.033,7.011,2.906c1.871,1.873,2.901,4.363,2.9,7.011c-0.002,5.464-4.448,9.91-9.91,9.91c0,0,0,0,0,0h-0.004c-1.659-0.001-3.288-0.417-4.736-1.206L2.048,22z M7.545,18.828l0.301,0.179c1.265,0.751,2.714,1.148,4.193,1.148h0.003c4.54,0,8.235-3.695,8.237-8.237c0.001-2.201-0.855-4.271-2.41-5.828c-1.555-1.557-3.623-2.415-5.824-2.416c-4.544,0-8.239,3.695-8.241,8.237c-0.001,1.556,0.435,3.072,1.259,4.384l0.196,0.312l-0.832,3.04L7.545,18.828z M17.035,14.274c-0.062-0.103-0.227-0.165-0.475-0.289c-0.248-0.124-1.465-0.723-1.692-0.806c-0.227-0.083-0.392-0.124-0.557,0.124c-0.165,0.248-0.64,0.806-0.784,0.971c-0.144,0.165-0.289,0.186-0.536,0.062c-0.248-0.124-1.046-0.385-1.991-1.229c-0.736-0.657-1.233-1.468-1.378-1.715c-0.144-0.248-0.015-0.382,0.109-0.505c0.111-0.111,0.248-0.289,0.371-0.434c0.124-0.145,0.165-0.248,0.248-0.413c0.083-0.165,0.041-0.31-0.021-0.434c-0.062-0.124-0.557-1.343-0.763-1.839C9.364,7.284,9.159,7.35,9.007,7.342c-0.144-0.007-0.31-0.009-0.475-0.009c-0.165,0-0.433,0.062-0.66,0.31C7.646,7.891,7.006,8.49,7.006,9.709c0,1.219,0.887,2.396,1.011,2.562c0.124,0.165,1.746,2.666,4.23,3.739c0.591,0.255,1.052,0.408,1.412,0.522c0.593,0.189,1.133,0.162,1.56,0.098c0.476-0.071,1.465-0.599,1.671-1.177C17.096,14.873,17.096,14.378,17.035,14.274z"/>
+</symbol>
+<symbol id="icon-woocommerce" viewBox="0 0 24 24">
+<path d="M19,2H5C3.3,2,2,3.3,2,5v11c0,1.7,1.3,3,3,3h4l6,3l-1-3h5c1.7,0,3-1.3,3-3V5C22,3.3,20.7,2,19,2z M17.4,6.5c-0.4,0.8-0.8,2.1-1,3.9c-0.3,1.8-0.4,3.1-0.3,4.1c0,0.3,0,0.5-0.1,0.7s-0.3,0.4-0.6,0.4s-0.6-0.1-0.9-0.4c-1-1-1.8-2.6-2.4-4.6c-0.7,1.4-1.2,2.4-1.6,3.1c-0.6,1.2-1.2,1.8-1.6,1.9c-0.3,0-0.5-0.2-0.8-0.7C7.6,13.5,7,10.7,6.4,6.7c0-0.3,0-0.5,0.2-0.7C6.7,5.8,7,5.7,7.3,5.6c0.5,0,0.9,0.2,0.9,0.8c0.3,2.3,0.7,4.2,1.1,5.7l2.4-4.5C11.9,7.2,12.1,7,12.5,7c0.5,0,0.8,0.3,0.9,0.9c0.3,1.4,0.6,2.6,1,3.7c0.3-2.7,0.8-4.7,1.4-5.9c0.2-0.3,0.4-0.5,0.7-0.5c0.2,0,0.5,0.1,0.7,0.2c0.2,0.2,0.3,0.4,0.3,0.6S17.5,6.4,17.4,6.5z"/>
+</symbol>
+<symbol id="icon-wordpress" viewBox="0 0 24 24">
+<path d="M12.158,12.786L9.46,20.625c0.806,0.237,1.657,0.366,2.54,0.366c1.047,0,2.051-0.181,2.986-0.51 c-0.024-0.038-0.046-0.079-0.065-0.124L12.158,12.786z M3.009,12c0,3.559,2.068,6.634,5.067,8.092L3.788,8.341 C3.289,9.459,3.009,10.696,3.009,12z M18.069,11.546c0-1.112-0.399-1.881-0.741-2.48c-0.456-0.741-0.883-1.368-0.883-2.109 c0-0.826,0.627-1.596,1.51-1.596c0.04,0,0.078,0.005,0.116,0.007C16.472,3.904,14.34,3.009,12,3.009 c-3.141,0-5.904,1.612-7.512,4.052c0.211,0.007,0.41,0.011,0.579,0.011c0.94,0,2.396-0.114,2.396-0.114 C7.947,6.93,8.004,7.642,7.52,7.699c0,0-0.487,0.057-1.029,0.085l3.274,9.739l1.968-5.901l-1.401-3.838 C9.848,7.756,9.389,7.699,9.389,7.699C8.904,7.67,8.961,6.93,9.446,6.958c0,0,1.484,0.114,2.368,0.114 c0.94,0,2.397-0.114,2.397-0.114c0.485-0.028,0.542,0.684,0.057,0.741c0,0-0.488,0.057-1.029,0.085l3.249,9.665l0.897-2.996 C17.841,13.284,18.069,12.316,18.069,11.546z M19.889,7.686c0.039,0.286,0.06,0.593,0.06,0.924c0,0.912-0.171,1.938-0.684,3.22 l-2.746,7.94c2.673-1.558,4.47-4.454,4.47-7.771C20.991,10.436,20.591,8.967,19.889,7.686z M12,22C6.486,22,2,17.514,2,12 C2,6.486,6.486,2,12,2c5.514,0,10,4.486,10,10C22,17.514,17.514,22,12,22z"/>
+</symbol>
+<symbol id="icon-yelp" viewBox="0 0 24 24">
+<path d="M12.271,16.718v1.417q-.011,3.257-.067,3.4a.707.707,0,0,1-.569.446,4.637,4.637,0,0,1-2.024-.424A4.609,4.609,0,0,1,7.8,20.565a.844.844,0,0,1-.19-.4.692.692,0,0,1,.044-.29,3.181,3.181,0,0,1,.379-.524q.335-.412,2.019-2.409.011,0,.669-.781a.757.757,0,0,1,.44-.274.965.965,0,0,1,.552.039.945.945,0,0,1,.418.324.732.732,0,0,1,.139.468Zm-1.662-2.8a.783.783,0,0,1-.58.781l-1.339.435q-3.067.981-3.257.981a.711.711,0,0,1-.6-.4,2.636,2.636,0,0,1-.19-.836,9.134,9.134,0,0,1,.011-1.857,3.559,3.559,0,0,1,.335-1.389.659.659,0,0,1,.625-.357,22.629,22.629,0,0,1,2.253.859q.781.324,1.283.524l.937.379a.771.771,0,0,1,.4.34A.982.982,0,0,1,10.609,13.917Zm9.213,3.313a4.467,4.467,0,0,1-1.021,1.8,4.559,4.559,0,0,1-1.512,1.417.671.671,0,0,1-.7-.078q-.156-.112-2.052-3.2l-.524-.859a.761.761,0,0,1-.128-.513.957.957,0,0,1,.217-.513.774.774,0,0,1,.926-.29q.011.011,1.327.446,2.264.736,2.7.887a2.082,2.082,0,0,1,.524.229.673.673,0,0,1,.245.68Zm-7.5-7.049q.056,1.137-.6,1.361-.647.19-1.272-.792L6.237,4.08a.7.7,0,0,1,.212-.691,5.788,5.788,0,0,1,2.314-1,5.928,5.928,0,0,1,2.5-.352.681.681,0,0,1,.547.5q.034.2.245,3.407T12.327,10.181Zm7.384,1.2a.679.679,0,0,1-.29.658q-.167.112-3.67.959-.747.167-1.015.257l.011-.022a.769.769,0,0,1-.513-.044.914.914,0,0,1-.413-.357.786.786,0,0,1,0-.971q.011-.011.836-1.137,1.394-1.908,1.673-2.275a2.423,2.423,0,0,1,.379-.435A.7.7,0,0,1,17.435,8a4.482,4.482,0,0,1,1.372,1.489,4.81,4.81,0,0,1,.9,1.868v.034Z"/>
+</symbol>
+<symbol id="icon-x" viewBox="0 0 24 24">
+<path d="M14.1173 9.62177L20.4459 2H18.9463L13.4511 8.61788L9.06215 2H4L10.637 12.0074L4 20H5.49977L11.3028 13.0113L15.9379 20H21L14.1169 9.62177H14.1173ZM12.0632 12.0956L11.3907 11.0991L6.04016 3.16971H8.34371L12.6617 9.56895L13.3341 10.5655L18.947 18.8835H16.6434L12.0632 12.096V12.0956Z"/>
+</symbol>
+<symbol id="icon-xanga" viewBox="0 0 24 24">
+<path d="M9,9h6v6H9V9z M3,9h6V3H3V9z M15,9h6V3h-6V9z M15,21h6v-6h-6V21z M3,21h6v-6H3V21z"/>
+</symbol>
+<symbol id="icon-youtube" viewBox="0 0 24 24">
+<path d="M21.8,8.001c0,0-0.195-1.378-0.795-1.985c-0.76-0.797-1.613-0.801-2.004-0.847c-2.799-0.202-6.997-0.202-6.997-0.202 h-0.009c0,0-4.198,0-6.997,0.202C4.608,5.216,3.756,5.22,2.995,6.016C2.395,6.623,2.2,8.001,2.2,8.001S2,9.62,2,11.238v1.517 c0,1.618,0.2,3.237,0.2,3.237s0.195,1.378,0.795,1.985c0.761,0.797,1.76,0.771,2.205,0.855c1.6,0.153,6.8,0.201,6.8,0.201 s4.203-0.006,7.001-0.209c0.391-0.047,1.243-0.051,2.004-0.847c0.6-0.607,0.795-1.985,0.795-1.985s0.2-1.618,0.2-3.237v-1.517 C22,9.62,21.8,8.001,21.8,8.001z M9.935,14.594l-0.001-5.62l5.404,2.82L9.935,14.594z"/>
+</symbol>
+</defs>
+</svg>
+
+</body>
+</html>
+<!--
+	generated 13 seconds ago
+	generated in 1.521 seconds
+	served from batcache in 0.004 seconds
+	expires in 287 seconds
+-->

--- a/tests/files/cle_cpc_detail.html
+++ b/tests/files/cle_cpc_detail.html
@@ -1,0 +1,1075 @@
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="profile" href="http://gmpg.org/xfn/11">
+<link rel="pingback" href="https://clecpc.org/xmlrpc.php">
+
+<script type="text/javascript">
+  WebFontConfig = {"google":{"families":["Source+Sans+Pro:b:latin,latin-ext","Source+Sans+Pro:r,i,b,bi:latin,latin-ext"]},"api_url":"https:\/\/fonts-api.wp.com\/css"};
+  (function() {
+    var wf = document.createElement('script');
+    wf.src = 'https://clecpc.org/wp-content/mu-plugins/wpcomsh/vendor/automattic/custom-fonts/js/webfont.js';
+    wf.type = 'text/javascript';
+    wf.async = 'true';
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(wf, s);
+	})();
+</script><style id="jetpack-custom-fonts-css">.wf-active body, .wf-active button, .wf-active input, .wf-active select, .wf-active textarea{font-family:"Source Sans Pro",sans-serif}.wf-active pre{font-family:"Source Sans Pro",sans-serif}.wf-active blockquote:before{font-family:"Source Sans Pro",sans-serif}.wf-active .menu-toggle{font-family:"Source Sans Pro",sans-serif}.wf-active .main-navigation li{font-family:"Source Sans Pro",sans-serif}.wf-active .site-footer a.button{font-family:"Source Sans Pro",sans-serif}.wf-active a.blue{font-family:"Source Sans Pro",sans-serif}.wf-active .widget_blog_subscription input[type="submit"]{font-family:"Source Sans Pro",sans-serif}.wf-active .footer-menu .widget_nav_menu li{font-family:"Source Sans Pro",sans-serif}.wf-active .entry-content a.button{font-family:"Source Sans Pro",sans-serif}.wf-active .block-two a.blue{font-family:"Source Sans Pro",sans-serif}.wf-active .contact-form input[type="submit"]{font-family:"Source Sans Pro",sans-serif}.wf-active h1, .wf-active h2, .wf-active h3, .wf-active h4, .wf-active h5, .wf-active h6{font-family:"Source Sans Pro",sans-serif;font-weight:700;font-style:normal}.wf-active p.site-title{font-family:"Source Sans Pro",sans-serif;font-weight:700;font-style:normal}.wf-active h1{font-style:normal;font-weight:700}.wf-active h2{font-style:normal;font-weight:700}.wf-active h3{font-style:normal;font-weight:700}.wf-active h4{font-style:normal;font-weight:700}.wf-active h5{font-style:normal;font-weight:700}.wf-active h6{font-style:normal;font-weight:700}.wf-active .widget-title, .wf-active .widgettitle{font-style:normal;font-weight:700}.wf-active .widget_calendar th{font-weight:700;font-style:normal}.wf-active .entry-title{font-style:normal;font-weight:700}.wf-active .page-title{font-style:normal;font-weight:700}.wf-active .author-title{font-weight:700;font-style:normal}.wf-active .news .two-third .customwidget .entry-title{font-style:normal;font-weight:700}.wf-active .content-caption .entry-content h1, .wf-active .content-caption .entry-content h2, .wf-active .content-caption .entry-content h3, .wf-active .content-caption .entry-content h4, .wf-active .content-caption .entry-content h5, .wf-active .content-caption .entry-content h6{font-family:"Source Sans Pro",sans-serif;font-weight:700;font-style:normal}.wf-active .block-one .child-pages h2{font-style:normal;font-weight:700}.wf-active .page-template-grid-page.singular .columns .entry-title, .wf-active .page-template-involved-template.singular .columns .entry-title, .wf-active .singular .block-six .columns .entry-title{font-style:normal;font-weight:700}@media screen and ( min-width: 55em ){.wf-active .singular .entry-title, .wf-active h1{font-style:normal;font-weight:700}}@media screen and ( min-width: 55em ){.wf-active .page-template-boxed-sidebar-template h1, .wf-active .page-template-boxed-sidebar-template.singular .entry-title{font-style:normal;font-weight:700}}@media screen and ( min-width: 55em ){.wf-active .site-title{font-style:normal;font-weight:700}}@media screen and ( min-width: 55em ){.wf-active .singular.page-template-right-column-page-php .entry-title, .wf-active h2{font-style:normal;font-weight:700}}@media screen and ( min-width: 55em ){.wf-active h3{font-style:normal;font-weight:700}}@media screen and ( min-width: 55em ){.wf-active h4{font-style:normal;font-weight:700}}@media screen and ( min-width: 55em ){.wf-active h5{font-style:normal;font-weight:700}}@media screen and ( min-width: 55em ){.wf-active h6{font-style:normal;font-weight:700}}@media screen and ( min-width: 55em ){.wf-active .archive.list-layout .entry-title, .wf-active .blog.list-layout .entry-title{font-style:normal;font-weight:700}}@media screen and ( min-width: 55em ){.wf-active .home.singular.page-template-right-column-page-php .entry-title{font-style:normal;font-weight:700}}@media screen and ( min-width: 55em ){.wf-active .home.singular.page-template-right-column-page-php .block-one .child-pages h2{font-style:normal;font-weight:700}}@media screen and ( min-width: 55em ){.wf-active .home.singular.page-template-right-column-page-php .news .two-third .customwidget .entry-title{font-style:normal;font-weight:700}}</style>
+<meta name='robots' content='index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1' />
+
+	<!-- This site is optimized with the Yoast SEO plugin v21.9.1 - https://yoast.com/wordpress/plugins/seo/ -->
+	<title>Police Discipline Work Group - Cleveland Community Police Commission</title>
+	<link rel="canonical" href="https://clecpc.org/events/police-discipline-work-group/" />
+	<meta property="og:locale" content="en_US" />
+	<meta property="og:type" content="article" />
+	<meta property="og:title" content="Police Discipline Work Group - Cleveland Community Police Commission" />
+	<meta property="og:description" content="Work Group to review the police disciplinary policy, disciplinary matrix and police manual of rules " />
+	<meta property="og:url" content="https://clecpc.org/events/police-discipline-work-group/" />
+	<meta property="og:site_name" content="Cleveland Community Police Commission" />
+	<meta property="article:modified_time" content="2024-01-24T19:54:50+00:00" />
+	<meta name="twitter:card" content="summary_large_image" />
+	<meta name="twitter:label1" content="Est. reading time" />
+	<meta name="twitter:data1" content="1 minute" />
+	<script type="application/ld+json" class="yoast-schema-graph">{"@context":"https://schema.org","@graph":[{"@type":"WebPage","@id":"https://clecpc.org/events/police-discipline-work-group/","url":"https://clecpc.org/events/police-discipline-work-group/","name":"Police Discipline Work Group - Cleveland Community Police Commission","isPartOf":{"@id":"https://clecpc.org/#website"},"datePublished":"2024-01-24T19:53:05+00:00","dateModified":"2024-01-24T19:54:50+00:00","breadcrumb":{"@id":"https://clecpc.org/events/police-discipline-work-group/#breadcrumb"},"inLanguage":"en-US","potentialAction":[{"@type":"ReadAction","target":["https://clecpc.org/events/police-discipline-work-group/"]}]},{"@type":"BreadcrumbList","@id":"https://clecpc.org/events/police-discipline-work-group/#breadcrumb","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://clecpc.org/"},{"@type":"ListItem","position":2,"name":"Events","item":"https://clecpc.org/events/"},{"@type":"ListItem","position":3,"name":"Police Discipline Work Group"}]},{"@type":"WebSite","@id":"https://clecpc.org/#website","url":"https://clecpc.org/","name":"Cleveland Community Police Commission","description":"","publisher":{"@id":"https://clecpc.org/#organization"},"potentialAction":[{"@type":"SearchAction","target":{"@type":"EntryPoint","urlTemplate":"https://clecpc.org/?s={search_term_string}"},"query-input":"required name=search_term_string"}],"inLanguage":"en-US"},{"@type":"Organization","@id":"https://clecpc.org/#organization","name":"Cleveland Community Police Commission","url":"https://clecpc.org/","logo":{"@type":"ImageObject","inLanguage":"en-US","@id":"https://clecpc.org/#/schema/logo/image/","url":"https://i0.wp.com/clecpc.org/wp-content/uploads/CPCLogo-Nav5.png?fit=105%2C71&ssl=1","contentUrl":"https://i0.wp.com/clecpc.org/wp-content/uploads/CPCLogo-Nav5.png?fit=105%2C71&ssl=1","width":105,"height":71,"caption":"Cleveland Community Police Commission"},"image":{"@id":"https://clecpc.org/#/schema/logo/image/"}}]}</script>
+	<!-- / Yoast SEO plugin. -->
+
+
+<link rel='dns-prefetch' href='//secure.gravatar.com' />
+<link rel='dns-prefetch' href='//stats.wp.com' />
+<link rel='dns-prefetch' href='//fonts-api.wp.com' />
+<link rel='dns-prefetch' href='//widgets.wp.com' />
+<link rel='dns-prefetch' href='//s0.wp.com' />
+<link rel='dns-prefetch' href='//0.gravatar.com' />
+<link rel='dns-prefetch' href='//1.gravatar.com' />
+<link rel='dns-prefetch' href='//2.gravatar.com' />
+<link rel='dns-prefetch' href='//i0.wp.com' />
+<link rel='dns-prefetch' href='//c0.wp.com' />
+<link rel='dns-prefetch' href='//jetpack.wordpress.com' />
+<link rel='dns-prefetch' href='//public-api.wordpress.com' />
+<link rel="alternate" type="application/rss+xml" title="Cleveland Community Police Commission &raquo; Feed" href="https://clecpc.org/feed/" />
+<link rel="alternate" type="application/rss+xml" title="Cleveland Community Police Commission &raquo; Comments Feed" href="https://clecpc.org/comments/feed/" />
+<link rel="alternate" type="application/rss+xml" title="Cleveland Community Police Commission &raquo; Police Discipline Work Group Comments Feed" href="https://clecpc.org/events/police-discipline-work-group/feed/" />
+		<!-- This site uses the Google Analytics by MonsterInsights plugin v8.23.1 - Using Analytics tracking - https://www.monsterinsights.com/ -->
+							<script src="//www.googletagmanager.com/gtag/js?id=G-ZXWB1C1R71"  data-cfasync="false" data-wpfc-render="false" type="text/javascript" async></script>
+			<script data-cfasync="false" data-wpfc-render="false" type="text/javascript">
+				var mi_version = '8.23.1';
+				var mi_track_user = true;
+				var mi_no_track_reason = '';
+				
+								var disableStrs = [
+										'ga-disable-G-ZXWB1C1R71',
+									];
+
+				/* Function to detect opted out users */
+				function __gtagTrackerIsOptedOut() {
+					for (var index = 0; index < disableStrs.length; index++) {
+						if (document.cookie.indexOf(disableStrs[index] + '=true') > -1) {
+							return true;
+						}
+					}
+
+					return false;
+				}
+
+				/* Disable tracking if the opt-out cookie exists. */
+				if (__gtagTrackerIsOptedOut()) {
+					for (var index = 0; index < disableStrs.length; index++) {
+						window[disableStrs[index]] = true;
+					}
+				}
+
+				/* Opt-out function */
+				function __gtagTrackerOptout() {
+					for (var index = 0; index < disableStrs.length; index++) {
+						document.cookie = disableStrs[index] + '=true; expires=Thu, 31 Dec 2099 23:59:59 UTC; path=/';
+						window[disableStrs[index]] = true;
+					}
+				}
+
+				if ('undefined' === typeof gaOptout) {
+					function gaOptout() {
+						__gtagTrackerOptout();
+					}
+				}
+								window.dataLayer = window.dataLayer || [];
+
+				window.MonsterInsightsDualTracker = {
+					helpers: {},
+					trackers: {},
+				};
+				if (mi_track_user) {
+					function __gtagDataLayer() {
+						dataLayer.push(arguments);
+					}
+
+					function __gtagTracker(type, name, parameters) {
+						if (!parameters) {
+							parameters = {};
+						}
+
+						if (parameters.send_to) {
+							__gtagDataLayer.apply(null, arguments);
+							return;
+						}
+
+						if (type === 'event') {
+														parameters.send_to = monsterinsights_frontend.v4_id;
+							var hookName = name;
+							if (typeof parameters['event_category'] !== 'undefined') {
+								hookName = parameters['event_category'] + ':' + name;
+							}
+
+							if (typeof MonsterInsightsDualTracker.trackers[hookName] !== 'undefined') {
+								MonsterInsightsDualTracker.trackers[hookName](parameters);
+							} else {
+								__gtagDataLayer('event', name, parameters);
+							}
+							
+						} else {
+							__gtagDataLayer.apply(null, arguments);
+						}
+					}
+
+					__gtagTracker('js', new Date());
+					__gtagTracker('set', {
+						'developer_id.dZGIzZG': true,
+											});
+										__gtagTracker('config', 'G-ZXWB1C1R71', {"forceSSL":"true","link_attribution":"true"} );
+															window.gtag = __gtagTracker;										(function () {
+						/* https://developers.google.com/analytics/devguides/collection/analyticsjs/ */
+						/* ga and __gaTracker compatibility shim. */
+						var noopfn = function () {
+							return null;
+						};
+						var newtracker = function () {
+							return new Tracker();
+						};
+						var Tracker = function () {
+							return null;
+						};
+						var p = Tracker.prototype;
+						p.get = noopfn;
+						p.set = noopfn;
+						p.send = function () {
+							var args = Array.prototype.slice.call(arguments);
+							args.unshift('send');
+							__gaTracker.apply(null, args);
+						};
+						var __gaTracker = function () {
+							var len = arguments.length;
+							if (len === 0) {
+								return;
+							}
+							var f = arguments[len - 1];
+							if (typeof f !== 'object' || f === null || typeof f.hitCallback !== 'function') {
+								if ('send' === arguments[0]) {
+									var hitConverted, hitObject = false, action;
+									if ('event' === arguments[1]) {
+										if ('undefined' !== typeof arguments[3]) {
+											hitObject = {
+												'eventAction': arguments[3],
+												'eventCategory': arguments[2],
+												'eventLabel': arguments[4],
+												'value': arguments[5] ? arguments[5] : 1,
+											}
+										}
+									}
+									if ('pageview' === arguments[1]) {
+										if ('undefined' !== typeof arguments[2]) {
+											hitObject = {
+												'eventAction': 'page_view',
+												'page_path': arguments[2],
+											}
+										}
+									}
+									if (typeof arguments[2] === 'object') {
+										hitObject = arguments[2];
+									}
+									if (typeof arguments[5] === 'object') {
+										Object.assign(hitObject, arguments[5]);
+									}
+									if ('undefined' !== typeof arguments[1].hitType) {
+										hitObject = arguments[1];
+										if ('pageview' === hitObject.hitType) {
+											hitObject.eventAction = 'page_view';
+										}
+									}
+									if (hitObject) {
+										action = 'timing' === arguments[1].hitType ? 'timing_complete' : hitObject.eventAction;
+										hitConverted = mapArgs(hitObject);
+										__gtagTracker('event', action, hitConverted);
+									}
+								}
+								return;
+							}
+
+							function mapArgs(args) {
+								var arg, hit = {};
+								var gaMap = {
+									'eventCategory': 'event_category',
+									'eventAction': 'event_action',
+									'eventLabel': 'event_label',
+									'eventValue': 'event_value',
+									'nonInteraction': 'non_interaction',
+									'timingCategory': 'event_category',
+									'timingVar': 'name',
+									'timingValue': 'value',
+									'timingLabel': 'event_label',
+									'page': 'page_path',
+									'location': 'page_location',
+									'title': 'page_title',
+									'referrer' : 'page_referrer',
+								};
+								for (arg in args) {
+																		if (!(!args.hasOwnProperty(arg) || !gaMap.hasOwnProperty(arg))) {
+										hit[gaMap[arg]] = args[arg];
+									} else {
+										hit[arg] = args[arg];
+									}
+								}
+								return hit;
+							}
+
+							try {
+								f.hitCallback();
+							} catch (ex) {
+							}
+						};
+						__gaTracker.create = newtracker;
+						__gaTracker.getByName = newtracker;
+						__gaTracker.getAll = function () {
+							return [];
+						};
+						__gaTracker.remove = noopfn;
+						__gaTracker.loaded = true;
+						window['__gaTracker'] = __gaTracker;
+					})();
+									} else {
+										console.log("");
+					(function () {
+						function __gtagTracker() {
+							return null;
+						}
+
+						window['__gtagTracker'] = __gtagTracker;
+						window['gtag'] = __gtagTracker;
+					})();
+									}
+			</script>
+				<!-- / Google Analytics by MonsterInsights -->
+		<script type="text/javascript">
+/* <![CDATA[ */
+window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/14.0.0\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/14.0.0\/svg\/","svgExt":".svg","source":{"concatemoji":"https:\/\/clecpc.org\/wp-includes\/js\/wp-emoji-release.min.js?ver=6.4.2"}};
+/*! This file is auto-generated */
+!function(i,n){var o,s,e;function c(e){try{var t={supportTests:e,timestamp:(new Date).valueOf()};sessionStorage.setItem(o,JSON.stringify(t))}catch(e){}}function p(e,t,n){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);var t=new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data),r=(e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(n,0,0),new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data));return t.every(function(e,t){return e===r[t]})}function u(e,t,n){switch(t){case"flag":return n(e,"\ud83c\udff3\ufe0f\u200d\u26a7\ufe0f","\ud83c\udff3\ufe0f\u200b\u26a7\ufe0f")?!1:!n(e,"\ud83c\uddfa\ud83c\uddf3","\ud83c\uddfa\u200b\ud83c\uddf3")&&!n(e,"\ud83c\udff4\udb40\udc67\udb40\udc62\udb40\udc65\udb40\udc6e\udb40\udc67\udb40\udc7f","\ud83c\udff4\u200b\udb40\udc67\u200b\udb40\udc62\u200b\udb40\udc65\u200b\udb40\udc6e\u200b\udb40\udc67\u200b\udb40\udc7f");case"emoji":return!n(e,"\ud83e\udef1\ud83c\udffb\u200d\ud83e\udef2\ud83c\udfff","\ud83e\udef1\ud83c\udffb\u200b\ud83e\udef2\ud83c\udfff")}return!1}function f(e,t,n){var r="undefined"!=typeof WorkerGlobalScope&&self instanceof WorkerGlobalScope?new OffscreenCanvas(300,150):i.createElement("canvas"),a=r.getContext("2d",{willReadFrequently:!0}),o=(a.textBaseline="top",a.font="600 32px Arial",{});return e.forEach(function(e){o[e]=t(a,e,n)}),o}function t(e){var t=i.createElement("script");t.src=e,t.defer=!0,i.head.appendChild(t)}"undefined"!=typeof Promise&&(o="wpEmojiSettingsSupports",s=["flag","emoji"],n.supports={everything:!0,everythingExceptFlag:!0},e=new Promise(function(e){i.addEventListener("DOMContentLoaded",e,{once:!0})}),new Promise(function(t){var n=function(){try{var e=JSON.parse(sessionStorage.getItem(o));if("object"==typeof e&&"number"==typeof e.timestamp&&(new Date).valueOf()<e.timestamp+604800&&"object"==typeof e.supportTests)return e.supportTests}catch(e){}return null}();if(!n){if("undefined"!=typeof Worker&&"undefined"!=typeof OffscreenCanvas&&"undefined"!=typeof URL&&URL.createObjectURL&&"undefined"!=typeof Blob)try{var e="postMessage("+f.toString()+"("+[JSON.stringify(s),u.toString(),p.toString()].join(",")+"));",r=new Blob([e],{type:"text/javascript"}),a=new Worker(URL.createObjectURL(r),{name:"wpTestEmojiSupports"});return void(a.onmessage=function(e){c(n=e.data),a.terminate(),t(n)})}catch(e){}c(n=f(s,u,p))}t(n)}).then(function(e){for(var t in e)n.supports[t]=e[t],n.supports.everything=n.supports.everything&&n.supports[t],"flag"!==t&&(n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&n.supports[t]);n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&!n.supports.flag,n.DOMReady=!1,n.readyCallback=function(){n.DOMReady=!0}}).then(function(){return e}).then(function(){var e;n.supports.everything||(n.readyCallback(),(e=n.source||{}).concatemoji?t(e.concatemoji):e.wpemoji&&e.twemoji&&(t(e.twemoji),t(e.wpemoji)))}))}((window,document),window._wpemojiSettings);
+/* ]]> */
+</script>
+<link rel='stylesheet' id='mec-select2-style-css' href='https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/packages/select2/select2.min.css?ver=6.5.6' type='text/css' media='all' />
+<link rel='stylesheet' id='mec-font-icons-css' href='https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/css/iconfonts.css?ver=6.4.2' type='text/css' media='all' />
+<link rel='stylesheet' id='mec-frontend-style-css' href='https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/css/frontend.min.css?ver=6.5.6' type='text/css' media='all' />
+<link rel='stylesheet' id='mec-tooltip-style-css' href='https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/packages/tooltip/tooltip.css?ver=6.4.2' type='text/css' media='all' />
+<link rel='stylesheet' id='mec-tooltip-shadow-style-css' href='https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/packages/tooltip/tooltipster-sideTip-shadow.min.css?ver=6.4.2' type='text/css' media='all' />
+<link rel='stylesheet' id='featherlight-css' href='https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/packages/featherlight/featherlight.css?ver=6.4.2' type='text/css' media='all' />
+<link rel='stylesheet' id='mec-google-fonts-css' href='//fonts-api.wp.com/css?family=Montserrat%3A400%2C700%7CRoboto%3A100%2C300%2C400%2C700&#038;ver=6.4.2' type='text/css' media='all' />
+<link rel='stylesheet' id='mec-lity-style-css' href='https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/packages/lity/lity.min.css?ver=6.4.2' type='text/css' media='all' />
+<link rel='stylesheet' id='mec-general-calendar-style-css' href='https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/css/mec-general-calendar.css?ver=6.4.2' type='text/css' media='all' />
+<style id='wp-emoji-styles-inline-css' type='text/css'>
+
+	img.wp-smiley, img.emoji {
+		display: inline !important;
+		border: none !important;
+		box-shadow: none !important;
+		height: 1em !important;
+		width: 1em !important;
+		margin: 0 0.07em !important;
+		vertical-align: -0.1em !important;
+		background: none !important;
+		padding: 0 !important;
+	}
+</style>
+<link rel='stylesheet' id='wp-block-library-css' href='https://clecpc.org/wp-content/plugins/gutenberg/build/block-library/style.css?ver=17.5.2' type='text/css' media='all' />
+<style id='wp-block-library-inline-css' type='text/css'>
+.has-text-align-justify{text-align:justify;}
+</style>
+<link rel='stylesheet' id='wp-block-library-theme-css' href='https://clecpc.org/wp-content/plugins/gutenberg/build/block-library/theme.css?ver=17.5.2' type='text/css' media='all' />
+<link rel='stylesheet' id='mediaelement-css' href='https://c0.wp.com/c/6.4.2/wp-includes/js/mediaelement/mediaelementplayer-legacy.min.css' type='text/css' media='all' />
+<link rel='stylesheet' id='wp-mediaelement-css' href='https://c0.wp.com/c/6.4.2/wp-includes/js/mediaelement/wp-mediaelement.min.css' type='text/css' media='all' />
+<style id='classic-theme-styles-inline-css' type='text/css'>
+/*! This file is auto-generated */
+.wp-block-button__link{color:#fff;background-color:#32373c;border-radius:9999px;box-shadow:none;text-decoration:none;padding:calc(.667em + 2px) calc(1.333em + 2px);font-size:1.125em}.wp-block-file__button{background:#32373c;color:#fff;text-decoration:none}
+</style>
+<link rel='stylesheet' id='wpcom-text-widget-styles-css' href='https://clecpc.org/wp-content/mu-plugins/wpcomsh/vendor/automattic/text-media-widget-styles/css/widget-text.css?ver=20170607' type='text/css' media='all' />
+<style id='global-styles-inline-css' type='text/css'>
+body{--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray: #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink: #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange: #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan: #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue: #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple: #9b51e0;--wp--preset--color--purple: #980560;--wp--preset--color--blue: #20c9f3;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan: linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange: linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red: linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray: linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum: linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple: linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux: linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean: linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%);--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium: 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large: 42px;--wp--preset--font-family--albert-sans: 'Albert Sans', sans-serif;--wp--preset--font-family--alegreya: Alegreya, serif;--wp--preset--font-family--arvo: Arvo, serif;--wp--preset--font-family--bodoni-moda: 'Bodoni Moda', serif;--wp--preset--font-family--cabin: Cabin, sans-serif;--wp--preset--font-family--chivo: Chivo, sans-serif;--wp--preset--font-family--commissioner: Commissioner, sans-serif;--wp--preset--font-family--cormorant: Cormorant, serif;--wp--preset--font-family--courier-prime: 'Courier Prime', monospace;--wp--preset--font-family--crimson-pro: 'Crimson Pro', serif;--wp--preset--font-family--dm-mono: 'DM Mono', monospace;--wp--preset--font-family--dm-sans: 'DM Sans', sans-serif;--wp--preset--font-family--domine: Domine, serif;--wp--preset--font-family--eb-garamond: 'EB Garamond', serif;--wp--preset--font-family--epilogue: Epilogue, sans-serif;--wp--preset--font-family--figtree: Figtree, sans-serif;--wp--preset--font-family--fira-sans: 'Fira Sans', sans-serif;--wp--preset--font-family--fraunces: Fraunces, serif;--wp--preset--font-family--ibm-plex-mono: 'IBM Plex Mono', monospace;--wp--preset--font-family--ibm-plex-sans: 'IBM Plex Sans', sans-serif;--wp--preset--font-family--inter: Inter, sans-serif;--wp--preset--font-family--josefin-sans: 'Josefin Sans', sans-serif;--wp--preset--font-family--jost: Jost, sans-serif;--wp--preset--font-family--libre-baskerville: 'Libre Baskerville', serif;--wp--preset--font-family--libre-franklin: 'Libre Franklin', sans-serif;--wp--preset--font-family--literata: Literata, serif;--wp--preset--font-family--lora: Lora, serif;--wp--preset--font-family--merriweather: Merriweather, serif;--wp--preset--font-family--montserrat: Montserrat, sans-serif;--wp--preset--font-family--newsreader: Newsreader, serif;--wp--preset--font-family--nunito: Nunito, sans-serif;--wp--preset--font-family--open-sans: 'Open Sans', sans-serif;--wp--preset--font-family--overpass: Overpass, sans-serif;--wp--preset--font-family--petrona: Petrona, serif;--wp--preset--font-family--piazzolla: Piazzolla, serif;--wp--preset--font-family--playfair-display: 'Playfair Display', serif;--wp--preset--font-family--plus-jakarta-sans: 'Plus Jakarta Sans', sans-serif;--wp--preset--font-family--poppins: Poppins, sans-serif;--wp--preset--font-family--raleway: Raleway, sans-serif;--wp--preset--font-family--roboto: Roboto, sans-serif;--wp--preset--font-family--roboto-slab: 'Roboto Slab', serif;--wp--preset--font-family--rubik: Rubik, sans-serif;--wp--preset--font-family--sora: Sora, sans-serif;--wp--preset--font-family--source-sans-3: 'Source Sans 3', sans-serif;--wp--preset--font-family--source-serif-4: 'Source Serif 4', serif;--wp--preset--font-family--space-mono: 'Space Mono', monospace;--wp--preset--font-family--texturina: Texturina, serif;--wp--preset--font-family--work-sans: 'Work Sans', sans-serif;--wp--preset--spacing--20: 0.44rem;--wp--preset--spacing--30: 0.67rem;--wp--preset--spacing--40: 1rem;--wp--preset--spacing--50: 1.5rem;--wp--preset--spacing--60: 2.25rem;--wp--preset--spacing--70: 3.38rem;--wp--preset--spacing--80: 5.06rem;--wp--preset--shadow--natural: 6px 6px 9px rgba(0, 0, 0, 0.2);--wp--preset--shadow--deep: 12px 12px 50px rgba(0, 0, 0, 0.4);--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0, 0.2);--wp--preset--shadow--outlined: 6px 6px 0px -3px rgba(255, 255, 255, 1), 6px 6px rgba(0, 0, 0, 1);--wp--preset--shadow--crisp: 6px 6px 0px rgba(0, 0, 0, 1);}:where(.is-layout-flex){gap: 0.5em;}:where(.is-layout-grid){gap: 0.5em;}body .is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}body .is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}body .is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}body .is-layout-constrained > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}body .is-layout-constrained > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}body .is-layout-constrained > .aligncenter{margin-left: auto !important;margin-right: auto !important;}body .is-layout-constrained > :where(:not(.alignleft):not(.alignright):not(.alignfull)){max-width: var(--wp--style--global--content-size);margin-left: auto !important;margin-right: auto !important;}body .is-layout-constrained > .alignwide{max-width: var(--wp--style--global--wide-size);}body .is-layout-flex{display: flex;}body .is-layout-flex{flex-wrap: wrap;align-items: center;}body .is-layout-flex > *{margin: 0;}body .is-layout-grid{display: grid;}body .is-layout-grid > *{margin: 0;}:where(.wp-block-columns.is-layout-flex){gap: 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}:where(.wp-block-post-template.is-layout-flex){gap: 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}.has-black-color{color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color: var(--wp--preset--color--white) !important;}.has-pale-pink-color{color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color: var(--wp--preset--color--vivid-purple) !important;}.has-black-background-color{background-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color: var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color: var(--wp--preset--color--vivid-purple) !important;}.has-black-border-color{border-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color: var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color: var(--wp--preset--color--vivid-purple) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background: var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background: var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange) !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background: var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background: var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background: var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background: var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background: var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background: var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background: var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background: var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size: var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size: var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size: var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size: var(--wp--preset--font-size--x-large) !important;}.has-albert-sans-font-family{font-family: var(--wp--preset--font-family--albert-sans) !important;}.has-alegreya-font-family{font-family: var(--wp--preset--font-family--alegreya) !important;}.has-arvo-font-family{font-family: var(--wp--preset--font-family--arvo) !important;}.has-bodoni-moda-font-family{font-family: var(--wp--preset--font-family--bodoni-moda) !important;}.has-cabin-font-family{font-family: var(--wp--preset--font-family--cabin) !important;}.has-chivo-font-family{font-family: var(--wp--preset--font-family--chivo) !important;}.has-commissioner-font-family{font-family: var(--wp--preset--font-family--commissioner) !important;}.has-cormorant-font-family{font-family: var(--wp--preset--font-family--cormorant) !important;}.has-courier-prime-font-family{font-family: var(--wp--preset--font-family--courier-prime) !important;}.has-crimson-pro-font-family{font-family: var(--wp--preset--font-family--crimson-pro) !important;}.has-dm-mono-font-family{font-family: var(--wp--preset--font-family--dm-mono) !important;}.has-dm-sans-font-family{font-family: var(--wp--preset--font-family--dm-sans) !important;}.has-domine-font-family{font-family: var(--wp--preset--font-family--domine) !important;}.has-eb-garamond-font-family{font-family: var(--wp--preset--font-family--eb-garamond) !important;}.has-epilogue-font-family{font-family: var(--wp--preset--font-family--epilogue) !important;}.has-figtree-font-family{font-family: var(--wp--preset--font-family--figtree) !important;}.has-fira-sans-font-family{font-family: var(--wp--preset--font-family--fira-sans) !important;}.has-fraunces-font-family{font-family: var(--wp--preset--font-family--fraunces) !important;}.has-ibm-plex-mono-font-family{font-family: var(--wp--preset--font-family--ibm-plex-mono) !important;}.has-ibm-plex-sans-font-family{font-family: var(--wp--preset--font-family--ibm-plex-sans) !important;}.has-inter-font-family{font-family: var(--wp--preset--font-family--inter) !important;}.has-josefin-sans-font-family{font-family: var(--wp--preset--font-family--josefin-sans) !important;}.has-jost-font-family{font-family: var(--wp--preset--font-family--jost) !important;}.has-libre-baskerville-font-family{font-family: var(--wp--preset--font-family--libre-baskerville) !important;}.has-libre-franklin-font-family{font-family: var(--wp--preset--font-family--libre-franklin) !important;}.has-literata-font-family{font-family: var(--wp--preset--font-family--literata) !important;}.has-lora-font-family{font-family: var(--wp--preset--font-family--lora) !important;}.has-merriweather-font-family{font-family: var(--wp--preset--font-family--merriweather) !important;}.has-montserrat-font-family{font-family: var(--wp--preset--font-family--montserrat) !important;}.has-newsreader-font-family{font-family: var(--wp--preset--font-family--newsreader) !important;}.has-nunito-font-family{font-family: var(--wp--preset--font-family--nunito) !important;}.has-open-sans-font-family{font-family: var(--wp--preset--font-family--open-sans) !important;}.has-overpass-font-family{font-family: var(--wp--preset--font-family--overpass) !important;}.has-petrona-font-family{font-family: var(--wp--preset--font-family--petrona) !important;}.has-piazzolla-font-family{font-family: var(--wp--preset--font-family--piazzolla) !important;}.has-playfair-display-font-family{font-family: var(--wp--preset--font-family--playfair-display) !important;}.has-plus-jakarta-sans-font-family{font-family: var(--wp--preset--font-family--plus-jakarta-sans) !important;}.has-poppins-font-family{font-family: var(--wp--preset--font-family--poppins) !important;}.has-raleway-font-family{font-family: var(--wp--preset--font-family--raleway) !important;}.has-roboto-font-family{font-family: var(--wp--preset--font-family--roboto) !important;}.has-roboto-slab-font-family{font-family: var(--wp--preset--font-family--roboto-slab) !important;}.has-rubik-font-family{font-family: var(--wp--preset--font-family--rubik) !important;}.has-sora-font-family{font-family: var(--wp--preset--font-family--sora) !important;}.has-source-sans-3-font-family{font-family: var(--wp--preset--font-family--source-sans-3) !important;}.has-source-serif-4-font-family{font-family: var(--wp--preset--font-family--source-serif-4) !important;}.has-space-mono-font-family{font-family: var(--wp--preset--font-family--space-mono) !important;}.has-texturina-font-family{font-family: var(--wp--preset--font-family--texturina) !important;}.has-work-sans-font-family{font-family: var(--wp--preset--font-family--work-sans) !important;}
+:where(.wp-block-columns.is-layout-flex){gap: 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}
+.wp-block-pullquote{font-size: 1.5em;line-height: 1.6;}
+.wp-block-navigation a:where(:not(.wp-element-button)){color: inherit;}
+:where(.wp-block-post-template.is-layout-flex){gap: 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}
+</style>
+<link rel='stylesheet' id='simple-banner-style-css' href='https://clecpc.org/wp-content/plugins/simple-banner/simple-banner.css?ver=2.17.0' type='text/css' media='all' />
+<link rel='stylesheet' id='dashicons-css' href='https://c0.wp.com/c/6.4.2/wp-includes/css/dashicons.min.css' type='text/css' media='all' />
+<link rel='stylesheet' id='wp-components-css' href='https://clecpc.org/wp-content/plugins/gutenberg/build/components/style.css?ver=17.5.2' type='text/css' media='all' />
+<link rel='stylesheet' id='godaddy-styles-css' href='https://clecpc.org/wp-content/plugins/coblocks/includes/Dependencies/GoDaddy/Styles/build/latest.css?ver=2.0.2' type='text/css' media='all' />
+<link rel='stylesheet' id='megamenu-css' href='https://clecpc.org/wp-content/uploads/maxmegamenu/style.css?ver=5fec45' type='text/css' media='all' />
+<link rel='stylesheet' id='pena-fonts-css' href='https://fonts-api.wp.com/css?family=Merriweather%3A400%2C300%2C300italic%2C400italic%2C700%2C700italic%2C900%2C900italic%7CMontserrat%3A400%2C700&#038;subset=latin%2Clatin-ext' type='text/css' media='all' />
+<link rel='stylesheet' id='pena-style-css' href='https://clecpc.org/wp-content/themes/pena/style.css?ver=6.4.2' type='text/css' media='all' />
+<link rel='stylesheet' id='genericons-css' href='https://clecpc.org/wp-content/plugins/jetpack/_inc/genericons/genericons/genericons.css?ver=3.1' type='text/css' media='all' />
+<link rel='stylesheet' id='tablepress-default-css' href='https://clecpc.org/wp-content/plugins/tablepress/css/build/default.css?ver=2.2.4' type='text/css' media='all' />
+<link rel='stylesheet' id='simcal-qtip-css' href='https://clecpc.org/wp-content/plugins/google-calendar-events/assets/generated/vendor/jquery.qtip.min.css?ver=3.3.0' type='text/css' media='all' />
+<link rel='stylesheet' id='simcal-default-calendar-grid-css' href='https://clecpc.org/wp-content/plugins/google-calendar-events/assets/generated/default-calendar-grid.min.css?ver=3.3.0' type='text/css' media='all' />
+<link rel='stylesheet' id='simcal-default-calendar-list-css' href='https://clecpc.org/wp-content/plugins/google-calendar-events/assets/generated/default-calendar-list.min.css?ver=3.3.0' type='text/css' media='all' />
+<link rel='stylesheet' id='ics-calendar-css' href='https://clecpc.org/wp-content/plugins/ics-calendar/assets/style.min.css?ver=10.14.1' type='text/css' media='all' />
+<link rel='stylesheet' id='elementor-frontend-css' href='https://clecpc.org/wp-content/plugins/elementor/assets/css/frontend.min.css?ver=3.19.0' type='text/css' media='all' />
+<link rel='stylesheet' id='eael-general-css' href='https://clecpc.org/wp-content/plugins/essential-addons-for-elementor-lite/assets/front-end/css/view/general.min.css?ver=5.9.7' type='text/css' media='all' />
+<style id='jetpack-global-styles-frontend-style-inline-css' type='text/css'>
+:root { --font-headings: unset; --font-base: unset; --font-headings-default: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif; --font-base-default: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;}
+</style>
+<link rel='stylesheet' id='jetpack_css-css' href='https://clecpc.org/wp-content/plugins/jetpack/css/jetpack.css?ver=13.1-a.7' type='text/css' media='all' />
+<script type="text/javascript" src="https://c0.wp.com/c/6.4.2/wp-includes/js/jquery/jquery.min.js" id="jquery-core-js"></script>
+<script type="text/javascript" src="https://c0.wp.com/c/6.4.2/wp-includes/js/jquery/jquery-migrate.min.js" id="jquery-migrate-js"></script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/js/mec-general-calendar.js?ver=6.5.6" id="mec-general-calendar-script-js"></script>
+<script type="text/javascript" id="mec-frontend-script-js-extra">
+/* <![CDATA[ */
+var mecdata = {"day":"day","days":"days","hour":"hour","hours":"hours","minute":"minute","minutes":"minutes","second":"second","seconds":"seconds","elementor_edit_mode":"no","recapcha_key":"","ajax_url":"https:\/\/clecpc.org\/wp-admin\/admin-ajax.php","fes_nonce":"ba59497885","current_year":"2024","current_month":"01","datepicker_format":"yy-mm-dd"};
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/js/frontend.js?ver=6.5.6" id="mec-frontend-script-js"></script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/js/events.js?ver=6.5.6" id="mec-events-script-js"></script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/google-analytics-for-wordpress/assets/js/frontend-gtag.min.js?ver=8.23.1" id="monsterinsights-frontend-script-js"></script>
+<script data-cfasync="false" data-wpfc-render="false" type="text/javascript" id='monsterinsights-frontend-script-js-extra'>/* <![CDATA[ */
+var monsterinsights_frontend = {"js_events_tracking":"true","download_extensions":"doc,pdf,ppt,zip,xls,docx,pptx,xlsx","inbound_paths":"[{\"path\":\"\\\/go\\\/\",\"label\":\"affiliate\"},{\"path\":\"\\\/recommend\\\/\",\"label\":\"affiliate\"}]","home_url":"https:\/\/clecpc.org","hash_tracking":"false","v4_id":"G-ZXWB1C1R71"};/* ]]> */
+</script>
+<script type="text/javascript" id="simple-banner-script-js-before">
+/* <![CDATA[ */
+const simpleBannerScriptParams = {"version":"2.17.0","hide_simple_banner":"yes","simple_banner_prepend_element":false,"simple_banner_position":"","header_margin":"","header_padding":"","simple_banner_z_index":"","simple_banner_text":"Public Feedback Needed by 9\/8\/23:<br><a href=\"https:\/\/bit.ly\/CPCPlan2023\">Send us your comments about the CPC's Work Plan<\/a>","pro_version_enabled":"","disabled_on_current_page":false,"debug_mode":"","id":15122,"disabled_pages_array":[],"is_current_page_a_post":false,"disabled_on_posts":"","simple_banner_disabled_page_paths":false,"simple_banner_font_size":"14","simple_banner_color":"#fdec35","simple_banner_text_color":"#2e2e2e","simple_banner_link_color":"#3756d2","simple_banner_close_color":"","simple_banner_custom_css":"","simple_banner_scrolling_custom_css":"","simple_banner_text_custom_css":"","simple_banner_button_css":"","site_custom_css":"","keep_site_custom_css":"","site_custom_js":"","keep_site_custom_js":"","wp_body_open_enabled":"","wp_body_open":true,"close_button_enabled":"","close_button_expiration":"11","close_button_cookie_set":false,"current_date":{"date":"2024-01-30 12:14:59.224241","timezone_type":3,"timezone":"UTC"},"start_date":{"date":"2024-01-30 12:14:59.224254","timezone_type":3,"timezone":"UTC"},"end_date":{"date":"2024-01-30 12:14:59.224263","timezone_type":3,"timezone":"UTC"},"simple_banner_start_after_date":"","simple_banner_remove_after_date":"","simple_banner_insert_inside_element":""}
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/simple-banner/simple-banner.js?ver=2.17.0" id="simple-banner-script-js"></script>
+<link rel="https://api.w.org/" href="https://clecpc.org/wp-json/" /><link rel="alternate" type="application/json" href="https://clecpc.org/wp-json/wp/v2/mec-events/15122" /><link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://clecpc.org/xmlrpc.php?rsd" />
+
+<link rel="alternate" type="application/json+oembed" href="https://clecpc.org/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fclecpc.org%2Fevents%2Fpolice-discipline-work-group%2F" />
+<link rel="alternate" type="text/xml+oembed" href="https://clecpc.org/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fclecpc.org%2Fevents%2Fpolice-discipline-work-group%2F&#038;format=xml" />
+<style type="text/css">.simple-banner{display:none;}</style><style type="text/css">.simple-banner .simple-banner-text{font-size:14;}</style><style type="text/css">.simple-banner{background:#fdec35;}</style><style type="text/css">.simple-banner .simple-banner-text{color:#2e2e2e;}</style><style type="text/css">.simple-banner .simple-banner-text a{color:#3756d2;}</style><style type="text/css">.simple-banner{z-index: 99999;}</style><style id="simple-banner-site-custom-css-dummy" type="text/css"></style><script id="simple-banner-site-custom-js-dummy" type="text/javascript"></script>	<style>img#wpstats{display:none}</style>
+		<meta name="generator" content="Elementor 3.19.0; features: e_optimized_assets_loading, additional_custom_breakpoints, block_editor_assets_optimize, e_image_loading_optimization; settings: css_print_method-external, google_font-enabled, font_display-auto">
+	<style type="text/css">
+			.site-title,
+		.site-description {
+			position: absolute;
+			clip: rect(1px, 1px, 1px, 1px);
+		}
+		</style>
+	<link rel="amphtml" href="https://clecpc.org/events/police-discipline-work-group/amp/"><script>( HTMLScriptElement.supports && HTMLScriptElement.supports("importmap") ) || document.write( '<script src="https://clecpc.org/wp-content/plugins/gutenberg/build/modules/importmap-polyfill.min.js"></scr' + 'ipt>' );</script><link rel="icon" href="https://i0.wp.com/clecpc.org/wp-content/uploads/2019/11/CPC-Bug3-Website.png?fit=32%2C32&#038;ssl=1" sizes="32x32" />
+<link rel="icon" href="https://i0.wp.com/clecpc.org/wp-content/uploads/2019/11/CPC-Bug3-Website.png?fit=192%2C192&#038;ssl=1" sizes="192x192" />
+<link rel="apple-touch-icon" href="https://i0.wp.com/clecpc.org/wp-content/uploads/2019/11/CPC-Bug3-Website.png?fit=180%2C180&#038;ssl=1" />
+<meta name="msapplication-TileImage" content="https://i0.wp.com/clecpc.org/wp-content/uploads/2019/11/CPC-Bug3-Website.png?fit=270%2C270&#038;ssl=1" />
+<link rel="stylesheet" type="text/css" id="wp-custom-css" href="https://clecpc.org/?custom-css=fe099d12e0" /><!-- Your Google Analytics Plugin is missing the tracking ID -->
+<style type="text/css">.mec-wrap, .mec-wrap div:not([class^="elementor-"]), .lity-container, .mec-wrap h1, .mec-wrap h2, .mec-wrap h3, .mec-wrap h4, .mec-wrap h5, .mec-wrap h6, .entry-content .mec-wrap h1, .entry-content .mec-wrap h2, .entry-content .mec-wrap h3, .entry-content .mec-wrap h4, .entry-content .mec-wrap h5, .entry-content .mec-wrap h6, .mec-wrap .mec-totalcal-box input[type="submit"], .mec-wrap .mec-totalcal-box .mec-totalcal-view span, .mec-agenda-event-title a, .lity-content .mec-events-meta-group-booking select, .lity-content .mec-book-ticket-variation h5, .lity-content .mec-events-meta-group-booking input[type="number"], .lity-content .mec-events-meta-group-booking input[type="text"], .lity-content .mec-events-meta-group-booking input[type="email"],.mec-organizer-item a, .mec-single-event .mec-events-meta-group-booking ul.mec-book-tickets-container li.mec-book-ticket-container label { font-family: "Montserrat", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;}.mec-event-content p, .mec-search-bar-result .mec-event-detail{ font-family: Roboto, sans-serif;} .mec-wrap .mec-totalcal-box input, .mec-wrap .mec-totalcal-box select, .mec-checkboxes-search .mec-searchbar-category-wrap, .mec-wrap .mec-totalcal-box .mec-totalcal-view span { font-family: "Roboto", Helvetica, Arial, sans-serif; }.mec-event-grid-modern .event-grid-modern-head .mec-event-day, .mec-event-list-minimal .mec-time-details, .mec-event-list-minimal .mec-event-detail, .mec-event-list-modern .mec-event-detail, .mec-event-grid-minimal .mec-time-details, .mec-event-grid-minimal .mec-event-detail, .mec-event-grid-simple .mec-event-detail, .mec-event-cover-modern .mec-event-place, .mec-event-cover-clean .mec-event-place, .mec-calendar .mec-event-article .mec-localtime-details div, .mec-calendar .mec-event-article .mec-event-detail, .mec-calendar.mec-calendar-daily .mec-calendar-d-top h2, .mec-calendar.mec-calendar-daily .mec-calendar-d-top h3, .mec-toggle-item-col .mec-event-day, .mec-weather-summary-temp { font-family: "Roboto", sans-serif; } .mec-fes-form, .mec-fes-list, .mec-fes-form input, .mec-event-date .mec-tooltip .box, .mec-event-status .mec-tooltip .box, .ui-datepicker.ui-widget, .mec-fes-form button[type="submit"].mec-fes-sub-button, .mec-wrap .mec-timeline-events-container p, .mec-wrap .mec-timeline-events-container h4, .mec-wrap .mec-timeline-events-container div, .mec-wrap .mec-timeline-events-container a, .mec-wrap .mec-timeline-events-container span { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif !important; }</style><style type="text/css">/** Mega Menu CSS: fs **/</style>
+<style id="wpforms-css-vars-root">
+				:root {
+					--wpforms-field-border-radius: 3px;
+--wpforms-field-background-color: #ffffff;
+--wpforms-field-border-color: rgba( 0, 0, 0, 0.25 );
+--wpforms-field-text-color: rgba( 0, 0, 0, 0.7 );
+--wpforms-label-color: rgba( 0, 0, 0, 0.85 );
+--wpforms-label-sublabel-color: rgba( 0, 0, 0, 0.55 );
+--wpforms-label-error-color: #d63637;
+--wpforms-button-border-radius: 3px;
+--wpforms-button-background-color: #066aab;
+--wpforms-button-text-color: #ffffff;
+--wpforms-field-size-input-height: 43px;
+--wpforms-field-size-input-spacing: 15px;
+--wpforms-field-size-font-size: 16px;
+--wpforms-field-size-line-height: 19px;
+--wpforms-field-size-padding-h: 14px;
+--wpforms-field-size-checkbox-size: 16px;
+--wpforms-field-size-sublabel-spacing: 5px;
+--wpforms-field-size-icon-size: 1;
+--wpforms-label-size-font-size: 16px;
+--wpforms-label-size-line-height: 19px;
+--wpforms-label-size-sublabel-font-size: 14px;
+--wpforms-label-size-sublabel-line-height: 17px;
+--wpforms-button-size-font-size: 17px;
+--wpforms-button-size-height: 41px;
+--wpforms-button-size-padding-h: 15px;
+--wpforms-button-size-margin-top: 10px;
+
+				}
+			</style></head>
+
+<body class="mec-events-template-default single single-mec-events postid-15122 wp-custom-logo mega-menu-menu-1 group-blog singular no-sidebar standard-menu sidebar-right elementor-default elementor-kit-1894">
+	<a class="skip-link screen-reader-text" href="#content">Skip to content</a>
+
+	<header id="masthead" class="site-header" role="banner">
+		<div class="site-branding">
+				<a href="https://clecpc.org/" class="custom-logo-link" rel="home"><img width="105" height="71" src="https://i0.wp.com/clecpc.org/wp-content/uploads/CPCLogo-Nav5.png?fit=105%2C71&amp;ssl=1" class="custom-logo" alt="Cleveland Community Police Commission" decoding="async" data-attachment-id="1717" data-permalink="https://clecpc.org/cpclogo-nav5/" data-orig-file="https://i0.wp.com/clecpc.org/wp-content/uploads/CPCLogo-Nav5.png?fit=105%2C71&amp;ssl=1" data-orig-size="105,71" data-comments-opened="1" data-image-meta="{&quot;aperture&quot;:&quot;0&quot;,&quot;credit&quot;:&quot;&quot;,&quot;camera&quot;:&quot;&quot;,&quot;caption&quot;:&quot;&quot;,&quot;created_timestamp&quot;:&quot;0&quot;,&quot;copyright&quot;:&quot;&quot;,&quot;focal_length&quot;:&quot;0&quot;,&quot;iso&quot;:&quot;0&quot;,&quot;shutter_speed&quot;:&quot;0&quot;,&quot;title&quot;:&quot;&quot;,&quot;orientation&quot;:&quot;0&quot;}" data-image-title="CPCLogo-Nav5" data-image-description="" data-image-caption="" data-medium-file="https://i0.wp.com/clecpc.org/wp-content/uploads/CPCLogo-Nav5.png?fit=105%2C71&amp;ssl=1" data-large-file="https://i0.wp.com/clecpc.org/wp-content/uploads/CPCLogo-Nav5.png?fit=105%2C71&amp;ssl=1" /></a>									<p class="site-title"><a href="https://clecpc.org/" rel="home">Cleveland Community Police Commission</a></p>
+						</div><!-- .site-branding -->
+			<nav id="site-navigation" class="main-navigation" role="navigation">
+				<button class="menu-toggle" aria-controls="primary-menu" aria-expanded="false">Menu</button>
+				<div id="mega-menu-wrap-menu-1" class="mega-menu-wrap"><div class="mega-menu-toggle"><div class="mega-toggle-blocks-left"></div><div class="mega-toggle-blocks-center"></div><div class="mega-toggle-blocks-right"><div class='mega-toggle-block mega-menu-toggle-block mega-toggle-block-1' id='mega-toggle-block-1' tabindex='0'><span class='mega-toggle-label' role='button' aria-expanded='false'><span class='mega-toggle-label-closed'></span><span class='mega-toggle-label-open'></span></span></div></div></div><ul id="mega-menu-menu-1" class="mega-menu max-mega-menu mega-menu-horizontal mega-no-js" data-event="hover_intent" data-effect="fade_up" data-effect-speed="200" data-effect-mobile="disabled" data-effect-speed-mobile="0" data-mobile-force-width="body" data-second-click="go" data-document-click="collapse" data-vertical-behaviour="standard" data-breakpoint="900" data-unbind="true" data-mobile-state="collapse_all" data-hover-intent-timeout="300" data-hover-intent-interval="100"><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-has-children mega-align-bottom-left mega-menu-flyout mega-menu-item-1532' id='mega-menu-item-1532'><a class="mega-menu-link" href="https://clecpc.org/about-us/" aria-haspopup="true" aria-expanded="false" tabindex="0">About Us<span class="mega-indicator"></span></a>
+<ul class="mega-sub-menu">
+<li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-5420' id='mega-menu-item-5420'><a class="mega-menu-link" href="https://clecpc.org/about-us/">About</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-13293' id='mega-menu-item-13293'><a class="mega-menu-link" href="https://clecpc.org/about-us/news/">News</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-4920' id='mega-menu-item-4920'><a class="mega-menu-link" href="https://clecpc.org/about-us/our-partners/">Community Partners</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-12256' id='mega-menu-item-12256'><a class="mega-menu-link" href="https://clecpc.org/about-us/rules-and-procedures/">Rules and Procedures</a></li></ul>
+</li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-has-children mega-align-bottom-left mega-menu-flyout mega-menu-item-145' id='mega-menu-item-145'><a class="mega-menu-link" href="https://clecpc.org/our-work/" aria-haspopup="true" aria-expanded="false" tabindex="0">Our Work<span class="mega-indicator"></span></a>
+<ul class="mega-sub-menu">
+<li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-13692' id='mega-menu-item-13692'><a class="mega-menu-link" href="https://clecpc.org/our-work/committees/">Committees</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-has-children mega-menu-item-5421' id='mega-menu-item-5421'><a class="mega-menu-link" href="https://clecpc.org/our-work/" aria-haspopup="true" aria-expanded="false">Reports & Recommendations<span class="mega-indicator"></span></a>
+	<ul class="mega-sub-menu">
+<li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-147' id='mega-menu-item-147'><a class="mega-menu-link" href="https://clecpc.org/our-work/accountability/">Accountability</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-148' id='mega-menu-item-148'><a class="mega-menu-link" href="https://clecpc.org/our-work/bias-free-policing/">Bias-Free Policing</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-1679' id='mega-menu-item-1679'><a class="mega-menu-link" href="https://clecpc.org/our-work/civilian-oversight/">Civilian Oversight</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-150' id='mega-menu-item-150'><a class="mega-menu-link" href="https://clecpc.org/our-work/cpop/">Community &amp; Problem-Oriented Policing (CPOP)</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-151' id='mega-menu-item-151'><a class="mega-menu-link" href="https://clecpc.org/our-work/search-seizure/">Search &amp; Seizure</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-149' id='mega-menu-item-149'><a class="mega-menu-link" href="https://clecpc.org/our-work/use-of-force/">Use of Force</a></li>	</ul>
+</li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-9188' id='mega-menu-item-9188'><a class="mega-menu-link" href="https://clecpc.org/100-years-project/">100 Years Project</a></li></ul>
+</li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-has-children mega-align-bottom-left mega-menu-flyout mega-menu-item-153' id='mega-menu-item-153'><a class="mega-menu-link" href="https://clecpc.org/get-involved/" aria-haspopup="true" aria-expanded="false" tabindex="0">Get Involved<span class="mega-indicator"></span></a>
+<ul class="mega-sub-menu">
+<li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-5422' id='mega-menu-item-5422'><a class="mega-menu-link" href="https://clecpc.org/get-involved/">Ways to Get Involved</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-154' id='mega-menu-item-154'><a class="mega-menu-link" href="https://clecpc.org/get-involved/calendar/">Event Calendar</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-690' id='mega-menu-item-690'><a class="mega-menu-link" href="https://clecpc.org/get-involved/work-groups/">CPC Work Groups</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-5009' id='mega-menu-item-5009'><a class="mega-menu-link" href="https://clecpc.org/get-involved/dpc-meetings/">District Policing Committee Meetings</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-2250' id='mega-menu-item-2250'><a class="mega-menu-link" href="https://clecpc.org/get-involved/feedback/">Community Feedback</a></li></ul>
+</li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-has-children mega-align-bottom-left mega-menu-flyout mega-menu-item-155' id='mega-menu-item-155'><a class="mega-menu-link" href="https://clecpc.org/resources/" aria-haspopup="true" aria-expanded="false" tabindex="0">Resources<span class="mega-indicator"></span></a>
+<ul class="mega-sub-menu">
+<li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-6202' id='mega-menu-item-6202'><a class="mega-menu-link" href="https://clecpc.org/resources/">Resources</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-156' id='mega-menu-item-156'><a class="mega-menu-link" href="https://clecpc.org/resources/consent-decree/">The Consent Decree</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-1449' id='mega-menu-item-1449'><a class="mega-menu-link" href="https://clecpc.org/resources/general-police-orders/">General Police Orders</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-157' id='mega-menu-item-157'><a class="mega-menu-link" href="https://clecpc.org/resources/meeting-agendas-minutes/">Agendas & Minutes</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-158' id='mega-menu-item-158'><a class="mega-menu-link" href="https://clecpc.org/resources/case-updates-filings/">Case Updates &amp; Filings</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-12695' id='mega-menu-item-12695'><a class="mega-menu-link" href="https://clecpc.org/resources/community-grants/">Community Grants</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-14381' id='mega-menu-item-14381'><a class="mega-menu-link" href="https://clecpc.org/resources/brady-giglio/">Brady-Giglio</a></li></ul>
+</li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-align-bottom-left mega-menu-flyout mega-menu-item-159' id='mega-menu-item-159'><a class="mega-menu-link" href="https://clecpc.org/contact/" tabindex="0">Contact Us</a></li></ul></div>			</nav><!-- #site-navigation -->
+	</header>
+	
+    <section id="main-content" class="mec-container">
+
+        
+        
+            <div class="mec-wrap colorskin-custom clearfix " id="mec_skin_9374">
+		<article class="row mec-single-event ">
+
+		<!-- start breadcrumbs -->
+				<!-- end breadcrumbs -->
+
+		<div class="col-md-8">
+			<div class="mec-events-event-image">
+                                            </div>
+			<div class="mec-event-content">
+								<h1 class="mec-single-title">Police Discipline Work Group</h1>
+				<div class="mec-single-event-description mec-events-content"><p>Work Group to review the police disciplinary policy, disciplinary matrix and police manual of rules </p>
+</div>
+			</div>
+
+			
+			<!-- Custom Data Fields -->
+			
+			<div class="mec-event-info-mobile"></div>
+
+			<!-- Export Module -->
+			<div class="mec-event-export-module mec-frontbox">
+     <div class="mec-event-exporting">
+        <div class="mec-export-details">
+            <ul>
+                <li><a class="mec-events-gcal mec-events-button mec-color mec-bg-color-hover mec-border-color" href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Police+Discipline+Work+Group&dates=20240201T233000Z/20240202T013000Z&details=Work+Group+to+review+the+police+disciplinary+policy%2C+disciplinary+matrix+and+police+manual+of+rules%C2%A0&amp;location=3631+Perkins+Ave.%2C+Cleveland+4th+Fl&recur=RRULE%3AFREQ%3DWEEKLY%3BUNTIL%3D20240328T203000Z" target="_blank">+ Add to Google Calendar</a></li>                <li><a class="mec-events-gcal mec-events-button mec-color mec-bg-color-hover mec-border-color" href="https://clecpc.org/?method=ical&#038;id=15122">+ iCal / Outlook export</a></li>            </ul>
+        </div>
+    </div>
+</div>
+			<!-- Countdown module -->
+			
+			<!-- Hourly Schedule -->
+			
+			
+			<!-- Booking Module -->
+			
+			<!-- Tags -->
+			<div class="mec-events-meta-group mec-events-meta-group-tags">
+                			</div>
+
+		</div>
+
+					<div class="col-md-4">
+
+				<div class="mec-event-info-desktop mec-event-meta mec-color-before mec-frontbox">
+											<div class="mec-single-event-date">
+							<i class="mec-sl-calendar"></i>
+							<h3 class="mec-date">Date</h3>
+							<dl>
+																	<dd><abbr class="mec-events-abbr"><span class="mec-start-date-label">Feb 01 2024</span></abbr></dd>
+															</dl>
+													</div>
+
+													<div class="mec-single-event-time">
+								<i class="mec-sl-clock " style=""></i>
+								<h3 class="mec-time">Time</h3>
+								<i class="mec-time-comment"></i>
+								<dl>
+																			<dd><abbr class="mec-events-abbr">6:30 pm - 8:30 pm</abbr></dd>
+																	</dl>
+							</div>
+							
+					<!-- Local Time Module -->
+					
+					
+										
+					
+					
+
+											<div class="mec-single-event-location">
+														<i class="mec-sl-location-pin"></i>
+							<h3 class="mec-events-single-section-title mec-location">Location</h3>
+							<dl>
+							<dd class="author fn org">CPC Offices</dd>
+							<dd class="location"><address class="mec-events-address"><span class="mec-address">3631 Perkins Ave., Cleveland 4th Fl</span></address></dd>
+
+														</dl>
+						</div>
+						
+											<div class="mec-single-event-category">
+							<i class="mec-sl-folder"></i>
+							<dt>Category</dt>
+							<dl><dd class="mec-events-event-categories">
+                                <a href="https://clecpc.org/mec-category/cpc-events/" class="mec-color-hover" rel="tag"><i class="mec-fa-angle-right"></i>CPC Events</a></dd></dl><dl><dd class="mec-events-event-categories">
+                                <a href="https://clecpc.org/mec-category/work-group-meetings-cpc-events/" class="mec-color-hover" rel="tag"><i class="mec-fa-angle-right"></i>Work Group Meetings</a></dd></dl>						</div>
+																						<div class="mec-single-event-organizer">
+														<h3 class="mec-events-single-section-title">Organizer</h3>
+							<dl>
+															<dd class="mec-organizer">
+									<i class="mec-sl-home"></i>
+									<h6>Cleveland Community Police Commission</h6>
+								</dd>
+															<dd class="mec-organizer-url">
+									<i class="mec-sl-sitemap"></i>
+									<h6>Website</h6>
+									<span><a href="http://clecpc.org" class="mec-color-hover" target="_blank">http://clecpc.org</a></span>
+																	</dd>
+														</dl>
+						</div>
+						
+					<!-- Register Booking Button -->
+					
+				</div>
+
+				<!-- Speakers Module -->
+				
+				<!-- Attendees List Module -->
+				
+				<!-- Next Previous Module -->
+				
+				<!-- Links Module -->
+				<div class="mec-event-social mec-frontbox">
+     <h3 class="mec-social-single mec-frontbox-title">Share this event</h3>
+     <div class="mec-event-sharing">
+        <div class="mec-links-details">
+            <ul>
+                <li class="mec-event-social-icon"><a class="facebook" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fclecpc.org%2Fevents%2Fpolice-discipline-work-group%2F" onclick="javascript:window.open(this.href, '', 'menubar=no,toolbar=no,resizable=yes,scrollbars=yes,height=500,width=600'); return false;" target="_blank" title="Share on Facebook"><i class="mec-fa-facebook"></i></a></li><li class="mec-event-social-icon"><a class="twitter" href="https://twitter.com/share?url=https%3A%2F%2Fclecpc.org%2Fevents%2Fpolice-discipline-work-group%2F" onclick="javascript:window.open(this.href, '', 'menubar=no,toolbar=no,resizable=yes,scrollbars=yes,height=600,width=500'); return false;" target="_blank" title="Tweet"><i class="mec-fa-twitter"></i></a></li><li class="mec-event-social-icon"><a class="linkedin" href="https://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fclecpc.org%2Fevents%2Fpolice-discipline-work-group%2F" onclick="javascript:window.open(this.href, '', 'menubar=no,toolbar=no,resizable=yes,scrollbars=yes,height=600,width=500'); return false;" target="_blank" title="Linkedin"><i class="mec-fa-linkedin"></i></a></li><li class="mec-event-social-icon"><a class="email" href="mailto:?subject=Police%20Discipline%20Work%20Group&body=https%3A%2F%2Fclecpc.org%2Fevents%2Fpolice-discipline-work-group%2F" title="Email"><i class="mec-fa-envelope"></i></a></li>            </ul>
+        </div>
+    </div>
+</div>
+				<!-- Weather Module -->
+				
+				<!-- Google Maps Module -->
+				<div class="mec-events-meta-group mec-events-meta-group-gmap">
+									</div>
+
+				<!-- QRCode Module -->
+				
+                <!-- Public Download Module -->
+                
+				<!-- Widgets -->
+				
+			</div>
+			</article>
+
+		
+</div>
+<script>
+// Fix modal speaker in some themes
+jQuery(".mec-speaker-avatar a").on('click', function(e)
+{
+    e.preventDefault();
+
+    var id = jQuery(this).attr('href');
+    lity(id);
+});
+
+// Fix modal booking in some themes
+jQuery(window).on('load', function()
+{
+    jQuery(".mec-booking-button.mec-booking-data-lity").on('click', function(e)
+    {
+        e.preventDefault();
+
+        var book_id = jQuery(this).attr('href');
+        lity(book_id);
+    });
+});
+</script>
+                
+<div id="comments" class="comments-area">
+
+	
+	
+	
+	
+		<div id="respond" class="comment-respond">
+			<h3 id="reply-title" class="comment-reply-title">Discussion: Leave a Comment or Question<small><a rel="nofollow" id="cancel-comment-reply-link" href="/events/police-discipline-work-group/#respond" style="display:none;">Cancel reply</a></small></h3>			<form id="commentform" class="comment-form">
+				<iframe
+					title="Comment Form"
+					src="https://jetpack.wordpress.com/jetpack-comment/?blogid=168708355&#038;postid=15122&#038;comment_registration=0&#038;require_name_email=1&#038;stc_enabled=1&#038;stb_enabled=1&#038;show_avatars=1&#038;avatar_default=identicon&#038;greeting=Discussion%3A+Leave+a+Comment+or+Question&#038;jetpack_comments_nonce=ccc2809eb5&#038;greeting_reply=Leave+a+Reply+to+%25s&#038;color_scheme=light&#038;lang=en_US&#038;jetpack_version=13.1-a.7&#038;show_cookie_consent=10&#038;has_cookie_consent=0&#038;is_current_user_subscribed=0&#038;token_key=%3Bnormal%3B&#038;sig=f139be6da977532643d456ede474482483b12592#parent=https%3A%2F%2Fclecpc.org%2Fevents%2Fpolice-discipline-work-group%2F"
+											name="jetpack_remote_comment"
+						style="width:100%; height: 430px; border:0;"
+										class="jetpack_remote_comment"
+					id="jetpack_remote_comment"
+					sandbox="allow-same-origin allow-top-navigation allow-scripts allow-forms allow-popups"
+				>
+									</iframe>
+									<!--[if !IE]><!-->
+					<script>
+						document.addEventListener('DOMContentLoaded', function () {
+							var commentForms = document.getElementsByClassName('jetpack_remote_comment');
+							for (var i = 0; i < commentForms.length; i++) {
+								commentForms[i].allowTransparency = false;
+								commentForms[i].scrolling = 'no';
+							}
+						});
+					</script>
+					<!--<![endif]-->
+							</form>
+		</div>
+
+		
+		<input type="hidden" name="comment_parent" id="comment_parent" value="" />
+
+		
+</div><!-- #comments -->    </section>
+
+    
+	<div class="social-block">
+			</div>
+	
+	
+	<footer id="colophon" class="site-footer" role="contentinfo">
+
+		<div class="hfeed site">
+
+			<div class="content site-content">
+
+				<div class="footer-widgets clear">
+
+					
+						<div class="widget-area">
+
+							<aside id="text-3" class="widget widget_text"><h2 class="widget-title">Community Police Commission</h2>			<div class="textwidget"></div>
+		</aside><aside id="custom_html-10" class="widget_text widget widget_custom_html"><h2 class="widget-title">Subscribe</h2><div class="textwidget custom-html-widget"><div class="wp-block-button"><a class="wp-block-button__link has-background" href="http://eepurl.com/gVB5J5" style="background-color:#0071a1;border-radius:6px" target="_blank" rel="noreferrer noopener"> Newsletter Sign up</a></div></div></aside><aside id="jetpack_widget_social_icons-6" class="widget jetpack_widget_social_icons">
+			<ul class="jetpack-social-widget-list size-medium">
+
+				
+											<li class="jetpack-social-widget-item">
+							<a href="https://www.facebook.com/216cpc/" target="_blank" rel="noopener noreferrer"><span class="screen-reader-text">Facebook</span><svg class="icon icon-facebook" aria-hidden="true" role="presentation"> <use href="#icon-facebook" xlink:href="#icon-facebook"></use> </svg>							</a>
+						</li>
+					
+				
+											<li class="jetpack-social-widget-item">
+							<a href="https://twitter.com/216cpc" target="_blank" rel="noopener noreferrer"><span class="screen-reader-text">Twitter</span><svg class="icon icon-twitter" aria-hidden="true" role="presentation"> <use href="#icon-twitter" xlink:href="#icon-twitter"></use> </svg>							</a>
+						</li>
+					
+				
+											<li class="jetpack-social-widget-item">
+							<a href="https://www.youtube.com/channel/UCZsDVxlvwJyEJU8-UuXgFiQ" target="_blank" rel="noopener noreferrer"><span class="screen-reader-text">YouTube</span><svg class="icon icon-youtube" aria-hidden="true" role="presentation"> <use href="#icon-youtube" xlink:href="#icon-youtube"></use> </svg>							</a>
+						</li>
+					
+				
+											<li class="jetpack-social-widget-item">
+							<a href="https://www.instagram.com/cleveland_cpc/" target="_blank" rel="noopener noreferrer"><span class="screen-reader-text">Instagram</span><svg class="icon icon-instagram" aria-hidden="true" role="presentation"> <use href="#icon-instagram" xlink:href="#icon-instagram"></use> </svg>							</a>
+						</li>
+					
+				
+			</ul>
+
+			</aside>
+						</div><!-- .widget-area -->
+
+					
+					
+						<div class="widget-area">
+
+							<aside id="widget_contact_info-3" class="widget widget_contact_info"><h2 class="widget-title">Address &amp; Info</h2><div itemscope itemtype="http://schema.org/LocalBusiness"><div class="confit-address" itemscope itemtype="http://schema.org/PostalAddress" itemprop="address"><a href="https://maps.google.com/maps?z=16&#038;q=3631%2Bperkins%2Bavenue%2C%2B4th%2Bfloor%2Bcleveland%2C%2Boh%2B44114" target="_blank" rel="noopener noreferrer">3631 Perkins Avenue, 4th Floor<br/>Cleveland, OH 44114</a></div><div class="confit-phone"><span itemprop="telephone">Phone: 1-216-505-5920</span></div><div class="confit-hours" itemprop="openingHours">Hours: M– F: 7:30am – 4:30pm</div></div></aside>
+						</div><!-- .widget-area -->
+
+					
+					
+						<div class="widget-area">
+
+							<aside id="custom_html-8" class="widget_text widget widget_custom_html"><h2 class="widget-title">Links</h2><div class="textwidget custom-html-widget"><a href="https://clecpc.org/about-us/">About Us</a><br>
+<a href="https://clecpc.org/our-work/">Our Work </a><br>
+<a href="https://clecpc.org/get-involved/work-groups/">Work Groups </a><br>
+
+<a href="https://clecpc.org/get-involved/calendar/">Event Calendar</a> <br>
+<a href="https://clecpc.org/contact/">Contact Us </a></div></aside><aside id="text-19" class="widget widget_text">			<div class="textwidget"><p>© 2023 Cleveland Community Police Commission</p>
+</div>
+		</aside>
+						</div><!-- .widget-area -->
+
+				
+				</div><!-- .footer-widgets -->
+
+			</div><!-- .site -->
+
+		</div><!-- .content -->
+
+	</footer><!-- #colophon -->
+				<div class="site-info">
+				<div class="hfeed site">
+					<div class="content site-content">
+						
+						
+											</div><!-- .content -->
+				</div><!-- .site -->
+			</div><!-- .site-info -->
+<!--  -->
+<style>
+			.sd-social-icon .sd-content ul li a.sd-button>span {
+				margin-left: 0;
+			}
+		</style><script defer id="bilmur" data-provider="wordpress.com" data-service="atomic"  src="https://s0.wp.com/wp-content/js/bilmur.min.js?m=202405"></script>
+<div class="simple-banner simple-banner-text" style="display:none !important"></div><script type="text/javascript" src="https://c0.wp.com/c/6.4.2/wp-includes/js/jquery/ui/core.min.js" id="jquery-ui-core-js"></script>
+<script type="text/javascript" src="https://c0.wp.com/c/6.4.2/wp-includes/js/jquery/ui/datepicker.min.js" id="jquery-ui-datepicker-js"></script>
+<script type="text/javascript" id="jquery-ui-datepicker-js-after">
+/* <![CDATA[ */
+jQuery(function(jQuery){jQuery.datepicker.setDefaults({"closeText":"Close","currentText":"Today","monthNames":["January","February","March","April","May","June","July","August","September","October","November","December"],"monthNamesShort":["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],"nextText":"Next","prevText":"Previous","dayNames":["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],"dayNamesShort":["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],"dayNamesMin":["S","M","T","W","T","F","S"],"dateFormat":"MM d, yy","firstDay":0,"isRTL":false});});
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/js/jquery.typewatch.js?ver=6.5.6" id="mec-typekit-script-js"></script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/packages/featherlight/featherlight.js?ver=6.5.6" id="featherlight-js"></script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/packages/select2/select2.full.min.js?ver=6.5.6" id="mec-select2-script-js"></script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/packages/tooltip/tooltip.js?ver=6.5.6" id="mec-tooltip-script-js"></script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/packages/lity/lity.min.js?ver=6.5.6" id="mec-lity-script-js"></script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/packages/colorbrightness/colorbrightness.min.js?ver=6.5.6" id="mec-colorbrightness-script-js"></script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/modern-events-calendar-lite/assets/packages/owl-carousel/owl.carousel.min.js?ver=6.5.6" id="mec-owl-carousel-script-js"></script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/jetpack/jetpack_vendor/automattic/jetpack-image-cdn/dist/image-cdn.js?minify=false&amp;ver=132249e245926ae3e188" id="jetpack-photon-js"></script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/coblocks/dist/js/coblocks-animation.js?ver=3.1.5" id="coblocks-animation-js"></script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/coblocks/dist/js/vendors/tiny-swiper.js?ver=3.1.5" id="coblocks-tiny-swiper-js"></script>
+<script type="text/javascript" id="coblocks-tinyswiper-initializer-js-extra">
+/* <![CDATA[ */
+var coblocksTinyswiper = {"carouselPrevButtonAriaLabel":"Previous","carouselNextButtonAriaLabel":"Next","sliderImageAriaLabel":"Image"};
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/coblocks/dist/js/coblocks-tinyswiper-initializer.js?ver=3.1.5" id="coblocks-tinyswiper-initializer-js"></script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/themes/pena/js/navigation.js?ver=20120206" id="pena-navigation-js"></script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/themes/pena/js/skip-link-focus-fix.js?ver=20130115" id="pena-skip-link-focus-fix-js"></script>
+<script type="text/javascript" src="https://c0.wp.com/c/6.4.2/wp-includes/js/comment-reply.min.js" id="comment-reply-js" async="async" data-wp-strategy="async"></script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/google-calendar-events/assets/generated/vendor/jquery.qtip.min.js?ver=3.3.0" id="simcal-qtip-js"></script>
+<script type="text/javascript" id="simcal-default-calendar-js-extra">
+/* <![CDATA[ */
+var simcal_default_calendar = {"ajax_url":"\/wp-admin\/admin-ajax.php","nonce":"fefd783391","locale":"en_US","text_dir":"ltr","months":{"full":["January","February","March","April","May","June","July","August","September","October","November","December"],"short":["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"]},"days":{"full":["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],"short":["Sun","Mon","Tue","Wed","Thu","Fri","Sat"]},"meridiem":{"AM":"AM","am":"am","PM":"PM","pm":"pm"}};
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/google-calendar-events/assets/generated/default-calendar.min.js?ver=3.3.0" id="simcal-default-calendar-js"></script>
+<script type="text/javascript" id="ics-calendar-js-extra">
+/* <![CDATA[ */
+var r34ics_ajax_obj = {"ajaxurl":"https:\/\/clecpc.org\/wp-admin\/admin-ajax.php","r34ics_nonce":"c409ca5f80"};
+var ics_calendar_i18n = {"hide_past_events":"Hide past events","show_past_events":"Show past events"};
+var r34ics_days_of_week_map = {"Sunday":"Sun","Monday":"Mon","Tuesday":"Tue","Wednesday":"Wed","Thursday":"Thu","Friday":"Fri","Saturday":"Sat"};
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/ics-calendar/assets/script.min.js?ver=10.14.1" id="ics-calendar-js"></script>
+<script type="text/javascript" id="eael-general-js-extra">
+/* <![CDATA[ */
+var localize = {"ajaxurl":"https:\/\/clecpc.org\/wp-admin\/admin-ajax.php","nonce":"a964e5bced","i18n":{"added":"Added ","compare":"Compare","loading":"Loading..."},"eael_translate_text":{"required_text":"is a required field","invalid_text":"Invalid","billing_text":"Billing","shipping_text":"Shipping","fg_mfp_counter_text":"of"},"page_permalink":"https:\/\/clecpc.org\/events\/police-discipline-work-group\/","cart_redirectition":"","cart_page_url":"","el_breakpoints":{"mobile":{"label":"Mobile Portrait","value":767,"default_value":767,"direction":"max","is_enabled":true},"mobile_extra":{"label":"Mobile Landscape","value":880,"default_value":880,"direction":"max","is_enabled":false},"tablet":{"label":"Tablet Portrait","value":1024,"default_value":1024,"direction":"max","is_enabled":true},"tablet_extra":{"label":"Tablet Landscape","value":1200,"default_value":1200,"direction":"max","is_enabled":false},"laptop":{"label":"Laptop","value":1366,"default_value":1366,"direction":"max","is_enabled":false},"widescreen":{"label":"Widescreen","value":2400,"default_value":2400,"direction":"min","is_enabled":false}},"ParticleThemesData":{"default":"{\"particles\":{\"number\":{\"value\":160,\"density\":{\"enable\":true,\"value_area\":800}},\"color\":{\"value\":\"#ffffff\"},\"shape\":{\"type\":\"circle\",\"stroke\":{\"width\":0,\"color\":\"#000000\"},\"polygon\":{\"nb_sides\":5},\"image\":{\"src\":\"img\/github.svg\",\"width\":100,\"height\":100}},\"opacity\":{\"value\":0.5,\"random\":false,\"anim\":{\"enable\":false,\"speed\":1,\"opacity_min\":0.1,\"sync\":false}},\"size\":{\"value\":3,\"random\":true,\"anim\":{\"enable\":false,\"speed\":40,\"size_min\":0.1,\"sync\":false}},\"line_linked\":{\"enable\":true,\"distance\":150,\"color\":\"#ffffff\",\"opacity\":0.4,\"width\":1},\"move\":{\"enable\":true,\"speed\":6,\"direction\":\"none\",\"random\":false,\"straight\":false,\"out_mode\":\"out\",\"bounce\":false,\"attract\":{\"enable\":false,\"rotateX\":600,\"rotateY\":1200}}},\"interactivity\":{\"detect_on\":\"canvas\",\"events\":{\"onhover\":{\"enable\":true,\"mode\":\"repulse\"},\"onclick\":{\"enable\":true,\"mode\":\"push\"},\"resize\":true},\"modes\":{\"grab\":{\"distance\":400,\"line_linked\":{\"opacity\":1}},\"bubble\":{\"distance\":400,\"size\":40,\"duration\":2,\"opacity\":8,\"speed\":3},\"repulse\":{\"distance\":200,\"duration\":0.4},\"push\":{\"particles_nb\":4},\"remove\":{\"particles_nb\":2}}},\"retina_detect\":true}","nasa":"{\"particles\":{\"number\":{\"value\":250,\"density\":{\"enable\":true,\"value_area\":800}},\"color\":{\"value\":\"#ffffff\"},\"shape\":{\"type\":\"circle\",\"stroke\":{\"width\":0,\"color\":\"#000000\"},\"polygon\":{\"nb_sides\":5},\"image\":{\"src\":\"img\/github.svg\",\"width\":100,\"height\":100}},\"opacity\":{\"value\":1,\"random\":true,\"anim\":{\"enable\":true,\"speed\":1,\"opacity_min\":0,\"sync\":false}},\"size\":{\"value\":3,\"random\":true,\"anim\":{\"enable\":false,\"speed\":4,\"size_min\":0.3,\"sync\":false}},\"line_linked\":{\"enable\":false,\"distance\":150,\"color\":\"#ffffff\",\"opacity\":0.4,\"width\":1},\"move\":{\"enable\":true,\"speed\":1,\"direction\":\"none\",\"random\":true,\"straight\":false,\"out_mode\":\"out\",\"bounce\":false,\"attract\":{\"enable\":false,\"rotateX\":600,\"rotateY\":600}}},\"interactivity\":{\"detect_on\":\"canvas\",\"events\":{\"onhover\":{\"enable\":true,\"mode\":\"bubble\"},\"onclick\":{\"enable\":true,\"mode\":\"repulse\"},\"resize\":true},\"modes\":{\"grab\":{\"distance\":400,\"line_linked\":{\"opacity\":1}},\"bubble\":{\"distance\":250,\"size\":0,\"duration\":2,\"opacity\":0,\"speed\":3},\"repulse\":{\"distance\":400,\"duration\":0.4},\"push\":{\"particles_nb\":4},\"remove\":{\"particles_nb\":2}}},\"retina_detect\":true}","bubble":"{\"particles\":{\"number\":{\"value\":15,\"density\":{\"enable\":true,\"value_area\":800}},\"color\":{\"value\":\"#1b1e34\"},\"shape\":{\"type\":\"polygon\",\"stroke\":{\"width\":0,\"color\":\"#000\"},\"polygon\":{\"nb_sides\":6},\"image\":{\"src\":\"img\/github.svg\",\"width\":100,\"height\":100}},\"opacity\":{\"value\":0.3,\"random\":true,\"anim\":{\"enable\":false,\"speed\":1,\"opacity_min\":0.1,\"sync\":false}},\"size\":{\"value\":50,\"random\":false,\"anim\":{\"enable\":true,\"speed\":10,\"size_min\":40,\"sync\":false}},\"line_linked\":{\"enable\":false,\"distance\":200,\"color\":\"#ffffff\",\"opacity\":1,\"width\":2},\"move\":{\"enable\":true,\"speed\":8,\"direction\":\"none\",\"random\":false,\"straight\":false,\"out_mode\":\"out\",\"bounce\":false,\"attract\":{\"enable\":false,\"rotateX\":600,\"rotateY\":1200}}},\"interactivity\":{\"detect_on\":\"canvas\",\"events\":{\"onhover\":{\"enable\":false,\"mode\":\"grab\"},\"onclick\":{\"enable\":false,\"mode\":\"push\"},\"resize\":true},\"modes\":{\"grab\":{\"distance\":400,\"line_linked\":{\"opacity\":1}},\"bubble\":{\"distance\":400,\"size\":40,\"duration\":2,\"opacity\":8,\"speed\":3},\"repulse\":{\"distance\":200,\"duration\":0.4},\"push\":{\"particles_nb\":4},\"remove\":{\"particles_nb\":2}}},\"retina_detect\":true}","snow":"{\"particles\":{\"number\":{\"value\":450,\"density\":{\"enable\":true,\"value_area\":800}},\"color\":{\"value\":\"#fff\"},\"shape\":{\"type\":\"circle\",\"stroke\":{\"width\":0,\"color\":\"#000000\"},\"polygon\":{\"nb_sides\":5},\"image\":{\"src\":\"img\/github.svg\",\"width\":100,\"height\":100}},\"opacity\":{\"value\":0.5,\"random\":true,\"anim\":{\"enable\":false,\"speed\":1,\"opacity_min\":0.1,\"sync\":false}},\"size\":{\"value\":5,\"random\":true,\"anim\":{\"enable\":false,\"speed\":40,\"size_min\":0.1,\"sync\":false}},\"line_linked\":{\"enable\":false,\"distance\":500,\"color\":\"#ffffff\",\"opacity\":0.4,\"width\":2},\"move\":{\"enable\":true,\"speed\":6,\"direction\":\"bottom\",\"random\":false,\"straight\":false,\"out_mode\":\"out\",\"bounce\":false,\"attract\":{\"enable\":false,\"rotateX\":600,\"rotateY\":1200}}},\"interactivity\":{\"detect_on\":\"canvas\",\"events\":{\"onhover\":{\"enable\":true,\"mode\":\"bubble\"},\"onclick\":{\"enable\":true,\"mode\":\"repulse\"},\"resize\":true},\"modes\":{\"grab\":{\"distance\":400,\"line_linked\":{\"opacity\":0.5}},\"bubble\":{\"distance\":400,\"size\":4,\"duration\":0.3,\"opacity\":1,\"speed\":3},\"repulse\":{\"distance\":200,\"duration\":0.4},\"push\":{\"particles_nb\":4},\"remove\":{\"particles_nb\":2}}},\"retina_detect\":true}","nyan_cat":"{\"particles\":{\"number\":{\"value\":150,\"density\":{\"enable\":false,\"value_area\":800}},\"color\":{\"value\":\"#ffffff\"},\"shape\":{\"type\":\"star\",\"stroke\":{\"width\":0,\"color\":\"#000000\"},\"polygon\":{\"nb_sides\":5},\"image\":{\"src\":\"http:\/\/wiki.lexisnexis.com\/academic\/images\/f\/fb\/Itunes_podcast_icon_300.jpg\",\"width\":100,\"height\":100}},\"opacity\":{\"value\":0.5,\"random\":false,\"anim\":{\"enable\":false,\"speed\":1,\"opacity_min\":0.1,\"sync\":false}},\"size\":{\"value\":4,\"random\":true,\"anim\":{\"enable\":false,\"speed\":40,\"size_min\":0.1,\"sync\":false}},\"line_linked\":{\"enable\":false,\"distance\":150,\"color\":\"#ffffff\",\"opacity\":0.4,\"width\":1},\"move\":{\"enable\":true,\"speed\":14,\"direction\":\"left\",\"random\":false,\"straight\":true,\"out_mode\":\"out\",\"bounce\":false,\"attract\":{\"enable\":false,\"rotateX\":600,\"rotateY\":1200}}},\"interactivity\":{\"detect_on\":\"canvas\",\"events\":{\"onhover\":{\"enable\":false,\"mode\":\"grab\"},\"onclick\":{\"enable\":true,\"mode\":\"repulse\"},\"resize\":true},\"modes\":{\"grab\":{\"distance\":200,\"line_linked\":{\"opacity\":1}},\"bubble\":{\"distance\":400,\"size\":40,\"duration\":2,\"opacity\":8,\"speed\":3},\"repulse\":{\"distance\":200,\"duration\":0.4},\"push\":{\"particles_nb\":4},\"remove\":{\"particles_nb\":2}}},\"retina_detect\":true}"},"eael_login_nonce":"ef8545b988","eael_register_nonce":"e02c09348c","eael_lostpassword_nonce":"eef575e278","eael_resetpassword_nonce":"fbd3773d7f"};
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/essential-addons-for-elementor-lite/assets/front-end/js/view/general.min.js?ver=5.9.7" id="eael-general-js"></script>
+<script defer type="text/javascript" src="https://stats.wp.com/e-202405.js" id="jetpack-stats-js"></script>
+<script type="text/javascript" id="jetpack-stats-js-after">
+/* <![CDATA[ */
+_stq = window._stq || [];
+_stq.push([ "view", JSON.parse("{\"v\":\"ext\",\"blog\":\"168708355\",\"post\":\"15122\",\"tz\":\"-5\",\"srv\":\"clecpc.org\",\"hp\":\"atomic\",\"ac\":\"2\",\"amp\":\"0\",\"j\":\"1:13.1-a.7\"}") ]);
+_stq.push([ "clickTrackerInit", "168708355", "15122" ]);
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://c0.wp.com/c/6.4.2/wp-includes/js/hoverIntent.min.js" id="hoverIntent-js"></script>
+<script type="text/javascript" id="megamenu-js-extra">
+/* <![CDATA[ */
+var megamenu = {"timeout":"300","interval":"100"};
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/megamenu/js/maxmegamenu.js?ver=3.3" id="megamenu-js"></script>
+<script type="text/javascript" src="https://clecpc.org/wp-content/plugins/google-calendar-events/assets/generated/vendor/imagesloaded.pkgd.min.js?ver=3.3.0" id="simplecalendar-imagesloaded-js"></script>
+<script defer type="text/javascript" src="https://clecpc.org/wp-content/plugins/akismet/_inc/akismet-frontend.js?ver=1704837122" id="akismet-frontend-js"></script>
+		<script type="text/javascript">
+			const iframe = document.getElementById( 'jetpack_remote_comment' );
+						const watchReply = function() {
+				// Check addComment._Jetpack_moveForm to make sure we don't monkey-patch twice.
+				if ( 'undefined' !== typeof addComment && ! addComment._Jetpack_moveForm ) {
+					// Cache the Core function.
+					addComment._Jetpack_moveForm = addComment.moveForm;
+					const commentParent = document.getElementById( 'comment_parent' );
+					const cancel = document.getElementById( 'cancel-comment-reply-link' );
+
+					function tellFrameNewParent ( commentParentValue ) {
+						const url = new URL( iframe.src );
+						if ( commentParentValue ) {
+							url.searchParams.set( 'replytocom', commentParentValue )
+						} else {
+							url.searchParams.delete( 'replytocom' );
+						}
+						if( iframe.src !== url.href ) {
+							iframe.src = url.href;
+						}
+					};
+
+					cancel.addEventListener( 'click', function () {
+						tellFrameNewParent( false );
+					} );
+
+					addComment.moveForm = function ( _, parentId ) {
+						tellFrameNewParent( parentId );
+						return addComment._Jetpack_moveForm.apply( null, arguments );
+					};
+				}
+			}
+			document.addEventListener( 'DOMContentLoaded', watchReply );
+			// In WP 6.4+, the script is loaded asynchronously, so we need to wait for it to load before we monkey-patch the functions it introduces.
+			document.querySelector('#comment-reply-js')?.addEventListener( 'load', watchReply );
+
+			
+			window.addEventListener( 'message', function ( event ) {
+				if ( event.origin !== 'https://jetpack.wordpress.com' ) {
+					return;
+				}
+				iframe.style.height = event.data + 'px';
+			});
+		</script>
+		
+
+  
+  <style>
+      </style>
+
+  <script>
+    var post_grid_vars = {"siteUrl":"https:\/\/clecpc.org"}  </script>
+  
+
+  <style>
+      </style>
+
+  <style>
+      </style>
+
+            <script type="application/ld+json">
+            {
+                "@context": "http://schema.org",
+                "@type": "Event",
+                "eventStatus": "https://schema.org/EventScheduled",
+                "startDate": "2024-02-01",
+                "endDate": "2024-02-01",
+                "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+                "location":
+                {
+                    "@type": "Place",
+                                        "name": "CPC Offices",
+                    "image": "",
+                    "address": "3631 Perkins Ave., Cleveland 4th Fl"
+                                    },
+                "organizer":
+                {
+                    "@type": "Person",
+                    "name": "Cleveland Community Police Commission",
+                    "url": "http://clecpc.org"
+                },
+                "offers":
+                {
+                    "url": "https://clecpc.org/events/police-discipline-work-group/",
+                    "price": "",
+                    "priceCurrency": "USD",
+                    "availability": "https://schema.org/InStock",
+                    "validFrom": "2024-02-01T00:00"
+                },
+                "performer": "",
+                "description": "Work Group to review the police disciplinary policy, disciplinary matrix and police manual of rules ",
+                "image": "",
+                "name": "Police Discipline Work Group",
+                "url": "https://clecpc.org/events/police-discipline-work-group/"
+            }
+            </script>
+            
+<svg style="position: absolute; width: 0; height: 0; overflow: hidden;" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<symbol id="icon-500px" viewBox="0 0 24 24">
+<path d="M6.94026,15.1412c.00437.01213.108.29862.168.44064a6.55008,6.55008,0,1,0,6.03191-9.09557,6.68654,6.68654,0,0,0-2.58357.51467A8.53914,8.53914,0,0,0,8.21268,8.61344L8.209,8.61725V3.22948l9.0504-.00008c.32934-.0036.32934-.46353.32934-.61466s0-.61091-.33035-.61467L7.47248,2a.43.43,0,0,0-.43131.42692v7.58355c0,.24466.30476.42131.58793.4819.553.11812.68074-.05864.81617-.2457l.018-.02481A10.52673,10.52673,0,0,1,9.32258,9.258a5.35268,5.35268,0,1,1,7.58985,7.54976,5.417,5.417,0,0,1-3.80867,1.56365,5.17483,5.17483,0,0,1-2.69822-.74478l.00342-4.61111a2.79372,2.79372,0,0,1,.71372-1.78792,2.61611,2.61611,0,0,1,1.98282-.89477,2.75683,2.75683,0,0,1,1.95525.79477,2.66867,2.66867,0,0,1,.79656,1.909,2.724,2.724,0,0,1-2.75849,2.748,4.94651,4.94651,0,0,1-.86254-.13719c-.31234-.093-.44519.34058-.48892.48349-.16811.54966.08453.65862.13687.67489a3.75751,3.75751,0,0,0,1.25234.18375,3.94634,3.94634,0,1,0-2.82444-6.742,3.67478,3.67478,0,0,0-1.13028,2.584l-.00041.02323c-.0035.11667-.00579,2.881-.00644,3.78811l-.00407-.00451a6.18521,6.18521,0,0,1-1.0851-1.86092c-.10544-.27856-.34358-.22925-.66857-.12917-.14192.04372-.57386.17677-.47833.489Zm4.65165-1.08338a.51346.51346,0,0,0,.19513.31818l.02276.022a.52945.52945,0,0,0,.3517.18416.24242.24242,0,0,0,.16577-.0611c.05473-.05082.67382-.67812.73287-.738l.69041.68819a.28978.28978,0,0,0,.21437.11032.53239.53239,0,0,0,.35708-.19486c.29792-.30419.14885-.46821.07676-.54751l-.69954-.69975.72952-.73469c.16-.17311.01874-.35708-.12218-.498-.20461-.20461-.402-.25742-.52855-.14083l-.7254.72665-.73354-.73375a.20128.20128,0,0,0-.14179-.05695.54135.54135,0,0,0-.34379.19648c-.22561.22555-.274.38149-.15656.5059l.73374.7315-.72942.73072A.26589.26589,0,0,0,11.59191,14.05782Zm1.59866-9.915A8.86081,8.86081,0,0,0,9.854,4.776a.26169.26169,0,0,0-.16938.22759.92978.92978,0,0,0,.08619.42094c.05682.14524.20779.531.50006.41955a8.40969,8.40969,0,0,1,2.91968-.55484,7.87875,7.87875,0,0,1,3.086.62286,8.61817,8.61817,0,0,1,2.30562,1.49315.2781.2781,0,0,0,.18318.07586c.15529,0,.30425-.15253.43167-.29551.21268-.23861.35873-.4369.1492-.63538a8.50425,8.50425,0,0,0-2.62312-1.694A9.0177,9.0177,0,0,0,13.19058,4.14283ZM19.50945,18.6236h0a.93171.93171,0,0,0-.36642-.25406.26589.26589,0,0,0-.27613.06613l-.06943.06929A7.90606,7.90606,0,0,1,7.60639,18.505a7.57284,7.57284,0,0,1-1.696-2.51537,8.58715,8.58715,0,0,1-.5147-1.77754l-.00871-.04864c-.04939-.25873-.28755-.27684-.62981-.22448-.14234.02178-.5755.088-.53426.39969l.001.00712a9.08807,9.08807,0,0,0,15.406,4.99094c.00193-.00192.04753-.04718.0725-.07436C19.79425,19.16234,19.87422,18.98728,19.50945,18.6236Z"/>
+</symbol>
+<symbol id="icon-amazon" viewBox="0 0 24 24">
+<path d="M13.582,8.182C11.934,8.367,9.78,8.49,8.238,9.166c-1.781,0.769-3.03,2.337-3.03,4.644 c0,2.953,1.86,4.429,4.253,4.429c2.02,0,3.125-0.477,4.685-2.065c0.516,0.747,0.685,1.109,1.629,1.894 c0.212,0.114,0.483,0.103,0.672-0.066l0.006,0.006c0.567-0.505,1.599-1.401,2.18-1.888c0.231-0.188,0.19-0.496,0.009-0.754 c-0.52-0.718-1.072-1.303-1.072-2.634V8.305c0-1.876,0.133-3.599-1.249-4.891C15.23,2.369,13.422,2,12.04,2 C9.336,2,6.318,3.01,5.686,6.351C5.618,6.706,5.877,6.893,6.109,6.945l2.754,0.298C9.121,7.23,9.308,6.977,9.357,6.72 c0.236-1.151,1.2-1.706,2.284-1.706c0.584,0,1.249,0.215,1.595,0.738c0.398,0.584,0.346,1.384,0.346,2.061V8.182z M13.049,14.088 c-0.451,0.8-1.169,1.291-1.967,1.291c-1.09,0-1.728-0.83-1.728-2.061c0-2.42,2.171-2.86,4.227-2.86v0.615 C13.582,12.181,13.608,13.104,13.049,14.088z M20.683,19.339C18.329,21.076,14.917,22,11.979,22c-4.118,0-7.826-1.522-10.632-4.057 c-0.22-0.199-0.024-0.471,0.241-0.317c3.027,1.762,6.771,2.823,10.639,2.823c2.608,0,5.476-0.541,8.115-1.66 C20.739,18.62,21.072,19.051,20.683,19.339z M21.336,21.043c-0.194,0.163-0.379,0.076-0.293-0.139 c0.284-0.71,0.92-2.298,0.619-2.684c-0.301-0.386-1.99-0.183-2.749-0.092c-0.23,0.027-0.266-0.173-0.059-0.319 c1.348-0.946,3.555-0.673,3.811-0.356C22.925,17.773,22.599,19.986,21.336,21.043z"/>
+</symbol>
+<symbol id="icon-apple" viewBox="0 0 24 24">
+<path d="M20.07,17.586a10.874,10.874,0,0,1-1.075,1.933,9.822,9.822,0,0,1-1.385,1.674,2.687,2.687,0,0,1-1.78.784,4.462,4.462,0,0,1-1.644-.393,4.718,4.718,0,0,0-1.77-.391,4.878,4.878,0,0,0-1.82.391A4.9,4.9,0,0,1,9.021,22a2.53,2.53,0,0,1-1.82-.8A10.314,10.314,0,0,1,5.752,19.46,11.987,11.987,0,0,1,4.22,16.417a11.143,11.143,0,0,1-.643-3.627,6.623,6.623,0,0,1,.87-3.465A5.1,5.1,0,0,1,6.268,7.483a4.9,4.9,0,0,1,2.463-.695,5.8,5.8,0,0,1,1.9.443,6.123,6.123,0,0,0,1.511.444,9.04,9.04,0,0,0,1.675-.523,5.537,5.537,0,0,1,2.277-.4,4.835,4.835,0,0,1,3.788,1.994,4.213,4.213,0,0,0-2.235,3.827,4.222,4.222,0,0,0,1.386,3.181,4.556,4.556,0,0,0,1.385.909q-.167.483-.353.927ZM16.211,2.4a4.267,4.267,0,0,1-1.094,2.8,3.726,3.726,0,0,1-3.1,1.528A3.114,3.114,0,0,1,12,6.347a4.384,4.384,0,0,1,1.16-2.828,4.467,4.467,0,0,1,1.414-1.061A4.215,4.215,0,0,1,16.19,2a3.633,3.633,0,0,1,.021.4Z"/>
+</symbol>
+<symbol id="icon-bandcamp" viewBox="0 0 24 24">
+<path d="M15.27 17.289 3 17.289 8.73 6.711 21 6.711 15.27 17.289"/>
+</symbol>
+<symbol id="icon-behance" viewBox="0 0 24 24">
+<path d="M7.799,5.698c0.589,0,1.12,0.051,1.606,0.156c0.482,0.102,0.894,0.273,1.241,0.507c0.344,0.235,0.612,0.546,0.804,0.938 c0.188,0.387,0.281,0.871,0.281,1.443c0,0.619-0.141,1.137-0.421,1.551c-0.284,0.413-0.7,0.751-1.255,1.014 c0.756,0.218,1.317,0.601,1.689,1.146c0.374,0.549,0.557,1.205,0.557,1.975c0,0.623-0.12,1.161-0.359,1.612 c-0.241,0.457-0.569,0.828-0.973,1.114c-0.408,0.288-0.876,0.5-1.399,0.637C9.052,17.931,8.514,18,7.963,18H2V5.698H7.799 M7.449,10.668c0.481,0,0.878-0.114,1.192-0.345c0.311-0.228,0.463-0.603,0.463-1.119c0-0.286-0.051-0.523-0.152-0.707 C8.848,8.315,8.711,8.171,8.536,8.07C8.362,7.966,8.166,7.894,7.94,7.854c-0.224-0.044-0.457-0.06-0.697-0.06H4.709v2.874H7.449z M7.6,15.905c0.267,0,0.521-0.024,0.759-0.077c0.243-0.053,0.457-0.137,0.637-0.261c0.182-0.12,0.332-0.283,0.441-0.491 C9.547,14.87,9.6,14.602,9.6,14.278c0-0.633-0.18-1.084-0.533-1.357c-0.356-0.27-0.83-0.404-1.413-0.404H4.709v3.388L7.6,15.905z M16.162,15.864c0.367,0.358,0.897,0.538,1.583,0.538c0.493,0,0.92-0.125,1.277-0.374c0.354-0.248,0.571-0.514,0.654-0.79h2.155 c-0.347,1.072-0.872,1.838-1.589,2.299C19.534,18,18.67,18.23,17.662,18.23c-0.701,0-1.332-0.113-1.899-0.337 c-0.567-0.227-1.041-0.544-1.439-0.958c-0.389-0.415-0.689-0.907-0.904-1.484c-0.213-0.574-0.32-1.21-0.32-1.899 c0-0.666,0.11-1.288,0.329-1.863c0.222-0.577,0.529-1.075,0.933-1.492c0.406-0.42,0.885-0.751,1.444-0.994 c0.558-0.241,1.175-0.363,1.857-0.363c0.754,0,1.414,0.145,1.98,0.44c0.563,0.291,1.026,0.686,1.389,1.181 c0.363,0.493,0.622,1.057,0.783,1.69c0.16,0.632,0.217,1.292,0.171,1.983h-6.428C15.557,14.84,15.795,15.506,16.162,15.864 M18.973,11.184c-0.291-0.321-0.783-0.496-1.384-0.496c-0.39,0-0.714,0.066-0.973,0.2c-0.254,0.132-0.461,0.297-0.621,0.491 c-0.157,0.197-0.265,0.405-0.328,0.628c-0.063,0.217-0.101,0.413-0.111,0.587h3.98C19.478,11.969,19.265,11.509,18.973,11.184z M15.057,7.738h4.985V6.524h-4.985L15.057,7.738z"/>
+</symbol>
+<symbol id="icon-blogger" viewBox="0 0 24 24">
+<path d="M14.722,14.019c0,0.361-0.293,0.654-0.654,0.654H9.977c-0.361,0-0.654-0.293-0.654-0.654s0.293-0.654,0.654-0.654h4.091C14.429,13.365,14.722,13.658,14.722,14.019z M9.981,10.698h2.038c0.382,0,0.692-0.31,0.692-0.692c0-0.382-0.31-0.692-0.692-0.692H9.981c-0.382,0-0.692,0.31-0.692,0.692C9.289,10.388,9.599,10.698,9.981,10.698z M21,5v14c0,1.105-0.895,2-2,2H5c-1.105,0-2-0.895-2-2V5c0-1.105,0.895-2,2-2h14C20.105,3,21,3.895,21,5z M17.544,11.39c0-0.398-0.322-0.72-0.72-0.72h-0.607l-0.013,0.001c-0.38,0-0.692-0.295-0.718-0.668l-0.001-0.008c0-1.988-1.611-3.599-3.599-3.599h-1.816c-1.988,0-3.599,1.611-3.599,3.599v3.947c0,1.987,1.611,3.599,3.599,3.599h3.874c1.988,0,3.599-1.611,3.599-3.599L17.544,11.39z"/>
+</symbol>
+<symbol id="icon-bluesky" viewBox="0 0 24 24">
+<path d="M21.2 3.3C20.7 3.1 19.8 2.8 17.6 4.3C15.4 6 12.9 9.2 12 11C11.1 9.2 8.6 6 6.3 4.3C4.1 2.7 3.3 3 2.7 3.3C2.1 3.6 2 4.6 2 5.1C2 5.6 2.3 9.8 2.5 10.5C3.2 12.8 5.6 13.6 7.8 13.3C4.5 13.8 1.6 15 5.4 19.2C9.6 23.5 11.1 18.3 11.9 15.6C12.7 18.3 13.6 23.3 18.3 19.2C21.9 15.6 19.3 13.8 16 13.3C18.2 13.5 20.6 12.8 21.3 10.5C21.7 9.8 22 5.7 22 5.1C22 4.6 21.9 3.6 21.2 3.3Z" />
+</symbol>
+<symbol id="icon-chain" viewBox="0 0 24 24">
+<path d="M19.647,16.706a1.134,1.134,0,0,0-.343-.833l-2.549-2.549a1.134,1.134,0,0,0-.833-.343,1.168,1.168,0,0,0-.883.392l.233.226q.2.189.264.264a2.922,2.922,0,0,1,.184.233.986.986,0,0,1,.159.312,1.242,1.242,0,0,1,.043.337,1.172,1.172,0,0,1-1.176,1.176,1.237,1.237,0,0,1-.337-.043,1,1,0,0,1-.312-.159,2.76,2.76,0,0,1-.233-.184q-.073-.068-.264-.264l-.226-.233a1.19,1.19,0,0,0-.4.895,1.134,1.134,0,0,0,.343.833L15.837,19.3a1.13,1.13,0,0,0,.833.331,1.18,1.18,0,0,0,.833-.318l1.8-1.789a1.12,1.12,0,0,0,.343-.821Zm-8.615-8.64a1.134,1.134,0,0,0-.343-.833L8.163,4.7a1.134,1.134,0,0,0-.833-.343,1.184,1.184,0,0,0-.833.331L4.7,6.473a1.12,1.12,0,0,0-.343.821,1.134,1.134,0,0,0,.343.833l2.549,2.549a1.13,1.13,0,0,0,.833.331,1.184,1.184,0,0,0,.883-.38L8.728,10.4q-.2-.189-.264-.264A2.922,2.922,0,0,1,8.28,9.9a.986.986,0,0,1-.159-.312,1.242,1.242,0,0,1-.043-.337A1.172,1.172,0,0,1,9.254,8.079a1.237,1.237,0,0,1,.337.043,1,1,0,0,1,.312.159,2.761,2.761,0,0,1,.233.184q.073.068.264.264l.226.233a1.19,1.19,0,0,0,.4-.895ZM22,16.706a3.343,3.343,0,0,1-1.042,2.488l-1.8,1.789a3.536,3.536,0,0,1-4.988-.025l-2.525-2.537a3.384,3.384,0,0,1-1.017-2.488,3.448,3.448,0,0,1,1.078-2.561l-1.078-1.078a3.434,3.434,0,0,1-2.549,1.078,3.4,3.4,0,0,1-2.5-1.029L3.029,9.794A3.4,3.4,0,0,1,2,7.294,3.343,3.343,0,0,1,3.042,4.806l1.8-1.789A3.384,3.384,0,0,1,7.331,2a3.357,3.357,0,0,1,2.5,1.042l2.525,2.537a3.384,3.384,0,0,1,1.017,2.488,3.448,3.448,0,0,1-1.078,2.561l1.078,1.078a3.551,3.551,0,0,1,5.049-.049l2.549,2.549A3.4,3.4,0,0,1,22,16.706Z"/>
+</symbol>
+<symbol id="icon-codepen" viewBox="0 0 24 24">
+<path d="M22.016,8.84c-0.002-0.013-0.005-0.025-0.007-0.037c-0.005-0.025-0.008-0.048-0.015-0.072 c-0.003-0.015-0.01-0.028-0.013-0.042c-0.008-0.02-0.015-0.04-0.023-0.062c-0.007-0.015-0.013-0.028-0.02-0.042 c-0.008-0.02-0.018-0.037-0.03-0.057c-0.007-0.013-0.017-0.027-0.025-0.038c-0.012-0.018-0.023-0.035-0.035-0.052 c-0.01-0.013-0.02-0.025-0.03-0.037c-0.015-0.017-0.028-0.032-0.043-0.045c-0.01-0.012-0.022-0.023-0.035-0.035 c-0.015-0.015-0.032-0.028-0.048-0.04c-0.012-0.01-0.025-0.02-0.037-0.03c-0.005-0.003-0.01-0.008-0.015-0.012l-9.161-6.096 c-0.289-0.192-0.666-0.192-0.955,0L2.359,8.237C2.354,8.24,2.349,8.245,2.344,8.249L2.306,8.277 c-0.017,0.013-0.033,0.027-0.048,0.04C2.246,8.331,2.234,8.342,2.222,8.352c-0.015,0.015-0.028,0.03-0.042,0.047 c-0.012,0.013-0.022,0.023-0.03,0.037C2.139,8.453,2.125,8.471,2.115,8.488C2.107,8.501,2.099,8.514,2.09,8.526 C2.079,8.548,2.069,8.565,2.06,8.585C2.054,8.6,2.047,8.613,2.04,8.626C2.032,8.648,2.025,8.67,2.019,8.69 c-0.005,0.013-0.01,0.027-0.013,0.042C1.999,8.755,1.995,8.778,1.99,8.803C1.989,8.817,1.985,8.828,1.984,8.84 C1.978,8.879,1.975,8.915,1.975,8.954v6.093c0,0.037,0.003,0.075,0.008,0.112c0.002,0.012,0.005,0.025,0.007,0.038 c0.005,0.023,0.008,0.047,0.015,0.072c0.003,0.015,0.008,0.028,0.013,0.04c0.007,0.022,0.013,0.042,0.022,0.063 c0.007,0.015,0.013,0.028,0.02,0.04c0.008,0.02,0.018,0.038,0.03,0.058c0.007,0.013,0.015,0.027,0.025,0.038 c0.012,0.018,0.023,0.035,0.035,0.052c0.01,0.013,0.02,0.025,0.03,0.037c0.013,0.015,0.028,0.032,0.042,0.045 c0.012,0.012,0.023,0.023,0.035,0.035c0.015,0.013,0.032,0.028,0.048,0.04l0.038,0.03c0.005,0.003,0.01,0.007,0.013,0.01 l9.163,6.095C11.668,21.953,11.833,22,12,22c0.167,0,0.332-0.047,0.478-0.144l9.163-6.095l0.015-0.01 c0.013-0.01,0.027-0.02,0.037-0.03c0.018-0.013,0.035-0.028,0.048-0.04c0.013-0.012,0.025-0.023,0.035-0.035 c0.017-0.015,0.03-0.032,0.043-0.045c0.01-0.013,0.02-0.025,0.03-0.037c0.013-0.018,0.025-0.035,0.035-0.052 c0.008-0.013,0.018-0.027,0.025-0.038c0.012-0.02,0.022-0.038,0.03-0.058c0.007-0.013,0.013-0.027,0.02-0.04 c0.008-0.022,0.015-0.042,0.023-0.063c0.003-0.013,0.01-0.027,0.013-0.04c0.007-0.025,0.01-0.048,0.015-0.072 c0.002-0.013,0.005-0.027,0.007-0.037c0.003-0.042,0.007-0.079,0.007-0.117V8.954C22.025,8.915,22.022,8.879,22.016,8.84z M12.862,4.464l6.751,4.49l-3.016,2.013l-3.735-2.492V4.464z M11.138,4.464v4.009l-3.735,2.494L4.389,8.954L11.138,4.464z M3.699,10.562L5.853,12l-2.155,1.438V10.562z M11.138,19.536l-6.749-4.491l3.015-2.011l3.735,2.492V19.536z M12,14.035L8.953,12 L12,9.966L15.047,12L12,14.035z M12.862,19.536v-4.009l3.735-2.492l3.016,2.011L12.862,19.536z M20.303,13.438L18.147,12 l2.156-1.438L20.303,13.438z"/>
+</symbol>
+<symbol id="icon-deviantart" viewBox="0 0 24 24">
+<path d="M 18.19 5.636 18.19 2 18.188 2 14.553 2 14.19 2.366 12.474 5.636 11.935 6 5.81 6 5.81 10.994 9.177 10.994 9.477 11.357 5.81 18.363 5.81 22 5.811 22 9.447 22 9.81 21.634 11.526 18.364 12.065 18 18.19 18 18.19 13.006 14.823 13.006 14.523 12.641 18.19 5.636z"/>
+</symbol>
+<symbol id="icon-digg" viewBox="0 0 24 24">
+<path d="M4.5,5.4h2.2V16H1V8.5h3.5V5.4L4.5,5.4z M4.5,14.2v-4H3.2v4H4.5z M7.6,8.5V16h2.2V8.5C9.8,8.5,7.6,8.5,7.6,8.5z M7.6,5.4 v2.2h2.2V5.4C9.8,5.4,7.6,5.4,7.6,5.4z M10.7,8.5h5.7v10.1h-5.7v-1.8h3.5V16h-3.5C10.7,16,10.7,8.5,10.7,8.5z M14.2,14.2v-4h-1.3v4 H14.2z M17.3,8.5H23v10.1h-5.7v-1.8h3.5V16h-3.5C17.3,16,17.3,8.5,17.3,8.5z M20.8,14.2v-4h-1.3v4H20.8z"/>
+</symbol>
+<symbol id="icon-discord" viewBox="0 0 24 24">
+<path d="M10.227 9.957c-.559 0-1 .48-1 1.063 0 .585.453 1.066 1 1.066.558 0 1-.48 1-1.066.007-.582-.442-1.063-1-1.063zm3.574 0c-.559 0-.996.48-.996 1.063 0 .585.449 1.066.996 1.066.558 0 1-.48 1-1.066 0-.582-.442-1.063-1-1.063zm0 0 M18.563 1.918H5.438c-1.11 0-2.008.879-2.008 1.973v12.957c0 1.093.898 1.972 2.007 1.972h11.11l-.52-1.773 1.254 1.14 1.184 1.075 2.105 1.82V3.891c0-1.094-.898-1.973-2.008-1.973zM14.78 14.434s-.351-.414-.644-.778c1.281-.355 1.773-1.14 1.773-1.14a5.745 5.745 0 0 1-1.129.566c-.488.2-.96.336-1.418.41a7.07 7.07 0 0 1-2.539-.008 8.133 8.133 0 0 1-1.441-.414 6.219 6.219 0 0 1-.715-.324c-.027-.02-.059-.027-.086-.047a.113.113 0 0 1-.039-.031c-.176-.094-.273-.16-.273-.16s.468.765 1.71 1.129c-.293.363-.656.797-.656.797-2.164-.067-2.984-1.457-2.984-1.457 0-3.086 1.41-5.586 1.41-5.586 1.41-1.036 2.75-1.008 2.75-1.008l.098.113c-1.762.5-2.575 1.258-2.575 1.258s.215-.117.579-.277c1.046-.454 1.878-.579 2.222-.606.059-.008.11-.02.168-.02a8.728 8.728 0 0 1 1.977-.019c.933.106 1.93.375 2.949.922 0 0-.773-.719-2.438-1.219l.137-.152s1.34-.028 2.75 1.008c0 0 1.414 2.5 1.414 5.586 0 0-.836 1.39-3 1.457zm0 0"/>
+</symbol>
+<symbol id="icon-dribbble" viewBox="0 0 24 24">
+<path d="M12,22C6.486,22,2,17.514,2,12S6.486,2,12,2c5.514,0,10,4.486,10,10S17.514,22,12,22z M20.434,13.369 c-0.292-0.092-2.644-0.794-5.32-0.365c1.117,3.07,1.572,5.57,1.659,6.09C18.689,17.798,20.053,15.745,20.434,13.369z M15.336,19.876c-0.127-0.749-0.623-3.361-1.822-6.477c-0.019,0.006-0.038,0.013-0.056,0.019c-4.818,1.679-6.547,5.02-6.701,5.334 c1.448,1.129,3.268,1.803,5.243,1.803C13.183,20.555,14.311,20.313,15.336,19.876z M5.654,17.724 c0.193-0.331,2.538-4.213,6.943-5.637c0.111-0.036,0.224-0.07,0.337-0.102c-0.214-0.485-0.448-0.971-0.692-1.45 c-4.266,1.277-8.405,1.223-8.778,1.216c-0.003,0.087-0.004,0.174-0.004,0.261C3.458,14.207,4.29,16.21,5.654,17.724z M3.639,10.264 c0.382,0.005,3.901,0.02,7.897-1.041c-1.415-2.516-2.942-4.631-3.167-4.94C5.979,5.41,4.193,7.613,3.639,10.264z M9.998,3.709 c0.236,0.316,1.787,2.429,3.187,5c3.037-1.138,4.323-2.867,4.477-3.085C16.154,4.286,14.17,3.471,12,3.471 C11.311,3.471,10.641,3.554,9.998,3.709z M18.612,6.612C18.432,6.855,17,8.69,13.842,9.979c0.199,0.407,0.389,0.821,0.567,1.237 c0.063,0.148,0.124,0.295,0.184,0.441c2.842-0.357,5.666,0.215,5.948,0.275C20.522,9.916,19.801,8.065,18.612,6.612z"/>
+</symbol>
+<symbol id="icon-dropbox" viewBox="0 0 24 24">
+<path d="M12,6.134L6.069,9.797L2,6.54l5.883-3.843L12,6.134z M2,13.054l5.883,3.843L12,13.459L6.069,9.797L2,13.054z M12,13.459 l4.116,3.439L22,13.054l-4.069-3.257L12,13.459z M22,6.54l-5.884-3.843L12,6.134l5.931,3.663L22,6.54z M12.011,14.2l-4.129,3.426 l-1.767-1.153v1.291l5.896,3.539l5.897-3.539v-1.291l-1.769,1.153L12.011,14.2z"/>
+</symbol>
+<symbol id="icon-etsy" viewBox="0 0 24 24">
+<path d="M9.16033,4.038c0-.27174.02717-.43478.48913-.43478h6.22283c1.087,0,1.68478.92391,2.11957,2.663l.35326,1.38587h1.05978C19.59511,3.712,19.75815,2,19.75815,2s-2.663.29891-4.23913.29891h-7.962L3.29076,2.163v1.1413L4.731,3.57609c1.00543.19022,1.25.40761,1.33152,1.33152,0,0,.08152,2.71739.08152,7.20109s-.08152,7.17391-.08152,7.17391c0,.81522-.32609,1.11413-1.33152,1.30435l-1.44022.27174V22l4.2663-.13587h7.11957c1.60326,0,5.32609.13587,5.32609.13587.08152-.97826.625-5.40761.70652-5.89674H19.7038L18.644,18.52174c-.84239,1.90217-2.06522,2.038-3.42391,2.038H11.1712c-1.3587,0-2.01087-.54348-2.01087-1.712V12.65217s3.0163,0,3.99457.08152c.76087.05435,1.22283.27174,1.46739,1.33152l.32609,1.413h1.16848l-.08152-3.55978.163-3.587H15.02989l-.38043,1.57609c-.24457,1.03261-.40761,1.22283-1.46739,1.33152-1.38587.13587-4.02174.1087-4.02174.1087Z"/>
+</symbol>
+<symbol id="icon-eventbrite" viewBox="0 0 24 24">
+<path style="fill-rule:evenodd;clip-rule:evenodd;" d="M18.041,3.931L5.959,3C4.325,3,3,4.325,3,5.959v12.083C3,19.675,4.325,21,5.959,21l12.083-0.931C19.699,19.983,21,18.744,21,17.11V6.89C21,5.256,19.741,4.027,18.041,3.931zM16.933,8.17c-0.082,0.215-0.192,0.432-0.378,0.551c-0.188,0.122-0.489,0.132-0.799,0.132c-1.521,0-3.062-0.048-4.607-0.048c-0.152,0.708-0.304,1.416-0.451,2.128c0.932-0.004,1.873,0.005,2.81,0.005c0.726,0,1.462-0.069,1.586,0.525c0.04,0.189-0.001,0.426-0.052,0.615c-0.105,0.38-0.258,0.676-0.625,0.783c-0.185,0.054-0.408,0.058-0.646,0.058c-1.145,0-2.345,0.017-3.493,0.02c-0.169,0.772-0.328,1.553-0.489,2.333c1.57-0.005,3.067-0.041,4.633-0.058c0.627-0.007,1.085,0.194,1.009,0.85c-0.031,0.262-0.098,0.497-0.211,0.725c-0.102,0.208-0.248,0.376-0.488,0.452c-0.237,0.075-0.541,0.064-0.862,0.078c-0.304,0.014-0.614,0.008-0.924,0.016c-0.309,0.009-0.619,0.022-0.919,0.022c-1.253,0-2.429,0.08-3.683,0.073c-0.603-0.004-1.014-0.249-1.124-0.757c-0.059-0.273-0.018-0.58,0.036-0.841c0.541-2.592,1.083-5.176,1.629-7.763c0.056-0.265,0.114-0.511,0.225-0.714C9.279,7.051,9.534,6.834,9.9,6.735c0.368-0.099,0.883-0.047,1.344-0.047c0.305,0,0.612,0.008,0.914,0.016c0.925,0.026,1.817,0.03,2.747,0.053c0.304,0.007,0.615,0.016,0.915,0.016c0.621,0,1.17,0.073,1.245,0.614C17.104,7.675,17.014,7.954,16.933,8.17z"/>
+</symbol>
+<symbol id="icon-facebook" viewBox="0 0 24 24">
+<path d="M12,2C6.5,2,2,6.5,2,12c0,5,3.7,9.1,8.4,9.9v-7H7.9V12h2.5V9.8c0-2.5,1.5-3.9,3.8-3.9c1.1,0,2.2,0.2,2.2,0.2v2.5h-1.3 c-1.2,0-1.6,0.8-1.6,1.6V12h2.8l-0.4,2.9h-2.3v7C18.3,21.1,22,17,22,12C22,6.5,17.5,2,12,2z"/>
+</symbol>
+<symbol id="icon-feed" viewBox="0 0 24 24">
+<path d="M2,8.667V12c5.515,0,10,4.485,10,10h3.333C15.333,14.637,9.363,8.667,2,8.667z M2,2v3.333 c9.19,0,16.667,7.477,16.667,16.667H22C22,10.955,13.045,2,2,2z M4.5,17C3.118,17,2,18.12,2,19.5S3.118,22,4.5,22S7,20.88,7,19.5 S5.882,17,4.5,17z"/>
+</symbol>
+<symbol id="icon-fediverse" viewBox="0 0 24 24">
+<path d="M5.85081 8.88733C5.63868 9.29358 5.30628 9.62442 4.89905 9.83466L10.1241 15.0801L11.3838 14.4417L5.85081 8.88733ZM12.7428 15.8059L11.4831 16.4443L14.1306 19.1022C14.3428 18.6958 14.6752 18.3649 15.0825 18.1547L12.7428 15.8059ZM18.788 10.9628L15.83 12.4619L16.0481 13.857L19.3951 12.1608C19.0742 11.8335 18.8622 11.4151 18.788 10.9628ZM14.1128 13.3322L7.11871 16.8768C7.43963 17.2041 7.65166 17.6225 7.72582 18.0748L14.3309 14.7273L14.1128 13.3322ZM11.8635 4.60095L8.48868 11.1895L9.48512 12.1898L13.0584 5.21403C12.6065 5.13759 12.1892 4.92348 11.8635 4.60095ZM7.61092 12.9031L5.90146 16.2403C6.35333 16.3168 6.77058 16.5309 7.0962 16.8534L8.60729 13.9033L7.61092 12.9031ZM4.87004 9.8493C4.52582 10.0216 4.14278 10.1017 3.75836 10.0817C3.68642 10.0777 3.61473 10.0702 3.54352 10.0593L4.54173 16.444C4.88595 16.2717 5.26899 16.1916 5.65342 16.2116C5.7253 16.2156 5.79694 16.2231 5.86809 16.2341L4.87004 9.8493ZM7.73111 18.1064C7.75395 18.2547 7.76177 18.4049 7.75437 18.5547C7.73734 18.8604 7.65743 19.1592 7.51964 19.4326L13.9033 20.457C13.8805 20.3087 13.8727 20.1585 13.88 20.0087C13.897 19.703 13.977 19.4042 14.1148 19.1308L7.73111 18.1064ZM19.4175 12.1841L16.471 17.9364C16.923 18.0128 17.3403 18.227 17.666 18.5496L20.6124 12.7973C20.1604 12.7208 19.7431 12.5067 19.4175 12.1841ZM15.3989 4.04834C15.1867 4.45466 14.8542 4.78556 14.4469 4.99581L19.01 9.57651C19.2221 9.17019 19.5546 8.83929 19.9619 8.62904L15.3989 4.04834ZM11.234 3.37973L5.46578 6.30295C5.78666 6.63022 5.99866 7.04859 6.07282 7.50088L11.841 4.57753C11.5202 4.25029 11.3082 3.83197 11.234 3.37973ZM14.4364 5.0011C14.0876 5.17976 13.6978 5.26314 13.3064 5.24282C13.2412 5.23884 13.1762 5.23202 13.1116 5.22237L13.6226 8.49422L15.0168 8.71794L14.4364 5.0011ZM13.9196 10.3964L15.1276 18.132C15.4678 17.9652 15.8448 17.888 16.2231 17.9077C16.3011 17.9121 16.3788 17.9207 16.4559 17.9333L15.3138 10.62L13.9196 10.3964ZM6.07692 7.52543C6.10063 7.67596 6.10884 7.82852 6.10141 7.98072C6.08459 8.28399 6.00588 8.5806 5.87013 8.85231L9.1445 9.37821L9.78804 8.12143L6.07692 7.52543ZM11.6889 8.42664L11.0452 9.68356L18.7819 10.9261C18.7596 10.7795 18.7521 10.631 18.7594 10.483C18.7766 10.1755 18.8575 9.87496 18.9968 9.60035L11.6889 8.42664Z"/>
+<path d="M13.3174 5.04077C14.433 5.10157 15.3867 4.24642 15.4474 3.13079C15.5082 2.01516 14.6531 1.06149 13.5374 1.00073C12.4218 0.93994 11.4682 1.79509 11.4074 2.91072C11.3466 4.02635 12.2018 4.98002 13.3174 5.04077ZM20.8714 12.6241C21.987 12.6848 22.9407 11.8297 23.0015 10.714C23.0623 9.59842 22.2071 8.64478 21.0915 8.58399C19.9759 8.52323 19.0222 9.37838 18.9614 10.494C18.9006 11.6096 19.7558 12.5633 20.8714 12.6241ZM15.992 22.1497C17.1076 22.2105 18.0613 21.3554 18.1221 20.2398C18.1828 19.1241 17.3277 18.1705 16.2121 18.1097C15.0965 18.0489 14.1428 18.9041 14.082 20.0197C14.0212 21.1353 14.8764 22.089 15.992 22.1497ZM5.42232 20.4537C6.53795 20.5144 7.49162 19.6593 7.55238 18.5437C7.61317 17.428 6.75802 16.4744 5.64239 16.4136C4.52677 16.3529 3.5731 17.208 3.51234 18.3236C3.45158 19.4392 4.3067 20.3929 5.42232 20.4537ZM3.76933 9.87973C4.88496 9.94052 5.83863 9.08537 5.89938 7.96974C5.96014 6.85411 5.10503 5.90045 3.98937 5.83969C2.87374 5.77893 1.9201 6.63405 1.85931 7.74967C1.79855 8.8653 2.6537 9.81897 3.76933 9.87973Z"/>
+</symbol>
+<symbol id="icon-flickr" viewBox="0 0 24 24">
+<path d="M6.5,7c-2.75,0-5,2.25-5,5s2.25,5,5,5s5-2.25,5-5S9.25,7,6.5,7z M17.5,7c-2.75,0-5,2.25-5,5s2.25,5,5,5s5-2.25,5-5 S20.25,7,17.5,7z"/>
+</symbol>
+<symbol id="icon-foursquare" viewBox="0 0 24 24">
+<path d="M17.573,2c0,0-9.197,0-10.668,0S5,3.107,5,3.805s0,16.948,0,16.948c0,0.785,0.422,1.077,0.66,1.172 c0.238,0.097,0.892,0.177,1.285-0.275c0,0,5.035-5.843,5.122-5.93c0.132-0.132,0.132-0.132,0.262-0.132h3.26 c1.368,0,1.588-0.977,1.732-1.552c0.078-0.318,0.692-3.428,1.225-6.122l0.675-3.368C19.56,2.893,19.14,2,17.573,2z M16.495,7.22 c-0.053,0.252-0.372,0.518-0.665,0.518c-0.293,0-4.157,0-4.157,0c-0.467,0-0.802,0.318-0.802,0.787v0.508 c0,0.467,0.337,0.798,0.805,0.798c0,0,3.197,0,3.528,0s0.655,0.362,0.583,0.715c-0.072,0.353-0.407,2.102-0.448,2.295 c-0.04,0.193-0.262,0.523-0.655,0.523c-0.33,0-2.88,0-2.88,0c-0.523,0-0.683,0.068-1.033,0.503 c-0.35,0.437-3.505,4.223-3.505,4.223c-0.032,0.035-0.063,0.027-0.063-0.015V4.852c0-0.298,0.26-0.648,0.648-0.648 c0,0,8.228,0,8.562,0c0.315,0,0.61,0.297,0.528,0.683L16.495,7.22z"/>
+</symbol>
+<symbol id="icon-ghost" viewBox="0 0 24 24">
+<path d="M10.203,20.997H3.005v-3.599h7.198V20.997z M20.995,17.398h-7.193v3.599h7.193V17.398z M20.998,10.2H3v3.599h17.998V10.2zM13.803,3.003H3.005v3.599h10.798V3.003z M21,3.003h-3.599v3.599H21V3.003z"/>
+</symbol>
+<symbol id="icon-goodreads" viewBox="0 0 24 24">
+<path d="M17.3,17.5c-0.2,0.8-0.5,1.4-1,1.9c-0.4,0.5-1,0.9-1.7,1.2C13.9,20.9,13.1,21,12,21c-0.6,0-1.3-0.1-1.9-0.2 c-0.6-0.1-1.1-0.4-1.6-0.7c-0.5-0.3-0.9-0.7-1.2-1.2c-0.3-0.5-0.5-1.1-0.5-1.7h1.5c0.1,0.5,0.2,0.9,0.5,1.2 c0.2,0.3,0.5,0.6,0.9,0.8c0.3,0.2,0.7,0.3,1.1,0.4c0.4,0.1,0.8,0.1,1.2,0.1c1.4,0,2.5-0.4,3.1-1.2c0.6-0.8,1-2,1-3.5v-1.7h0 c-0.4,0.8-0.9,1.4-1.6,1.9c-0.7,0.5-1.5,0.7-2.4,0.7c-1,0-1.9-0.2-2.6-0.5C8.7,15,8.1,14.5,7.7,14c-0.5-0.6-0.8-1.3-1-2.1 c-0.2-0.8-0.3-1.6-0.3-2.5c0-0.9,0.1-1.7,0.4-2.5c0.3-0.8,0.6-1.5,1.1-2c0.5-0.6,1.1-1,1.8-1.4C10.3,3.2,11.1,3,12,3 c0.5,0,0.9,0.1,1.3,0.2c0.4,0.1,0.8,0.3,1.1,0.5c0.3,0.2,0.6,0.5,0.9,0.8c0.3,0.3,0.5,0.6,0.6,1h0V3.4h1.5V15 C17.6,15.9,17.5,16.7,17.3,17.5z M13.8,14.1c0.5-0.3,0.9-0.7,1.3-1.1c0.3-0.5,0.6-1,0.8-1.6c0.2-0.6,0.3-1.2,0.3-1.9 c0-0.6-0.1-1.2-0.2-1.9c-0.1-0.6-0.4-1.2-0.7-1.7c-0.3-0.5-0.7-0.9-1.3-1.2c-0.5-0.3-1.1-0.5-1.9-0.5s-1.4,0.2-1.9,0.5 c-0.5,0.3-1,0.7-1.3,1.2C8.5,6.4,8.3,7,8.1,7.6C8,8.2,7.9,8.9,7.9,9.5c0,0.6,0.1,1.3,0.2,1.9C8.3,12,8.6,12.5,8.9,13 c0.3,0.5,0.8,0.8,1.3,1.1c0.5,0.3,1.1,0.4,1.9,0.4C12.7,14.5,13.3,14.4,13.8,14.1z"/>
+</symbol>
+<symbol id="icon-google" viewBox="0 0 24 24">
+<path d="M12.02,10.18v3.72v0.01h5.51c-0.26,1.57-1.67,4.22-5.5,4.22c-3.31,0-6.01-2.75-6.01-6.12s2.7-6.12,6.01-6.12 c1.87,0,3.13,0.8,3.85,1.48l2.84-2.76C16.99,2.99,14.73,2,12.03,2c-5.52,0-10,4.48-10,10s4.48,10,10,10c5.77,0,9.6-4.06,9.6-9.77 c0-0.83-0.11-1.42-0.25-2.05H12.02z"/>
+</symbol>
+<symbol id="icon-github" viewBox="0 0 24 24">
+<path d="M12,2C6.477,2,2,6.477,2,12c0,4.419,2.865,8.166,6.839,9.489c0.5,0.09,0.682-0.218,0.682-0.484 c0-0.236-0.009-0.866-0.014-1.699c-2.782,0.602-3.369-1.34-3.369-1.34c-0.455-1.157-1.11-1.465-1.11-1.465 c-0.909-0.62,0.069-0.608,0.069-0.608c1.004,0.071,1.532,1.03,1.532,1.03c0.891,1.529,2.341,1.089,2.91,0.833
+c0.091-0.647,0.349-1.086,0.635-1.337c-2.22-0.251-4.555-1.111-4.555-4.943c0-1.091,0.39-1.984,1.03-2.682 C6.546,8.54,6.202,7.524,6.746,6.148c0,0,0.84-0.269,2.75,1.025C10.295,6.95,11.15,6.84,12,6.836 c0.85,0.004,1.705,0.114,2.504,0.336c1.909-1.294,2.748-1.025,2.748-1.025c0.546,1.376,0.202,2.394,0.1,2.646 c0.64,0.699,1.026,1.591,1.026,2.682c0,3.841-2.337,4.687-4.565,4.935c0.359,0.307,0.679,0.917,0.679,1.852 c0,1.335-0.012,2.415-0.012,2.741c0,0.269,0.18,0.579,0.688,0.481C19.138,20.161,22,16.416,22,12C22,6.477,17.523,2,12,2z"/>
+</symbol>
+<symbol id="icon-instagram" viewBox="0 0 24 24">
+<path d="M12,4.622c2.403,0,2.688,0.009,3.637,0.052c0.877,0.04,1.354,0.187,1.671,0.31c0.42,0.163,0.72,0.358,1.035,0.673 c0.315,0.315,0.51,0.615,0.673,1.035c0.123,0.317,0.27,0.794,0.31,1.671c0.043,0.949,0.052,1.234,0.052,3.637 s-0.009,2.688-0.052,3.637c-0.04,0.877-0.187,1.354-0.31,1.671c-0.163,0.42-0.358,0.72-0.673,1.035 c-0.315,0.315-0.615,0.51-1.035,0.673c-0.317,0.123-0.794,0.27-1.671,0.31c-0.949,0.043-1.233,0.052-3.637,0.052 s-2.688-0.009-3.637-0.052c-0.877-0.04-1.354-0.187-1.671-0.31c-0.42-0.163-0.72-0.358-1.035-0.673 c-0.315-0.315-0.51-0.615-0.673-1.035c-0.123-0.317-0.27-0.794-0.31-1.671C4.631,14.688,4.622,14.403,4.622,12 s0.009-2.688,0.052-3.637c0.04-0.877,0.187-1.354,0.31-1.671c0.163-0.42,0.358-0.72,0.673-1.035 c0.315-0.315,0.615-0.51,1.035-0.673c0.317-0.123,0.794-0.27,1.671-0.31C9.312,4.631,9.597,4.622,12,4.622 M12,3 C9.556,3,9.249,3.01,8.289,3.054C7.331,3.098,6.677,3.25,6.105,3.472C5.513,3.702,5.011,4.01,4.511,4.511 c-0.5,0.5-0.808,1.002-1.038,1.594C3.25,6.677,3.098,7.331,3.054,8.289C3.01,9.249,3,9.556,3,12c0,2.444,0.01,2.751,0.054,3.711 c0.044,0.958,0.196,1.612,0.418,2.185c0.23,0.592,0.538,1.094,1.038,1.594c0.5,0.5,1.002,0.808,1.594,1.038 c0.572,0.222,1.227,0.375,2.185,0.418C9.249,20.99,9.556,21,12,21s2.751-0.01,3.711-0.054c0.958-0.044,1.612-0.196,2.185-0.418 c0.592-0.23,1.094-0.538,1.594-1.038c0.5-0.5,0.808-1.002,1.038-1.594c0.222-0.572,0.375-1.227,0.418-2.185 C20.99,14.751,21,14.444,21,12s-0.01-2.751-0.054-3.711c-0.044-0.958-0.196-1.612-0.418-2.185c-0.23-0.592-0.538-1.094-1.038-1.594 c-0.5-0.5-1.002-0.808-1.594-1.038c-0.572-0.222-1.227-0.375-2.185-0.418C14.751,3.01,14.444,3,12,3L12,3z M12,7.378 c-2.552,0-4.622,2.069-4.622,4.622S9.448,16.622,12,16.622s4.622-2.069,4.622-4.622S14.552,7.378,12,7.378z M12,15 c-1.657,0-3-1.343-3-3s1.343-3,3-3s3,1.343,3,3S13.657,15,12,15z M16.804,6.116c-0.596,0-1.08,0.484-1.08,1.08 s0.484,1.08,1.08,1.08c0.596,0,1.08-0.484,1.08-1.08S17.401,6.116,16.804,6.116z"/>
+</symbol>
+<symbol id="icon-linkedin" viewBox="0 0 24 24">
+<path d="M19.7,3H4.3C3.582,3,3,3.582,3,4.3v15.4C3,20.418,3.582,21,4.3,21h15.4c0.718,0,1.3-0.582,1.3-1.3V4.3 C21,3.582,20.418,3,19.7,3z M8.339,18.338H5.667v-8.59h2.672V18.338z M7.004,8.574c-0.857,0-1.549-0.694-1.549-1.548 c0-0.855,0.691-1.548,1.549-1.548c0.854,0,1.547,0.694,1.547,1.548C8.551,7.881,7.858,8.574,7.004,8.574z M18.339,18.338h-2.669 v-4.177c0-0.996-0.017-2.278-1.387-2.278c-1.389,0-1.601,1.086-1.601,2.206v4.249h-2.667v-8.59h2.559v1.174h0.037 c0.356-0.675,1.227-1.387,2.526-1.387c2.703,0,3.203,1.779,3.203,4.092V18.338z"/>
+</symbol>
+<symbol id="icon-mail" viewBox="0 0 24 24">
+<path d="M20,4H4C2.895,4,2,4.895,2,6v12c0,1.105,0.895,2,2,2h16c1.105,0,2-0.895,2-2V6C22,4.895,21.105,4,20,4z M20,8.236l-8,4.882 L4,8.236V6h16V8.236z"/>
+</symbol>
+<symbol id="icon-mastodon" viewBox="0 0 24 24">
+<path style="fill-rule:evenodd" d="M20.617 13.92c-.265 1.36-2.37 2.85-4.788 3.14-1.262.15-2.503.288-3.827.228-2.165-.1-3.873-.517-3.873-.517 0 .212.013.412.04.6.28 2.136 2.118 2.264 3.858 2.324 1.756.06 3.32-.433 3.32-.433l.072 1.59s-1.228.658-3.417.78c-1.207.066-2.705-.03-4.45-.493-3.785-1-4.436-5.036-4.536-9.13-.03-1.215-.01-2.36-.01-3.32 0-4.186 2.74-5.413 2.74-5.413 1.384-.635 3.757-.902 6.225-.923h.06c2.467.022 4.842.29 6.225.924 0 0 2.742 1.227 2.742 5.413 0 0 .034 3.09-.383 5.233zm-2.854-4.91v5.07h-2.008V9.16c0-1.037-.436-1.563-1.31-1.563-.964 0-1.447.624-1.447 1.86v2.692h-1.996V9.455c0-1.235-.484-1.86-1.45-1.86-.872 0-1.308.527-1.308 1.564v4.92H6.236V9.01c0-1.034.263-1.858.793-2.467.546-.61 1.26-.92 2.15-.92 1.027 0 1.805.394 2.32 1.184l.5.84.5-.84c.514-.79 1.292-1.185 2.32-1.185.888 0 1.604.312 2.15.92.53.61.793 1.434.793 2.47z"/>
+</symbol>
+<symbol id="icon-meetup" viewBox="0 0 24 24">
+<path d="M19.24775,14.722a3.57032,3.57032,0,0,1-2.94457,3.52073,3.61886,3.61886,0,0,1-.64652.05634c-.07314-.0008-.10187.02846-.12507.09547A2.38881,2.38881,0,0,1,13.49453,20.094a2.33092,2.33092,0,0,1-1.827-.50716.13635.13635,0,0,0-.19878-.00408,3.191,3.191,0,0,1-2.104.60248,3.26309,3.26309,0,0,1-3.00324-2.71993,2.19076,2.19076,0,0,1-.03512-.30865c-.00156-.08579-.03413-.1189-.11608-.13493a2.86421,2.86421,0,0,1-1.23189-.56111,2.945,2.945,0,0,1-1.166-2.05749,2.97484,2.97484,0,0,1,.87524-2.50774.112.112,0,0,0,.02091-.16107,2.7213,2.7213,0,0,1-.36648-1.48A2.81256,2.81256,0,0,1,6.57673,7.58838a.35764.35764,0,0,0,.28869-.22819,4.2208,4.2208,0,0,1,6.02892-1.90111.25161.25161,0,0,0,.22023.0243,3.65608,3.65608,0,0,1,3.76031.90678A3.57244,3.57244,0,0,1,17.95918,8.626a2.97339,2.97339,0,0,1,.01829.57356.10637.10637,0,0,0,.0853.12792,1.97669,1.97669,0,0,1,1.27939,1.33733,2.00266,2.00266,0,0,1-.57112,2.12652c-.05284.05166-.04168.08328-.01173.13489A3.51189,3.51189,0,0,1,19.24775,14.722Zm-6.35959-.27836a1.6984,1.6984,0,0,0,1.14556,1.61113,3.82039,3.82039,0,0,0,1.036.17935,1.46888,1.46888,0,0,0,.73509-.12255.44082.44082,0,0,0,.26057-.44274.45312.45312,0,0,0-.29211-.43375.97191.97191,0,0,0-.20678-.063c-.21326-.03806-.42754-.0701-.63973-.11215a.54787.54787,0,0,1-.50172-.60926,2.75864,2.75864,0,0,1,.1773-.901c.1763-.535.414-1.045.64183-1.55913A12.686,12.686,0,0,0,15.85,10.47863a1.58461,1.58461,0,0,0,.04861-.87208,1.04531,1.04531,0,0,0-.85432-.83981,1.60658,1.60658,0,0,0-1.23654.16594.27593.27593,0,0,1-.36286-.03413c-.085-.0747-.16594-.15379-.24918-.23055a.98682.98682,0,0,0-1.33577-.04933,6.1468,6.1468,0,0,1-.4989.41615.47762.47762,0,0,1-.51535.03566c-.17448-.09307-.35512-.175-.53531-.25665a1.74949,1.74949,0,0,0-.56476-.2016,1.69943,1.69943,0,0,0-1.61654.91787,8.05815,8.05815,0,0,0-.32952.80126c-.45471,1.2557-.82507,2.53825-1.20838,3.81639a1.24151,1.24151,0,0,0,.51532,1.44389,1.42659,1.42659,0,0,0,1.22008.17166,1.09728,1.09728,0,0,0,.66994-.69764c.44145-1.04111.839-2.09989,1.25981-3.14926.11581-.28876.22792-.57874.35078-.86438a.44548.44548,0,0,1,.69189-.19539.50521.50521,0,0,1,.15044.43836,1.75625,1.75625,0,0,1-.14731.50453c-.27379.69219-.55265,1.38236-.82766,2.074a2.0836,2.0836,0,0,0-.14038.42876.50719.50719,0,0,0,.27082.57722.87236.87236,0,0,0,.66145.02739.99137.99137,0,0,0,.53406-.532q.61571-1.20914,1.228-2.42031.28423-.55863.57585-1.1133a.87189.87189,0,0,1,.29055-.35253.34987.34987,0,0,1,.37634-.01265.30291.30291,0,0,1,.12434.31459.56716.56716,0,0,1-.04655.1915c-.05318.12739-.10286.25669-.16183.38156-.34118.71775-.68754,1.43273-1.02568,2.152A2.00213,2.00213,0,0,0,12.88816,14.44366Zm4.78568,5.28972a.88573.88573,0,0,0-1.77139.00465.8857.8857,0,0,0,1.77139-.00465Zm-14.83838-7.296a.84329.84329,0,1,0,.00827-1.68655.8433.8433,0,0,0-.00827,1.68655Zm10.366-9.43673a.83506.83506,0,1,0-.0091,1.67.83505.83505,0,0,0,.0091-1.67Zm6.85014,5.22a.71651.71651,0,0,0-1.433.0093.71656.71656,0,0,0,1.433-.0093ZM5.37528,6.17908A.63823.63823,0,1,0,6.015,5.54483.62292.62292,0,0,0,5.37528,6.17908Zm6.68214,14.80843a.54949.54949,0,1,0-.55052.541A.54556.54556,0,0,0,12.05742,20.98752Zm8.53235-8.49689a.54777.54777,0,0,0-.54027.54023.53327.53327,0,0,0,.532.52293.51548.51548,0,0,0,.53272-.5237A.53187.53187,0,0,0,20.58977,12.49063ZM7.82846,2.4715a.44927.44927,0,1,0,.44484.44766A.43821.43821,0,0,0,7.82846,2.4715Zm13.775,7.60492a.41186.41186,0,0,0-.40065.39623.40178.40178,0,0,0,.40168.40168A.38994.38994,0,0,0,22,10.48172.39946.39946,0,0,0,21.60349,10.07642ZM5.79193,17.96207a.40469.40469,0,0,0-.397-.39646.399.399,0,0,0-.396.405.39234.39234,0,0,0,.39939.389A.39857.39857,0,0,0,5.79193,17.96207Z"/>
+</symbol>
+<symbol id="icon-medium" viewBox="0 0 24 24">
+<path d="M5.727 8.027a.623.623 0 0 0-.204-.527L4.02 5.687v-.273H8.69l3.614 7.926 3.175-7.926h4.457v.274l-1.285 1.234a.367.367 0 0 0-.144.36v9.066a.374.374 0 0 0 .144.363l1.258 1.234v.27h-6.324v-.27l1.3-1.265c.13-.13.13-.164.13-.36V8.988l-3.621 9.196h-.489L6.691 8.988v6.164c-.035.258.051.52.235.707l1.691 2.055v.27h-4.8v-.27l1.69-2.055a.814.814 0 0 0 .22-.707zm0 0"/>
+</symbol>
+<symbol id="icon-nextdoor" viewBox="0 0 24 24">
+<path d="M11.8615 0.651877C6.11188 0.714092 1.22843 5.12326 0.698031 10.9732C0.132369 17.213 4.73317 22.7304 10.9732 23.2962C17.213 23.8619 22.7304 19.2611 23.2962 13.0211C23.8619 6.78111 19.2611 1.26369 13.0211 0.69803C12.6356 0.663073 12.2486 0.647668 11.8615 0.651877ZM12.5886 7.09625C15.2249 7.09625 17.2615 8.96861 17.2615 11.3538V16.3385C17.2615 16.4649 17.1572 16.5692 17.0308 16.5692H14.9365C14.8755 16.5684 14.8173 16.5438 14.7742 16.5007C14.7311 16.4576 14.7065 16.3994 14.7057 16.3385V11.7C14.7057 10.6698 13.9102 9.49606 12.5884 9.49606C11.2093 9.49606 10.4712 10.6698 10.4712 11.7V16.3385C10.4712 16.4649 10.3669 16.5692 10.2404 16.5692H8.14615C8.02062 16.5692 7.92111 16.464 7.92111 16.3385V11.8442C7.92111 11.7076 7.82345 11.5924 7.69034 11.5615C5.26634 11.0206 4.89988 9.66277 4.85188 7.66154C4.85095 7.60025 4.87809 7.53785 4.92111 7.49428C4.96412 7.45052 5.02135 7.42505 5.08265 7.42505L7.24043 7.43649C7.36228 7.43834 7.45957 7.53415 7.46529 7.65581C7.48929 8.47551 7.54615 9.39231 8.28462 9.39231C8.43785 9.39231 8.55102 9.17464 8.61932 9.07495C9.43348 7.87864 10.8864 7.09625 12.5886 7.09625Z"/>
+</symbol>
+<symbol id="icon-patreon" viewBox="0 0 24 24">
+<path d="M20 7.40755C19.9969 5.10922 18.2543 3.22555 16.2097 2.54588C13.6708 1.70188 10.3222 1.82421 7.89775 2.99921C4.95932 4.42355 4.03626 7.54355 4.00186 10.6552C3.97363 13.2136 4.2222 19.9517 7.92225 19.9997C10.6715 20.0356 11.0809 16.3967 12.3529 14.6442C13.258 13.3974 14.4233 13.0452 15.8578 12.6806C18.3233 12.0537 20.0036 10.0551 20 7.40755Z"/>
+</symbol>
+<symbol id="icon-pinterest" viewBox="0 0 24 24">
+<path d="M12.289,2C6.617,2,3.606,5.648,3.606,9.622c0,1.846,1.025,4.146,2.666,4.878c0.25,0.111,0.381,0.063,0.439-0.169 c0.044-0.175,0.267-1.029,0.365-1.428c0.032-0.128,0.017-0.237-0.091-0.362C6.445,11.911,6.01,10.75,6.01,9.668 c0-2.777,2.194-5.464,5.933-5.464c3.23,0,5.49,2.108,5.49,5.122c0,3.407-1.794,5.768-4.13,5.768c-1.291,0-2.257-1.021-1.948-2.277 c0.372-1.495,1.089-3.112,1.089-4.191c0-0.967-0.542-1.775-1.663-1.775c-1.319,0-2.379,1.309-2.379,3.059 c0,1.115,0.394,1.869,0.394,1.869s-1.302,5.279-1.54,6.261c-0.405,1.666,0.053,4.368,0.094,4.604 c0.021,0.126,0.167,0.169,0.25,0.063c0.129-0.165,1.699-2.419,2.142-4.051c0.158-0.59,0.817-2.995,0.817-2.995 c0.43,0.784,1.681,1.446,3.013,1.446c3.963,0,6.822-3.494,6.822-7.833C20.394,5.112,16.849,2,12.289,2"/>
+</symbol>
+<symbol id="icon-pocket" viewBox="0 0 24 24">
+<path d="M21.927,4.194C21.667,3.48,20.982,3,20.222,3h-0.01h-1.721H3.839C3.092,3,2.411,3.47,2.145,4.17 C2.066,4.378,2.026,4.594,2.026,4.814v6.035l0.069,1.2c0.29,2.73,1.707,5.115,3.899,6.778c0.039,0.03,0.079,0.059,0.119,0.089 l0.025,0.018c1.175,0.859,2.491,1.441,3.91,1.727c0.655,0.132,1.325,0.2,1.991,0.2c0.615,0,1.232-0.057,1.839-0.17 c0.073-0.014,0.145-0.028,0.219-0.044c0.02-0.004,0.042-0.012,0.064-0.023c1.359-0.297,2.621-0.864,3.753-1.691l0.025-0.018 c0.04-0.029,0.08-0.058,0.119-0.089c2.192-1.664,3.609-4.049,3.898-6.778l0.069-1.2V4.814C22.026,4.605,22,4.398,21.927,4.194z M17.692,10.481l-4.704,4.512c-0.266,0.254-0.608,0.382-0.949,0.382c-0.342,0-0.684-0.128-0.949-0.382l-4.705-4.512 C5.838,9.957,5.82,9.089,6.344,8.542c0.524-0.547,1.392-0.565,1.939-0.04l3.756,3.601l3.755-3.601 c0.547-0.524,1.415-0.506,1.939,0.04C18.256,9.089,18.238,9.956,17.692,10.481z"/>
+</symbol>
+<symbol id="icon-ravelry" viewBox="0 0 23 20">
+<path d="M12.098 19.34a.25.25 0 01-.118-.043 13.986 13.986 0 01-.394-.258c-.164-.11-.477-.352-.934-.723-.46-.375-.882-.761-1.27-1.168-.39-.406-.796-.925-1.218-1.562a8.521 8.521 0 01-.976-1.926c-.125-.023-.758-.16-1.907-.414A8.785 8.785 0 007.84 17.29a8.152 8.152 0 004.258 2.05zm-6.98-6.762l1.831.313A13.424 13.424 0 016.5 11.02a16.216 16.216 0 01-.207-1.622l-.043-.593c-.61.61-1.047 1.445-1.316 2.5.035.484.097.91.183 1.273zm1.198-6.797a9.064 9.064 0 00-.84 1.653c.32-.344.59-.598.81-.758zm15.649 4.844a8.8 8.8 0 00-.676-3.426 8.85 8.85 0 00-1.824-2.812 8.614 8.614 0 00-2.727-1.883 8.115 8.115 0 00-3.312-.695 8.131 8.131 0 00-3.059.586A8.412 8.412 0 007.754 4.05c-.219.433-.383 1.027-.488 1.785a5.407 5.407 0 011.554-.93 7.481 7.481 0 011.727-.48 16.642 16.642 0 011.558-.153c.489-.02.883-.015 1.18.012l.438.035c.238.008.43.063.574.172a.66.66 0 01.27.367c.03.141.054.278.07.414a.8.8 0 01-.012.317 12.781 12.781 0 00-2.477-.004 7.093 7.093 0 00-1.992.484 9.6 9.6 0 00-1.554.801A12.46 12.46 0 007.176 7.97c.031.27.07.613.125 1.031.054.422.183 1.082.386 1.988.204.903.43 1.57.676 2.004.895.043 1.793-.012 2.696-.164.902-.152 1.683-.351 2.336-.598a20.681 20.681 0 001.77-.746c.526-.254.925-.472 1.19-.66l.407-.265c.156-.121.3-.196.43-.23a.367.367 0 01.331.058c.094.07.157.199.184.383.102.722-.039 1.171-.426 1.351-1.508.723-3.203 1.219-5.086 1.496-.976.149-2.129.207-3.449.176a7.673 7.673 0 001.195 1.973c.504.597 1 1.07 1.493 1.418.496.343.968.636 1.421.878.454.243.825.407 1.106.489l.426.133c1.039.171 1.992.113 2.863-.168 1.414-.739 2.555-1.813 3.418-3.227.867-1.414 1.297-2.969 1.297-4.664zm.805-.414c-.102 1.004-.247 1.793-.434 2.367-.508 1.547-1.168 2.836-1.977 3.867-.808 1.032-1.964 1.973-3.468 2.828-.348.247-.645.41-.895.493-.52.195-1.113.254-1.773.18-.262.019-.528.03-.797.03-2.055 0-3.883-.64-5.492-1.93-1.61-1.288-2.68-2.929-3.22-4.933-.007 0-.019 0-.042-.004-.024-.004-.04-.007-.055-.007-.043.375-.035.793.028 1.257.062.465.156.891.285 1.282.125.39.254.757.39 1.093.133.34.25.606.344.801l.152.29c.059.09.254.394.586.913a4.327 4.327 0 01-1.355-1.187 5.669 5.669 0 01-.856-1.563 14.087 14.087 0 01-.43-1.531 9.012 9.012 0 01-.19-1.2l-.02-.468c-.035-.016-.16-.059-.367-.137-.207-.078-.383-.148-.528-.203-.144-.054-.336-.133-.578-.226a9.221 9.221 0 01-.625-.282c-.176-.09-.36-.183-.543-.285-.187-.097-.34-.199-.465-.3a1.27 1.27 0 01-.27-.286c.138.075.321.172.548.285.23.118.64.286 1.23.508.594.223 1.121.364 1.586.426l.023-.36c.079-1.109.418-2.187 1.024-3.234A9.226 9.226 0 016.5 4.621c.203-.855.5-1.652.883-2.39.11-.208.226-.376.347-.5.125-.13.305-.247.536-.36 1.148-.55 2.25-.937 3.304-1.16A9.935 9.935 0 0114.86.09c1.136.14 2.25.5 3.34 1.082 1.593.855 2.804 2.105 3.624 3.75.82 1.644 1.137 3.406.946 5.289zm0 0"/>
+</symbol>
+<symbol id="icon-reddit" viewBox="0 0 24 24">
+<path d="M22,11.816c0-1.256-1.021-2.277-2.277-2.277c-0.593,0-1.122,0.24-1.526,0.614c-1.481-0.965-3.455-1.594-5.647-1.69 l1.171-3.702l3.18,0.748c0.008,1.028,0.846,1.862,1.876,1.862c1.035,0,1.877-0.842,1.877-1.878c0-1.035-0.842-1.877-1.877-1.877 c-0.769,0-1.431,0.466-1.72,1.13l-3.508-0.826c-0.203-0.047-0.399,0.067-0.46,0.261l-1.35,4.268 c-2.316,0.038-4.411,0.67-5.97,1.671C5.368,9.765,4.853,9.539,4.277,9.539C3.021,9.539,2,10.56,2,11.816 c0,0.814,0.433,1.523,1.078,1.925c-0.037,0.221-0.061,0.444-0.061,0.672c0,3.292,4.011,5.97,8.941,5.97s8.941-2.678,8.941-5.97 c0-0.214-0.02-0.424-0.053-0.632C21.533,13.39,22,12.661,22,11.816z M18.776,4.394c0.606,0,1.1,0.493,1.1,1.1s-0.493,1.1-1.1,1.1 s-1.1-0.494-1.1-1.1S18.169,4.394,18.776,4.394z M2.777,11.816c0-0.827,0.672-1.5,1.499-1.5c0.313,0,0.598,0.103,0.838,0.269 c-0.851,0.676-1.477,1.479-1.812,2.36C2.983,12.672,2.777,12.27,2.777,11.816z M11.959,19.606c-4.501,0-8.164-2.329-8.164-5.193 S7.457,9.22,11.959,9.22s8.164,2.329,8.164,5.193S16.46,19.606,11.959,19.606z M20.636,13.001c-0.326-0.89-0.948-1.701-1.797-2.384 c0.248-0.186,0.55-0.301,0.883-0.301c0.827,0,1.5,0.673,1.5,1.5C21.223,12.299,20.992,12.727,20.636,13.001z M8.996,14.704 c-0.76,0-1.397-0.616-1.397-1.376c0-0.76,0.637-1.397,1.397-1.397c0.76,0,1.376,0.637,1.376,1.397 C10.372,14.088,9.756,14.704,8.996,14.704z M16.401,13.328c0,0.76-0.616,1.376-1.376,1.376c-0.76,0-1.399-0.616-1.399-1.376 c0-0.76,0.639-1.397,1.399-1.397C15.785,11.931,16.401,12.568,16.401,13.328z M15.229,16.708c0.152,0.152,0.152,0.398,0,0.55 c-0.674,0.674-1.727,1.002-3.219,1.002c-0.004,0-0.007-0.002-0.011-0.002c-0.004,0-0.007,0.002-0.011,0.002 c-1.492,0-2.544-0.328-3.218-1.002c-0.152-0.152-0.152-0.398,0-0.55c0.152-0.152,0.399-0.151,0.55,0 c0.521,0.521,1.394,0.775,2.669,0.775c0.004,0,0.007,0.002,0.011,0.002c0.004,0,0.007-0.002,0.011-0.002 c1.275,0,2.148-0.253,2.669-0.775C14.831,16.556,15.078,16.556,15.229,16.708z"/>
+</symbol>
+<symbol id="icon-skype" viewBox="0 0 24 24">
+<path d="M10.113,2.699c0.033-0.006,0.067-0.013,0.1-0.02c0.033,0.017,0.066,0.033,0.098,0.051L10.113,2.699z M2.72,10.223 c-0.006,0.034-0.011,0.069-0.017,0.103c0.018,0.032,0.033,0.064,0.051,0.095L2.72,10.223z M21.275,13.771 c0.007-0.035,0.011-0.071,0.018-0.106c-0.018-0.031-0.033-0.064-0.052-0.095L21.275,13.771z M13.563,21.199 c0.032,0.019,0.065,0.035,0.096,0.053c0.036-0.006,0.071-0.011,0.105-0.017L13.563,21.199z M22,16.386 c0,1.494-0.581,2.898-1.637,3.953c-1.056,1.057-2.459,1.637-3.953,1.637c-0.967,0-1.914-0.251-2.75-0.725 c0.036-0.006,0.071-0.011,0.105-0.017l-0.202-0.035c0.032,0.019,0.065,0.035,0.096,0.053c-0.543,0.096-1.099,0.147-1.654,0.147 c-1.275,0-2.512-0.25-3.676-0.743c-1.125-0.474-2.135-1.156-3.002-2.023c-0.867-0.867-1.548-1.877-2.023-3.002 c-0.493-1.164-0.743-2.401-0.743-3.676c0-0.546,0.049-1.093,0.142-1.628c0.018,0.032,0.033,0.064,0.051,0.095L2.72,10.223 c-0.006,0.034-0.011,0.069-0.017,0.103C2.244,9.5,2,8.566,2,7.615c0-1.493,0.582-2.898,1.637-3.953 c1.056-1.056,2.46-1.638,3.953-1.638c0.915,0,1.818,0.228,2.622,0.655c-0.033,0.007-0.067,0.013-0.1,0.02l0.199,0.031 c-0.032-0.018-0.066-0.034-0.098-0.051c0.002,0,0.003-0.001,0.004-0.001c0.586-0.112,1.187-0.169,1.788-0.169 c1.275,0,2.512,0.249,3.676,0.742c1.124,0.476,2.135,1.156,3.002,2.024c0.868,0.867,1.548,1.877,2.024,3.002 c0.493,1.164,0.743,2.401,0.743,3.676c0,0.575-0.054,1.15-0.157,1.712c-0.018-0.031-0.033-0.064-0.052-0.095l0.034,0.201 c0.007-0.035,0.011-0.071,0.018-0.106C21.754,14.494,22,15.432,22,16.386z M16.817,14.138c0-1.331-0.613-2.743-3.033-3.282 l-2.209-0.49c-0.84-0.192-1.807-0.444-1.807-1.237c0-0.794,0.679-1.348,1.903-1.348c2.468,0,2.243,1.696,3.468,1.696 c0.645,0,1.209-0.379,1.209-1.031c0-1.521-2.435-2.663-4.5-2.663c-2.242,0-4.63,0.952-4.63,3.488c0,1.221,0.436,2.521,2.839,3.123 l2.984,0.745c0.903,0.223,1.129,0.731,1.129,1.189c0,0.762-0.758,1.507-2.129,1.507c-2.679,0-2.307-2.062-3.743-2.062 c-0.645,0-1.113,0.444-1.113,1.078c0,1.236,1.501,2.886,4.856,2.886C15.236,17.737,16.817,16.199,16.817,14.138z"/>
+</symbol>
+<symbol id="icon-slideshare" viewBox="0 0 24 24">
+<path d="M11.738,10.232a2.142,2.142,0,0,1-.721,1.619,2.556,2.556,0,0,1-3.464,0,2.183,2.183,0,0,1,0-3.243,2.572,2.572,0,0,1,3.464,0A2.136,2.136,0,0,1,11.738,10.232Zm5.7,0a2.15,2.15,0,0,1-.715,1.619,2.563,2.563,0,0,1-3.469,0,2.183,2.183,0,0,1,0-3.243,2.58,2.58,0,0,1,3.469,0A2.144,2.144,0,0,1,17.439,10.232Zm2.555,2.045V4.7a2.128,2.128,0,0,0-.363-1.4,1.614,1.614,0,0,0-1.261-.415H5.742a1.656,1.656,0,0,0-1.278.386A2.246,2.246,0,0,0,4.129,4.7v7.643a8.212,8.212,0,0,0,1,.454q.516.193.92.318a6.847,6.847,0,0,0,.92.21q.516.085.806.125a6.615,6.615,0,0,0,.795.045l.665.006q.16,0,.642-.023t.506-.023a1.438,1.438,0,0,1,1.079.307,1.134,1.134,0,0,0,.114.1,7.215,7.215,0,0,0,.693.579q.079-1.033,1.34-.988.057,0,.415.017l.488.023q.13.006.517.011t.6-.011l.619-.051a5.419,5.419,0,0,0,.693-.1l.7-.153a5.353,5.353,0,0,0,.761-.221q.345-.131.766-.307a8.727,8.727,0,0,0,.818-.392Zm1.851-.057a10.4,10.4,0,0,1-4.225,2.862,6.5,6.5,0,0,1-.261,5.281,3.524,3.524,0,0,1-2.078,1.681,2.452,2.452,0,0,1-2.067-.17,1.915,1.915,0,0,1-.931-1.863l-.011-3.7V16.3l-.279-.068q-.188-.045-.267-.057l-.011,3.839a1.9,1.9,0,0,1-.943,1.863,2.481,2.481,0,0,1-2.078.17,3.519,3.519,0,0,1-2.067-1.7,6.546,6.546,0,0,1-.25-5.258A10.4,10.4,0,0,1,2.152,12.22a.56.56,0,0,1-.045-.715q.238-.3.681.011l.125.079a.767.767,0,0,1,.125.091V3.8a1.987,1.987,0,0,1,.534-1.4,1.7,1.7,0,0,1,1.295-.579H19.141a1.7,1.7,0,0,1,1.295.579,1.985,1.985,0,0,1,.534,1.4v7.882l.238-.17q.443-.307.681-.011a.56.56,0,0,1-.045.715Z"/>
+</symbol>
+<symbol id="icon-snapchat" viewBox="0 0 24 24">
+<path d="M12.065,2a5.526,5.526,0,0,1,3.132.892A5.854,5.854,0,0,1,17.326,5.4a5.821,5.821,0,0,1,.351,2.33q0,.612-.117,2.487a.809.809,0,0,0,.365.091,1.93,1.93,0,0,0,.664-.176,1.93,1.93,0,0,1,.664-.176,1.3,1.3,0,0,1,.729.234.7.7,0,0,1,.351.6.839.839,0,0,1-.41.7,2.732,2.732,0,0,1-.9.41,3.192,3.192,0,0,0-.9.378.728.728,0,0,0-.41.618,1.575,1.575,0,0,0,.156.56,6.9,6.9,0,0,0,1.334,1.953,5.6,5.6,0,0,0,1.881,1.315,5.875,5.875,0,0,0,1.042.3.42.42,0,0,1,.365.456q0,.911-2.852,1.341a1.379,1.379,0,0,0-.143.507,1.8,1.8,0,0,1-.182.605.451.451,0,0,1-.429.241,5.878,5.878,0,0,1-.807-.085,5.917,5.917,0,0,0-.833-.085,4.217,4.217,0,0,0-.807.065,2.42,2.42,0,0,0-.82.293,6.682,6.682,0,0,0-.755.5q-.351.267-.755.527a3.886,3.886,0,0,1-.989.436A4.471,4.471,0,0,1,11.831,22a4.307,4.307,0,0,1-1.256-.176,3.784,3.784,0,0,1-.976-.436q-.4-.26-.749-.527a6.682,6.682,0,0,0-.755-.5,2.422,2.422,0,0,0-.807-.293,4.432,4.432,0,0,0-.82-.065,5.089,5.089,0,0,0-.853.1,5,5,0,0,1-.762.1.474.474,0,0,1-.456-.241,1.819,1.819,0,0,1-.182-.618,1.411,1.411,0,0,0-.143-.521q-2.852-.429-2.852-1.341a.42.42,0,0,1,.365-.456,5.793,5.793,0,0,0,1.042-.3,5.524,5.524,0,0,0,1.881-1.315,6.789,6.789,0,0,0,1.334-1.953A1.575,1.575,0,0,0,6,12.9a.728.728,0,0,0-.41-.618,3.323,3.323,0,0,0-.9-.384,2.912,2.912,0,0,1-.9-.41.814.814,0,0,1-.41-.684.71.71,0,0,1,.338-.593,1.208,1.208,0,0,1,.716-.241,1.976,1.976,0,0,1,.625.169,2.008,2.008,0,0,0,.69.169.919.919,0,0,0,.416-.091q-.117-1.849-.117-2.474A5.861,5.861,0,0,1,6.385,5.4,5.516,5.516,0,0,1,8.625,2.819,7.075,7.075,0,0,1,12.062,2Z"/>
+</symbol>
+<symbol id="icon-soundcloud" viewBox="0 0 24 24">
+<path d="M8.9,16.1L9,14L8.9,9.5c0-0.1,0-0.1-0.1-0.1c0,0-0.1-0.1-0.1-0.1c-0.1,0-0.1,0-0.1,0.1c0,0-0.1,0.1-0.1,0.1L8.3,14l0.1,2.1 c0,0.1,0,0.1,0.1,0.1c0,0,0.1,0.1,0.1,0.1C8.8,16.3,8.9,16.3,8.9,16.1z M11.4,15.9l0.1-1.8L11.4,9c0-0.1,0-0.2-0.1-0.2 c0,0-0.1,0-0.1,0s-0.1,0-0.1,0c-0.1,0-0.1,0.1-0.1,0.2l0,0.1l-0.1,5c0,0,0,0.7,0.1,2v0c0,0.1,0,0.1,0.1,0.1c0.1,0.1,0.1,0.1,0.2,0.1 c0.1,0,0.1,0,0.2-0.1c0.1,0,0.1-0.1,0.1-0.2L11.4,15.9z M2.4,12.9L2.5,14l-0.2,1.1c0,0.1,0,0.1-0.1,0.1c0,0-0.1,0-0.1-0.1L2.1,14 l0.1-1.1C2.2,12.9,2.3,12.9,2.4,12.9C2.3,12.9,2.4,12.9,2.4,12.9z M3.1,12.2L3.3,14l-0.2,1.8c0,0.1,0,0.1-0.1,0.1 c-0.1,0-0.1,0-0.1-0.1L2.8,14L3,12.2C3,12.2,3,12.2,3.1,12.2C3.1,12.2,3.1,12.2,3.1,12.2z M3.9,11.9L4.1,14l-0.2,2.1 c0,0.1,0,0.1-0.1,0.1c-0.1,0-0.1,0-0.1-0.1L3.5,14l0.2-2.1c0-0.1,0-0.1,0.1-0.1C3.9,11.8,3.9,11.8,3.9,11.9z M4.7,11.9L4.9,14 l-0.2,2.1c0,0.1-0.1,0.1-0.1,0.1c-0.1,0-0.1,0-0.1-0.1L4.3,14l0.2-2.2c0-0.1,0-0.1,0.1-0.1C4.7,11.7,4.7,11.8,4.7,11.9z M5.6,12 l0.2,2l-0.2,2.1c0,0.1-0.1,0.1-0.1,0.1c0,0-0.1,0-0.1,0c0,0,0-0.1,0-0.1L5.1,14l0.2-2c0,0,0-0.1,0-0.1s0.1,0,0.1,0 C5.5,11.9,5.5,11.9,5.6,12L5.6,12z M6.4,10.7L6.6,14l-0.2,2.1c0,0,0,0.1,0,0.1c0,0-0.1,0-0.1,0c-0.1,0-0.1-0.1-0.2-0.2L5.9,14 l0.2-3.3c0-0.1,0.1-0.2,0.2-0.2c0,0,0.1,0,0.1,0C6.4,10.7,6.4,10.7,6.4,10.7z M7.2,10l0.2,4.1l-0.2,2.1c0,0,0,0.1,0,0.1 c0,0-0.1,0-0.1,0c-0.1,0-0.2-0.1-0.2-0.2l-0.1-2.1L6.8,10c0-0.1,0.1-0.2,0.2-0.2c0,0,0.1,0,0.1,0S7.2,9.9,7.2,10z M8,9.6L8.2,14 L8,16.1c0,0.1-0.1,0.2-0.2,0.2c-0.1,0-0.2-0.1-0.2-0.2L7.5,14l0.1-4.4c0-0.1,0-0.1,0.1-0.1c0,0,0.1-0.1,0.1-0.1c0.1,0,0.1,0,0.1,0.1 C8,9.6,8,9.6,8,9.6z M11.4,16.1L11.4,16.1L11.4,16.1z M9.7,9.6L9.8,14l-0.1,2.1c0,0.1,0,0.1-0.1,0.2s-0.1,0.1-0.2,0.1 c-0.1,0-0.1,0-0.1-0.1s-0.1-0.1-0.1-0.2L9.2,14l0.1-4.4c0-0.1,0-0.1,0.1-0.2s0.1-0.1,0.2-0.1c0.1,0,0.1,0,0.2,0.1S9.7,9.5,9.7,9.6 L9.7,9.6z M10.6,9.8l0.1,4.3l-0.1,2c0,0.1,0,0.1-0.1,0.2c0,0-0.1,0.1-0.2,0.1c-0.1,0-0.1,0-0.2-0.1c0,0-0.1-0.1-0.1-0.2L10,14 l0.1-4.3c0-0.1,0-0.1,0.1-0.2c0,0,0.1-0.1,0.2-0.1c0.1,0,0.1,0,0.2,0.1S10.6,9.7,10.6,9.8z M12.4,14l-0.1,2c0,0.1,0,0.1-0.1,0.2 c-0.1,0.1-0.1,0.1-0.2,0.1c-0.1,0-0.1,0-0.2-0.1c-0.1-0.1-0.1-0.1-0.1-0.2l-0.1-1l-0.1-1l0.1-5.5v0c0-0.1,0-0.2,0.1-0.2 c0.1,0,0.1-0.1,0.2-0.1c0,0,0.1,0,0.1,0c0.1,0,0.1,0.1,0.1,0.2L12.4,14z M22.1,13.9c0,0.7-0.2,1.3-0.7,1.7c-0.5,0.5-1.1,0.7-1.7,0.7 h-6.8c-0.1,0-0.1,0-0.2-0.1c-0.1-0.1-0.1-0.1-0.1-0.2V8.2c0-0.1,0.1-0.2,0.2-0.3c0.5-0.2,1-0.3,1.6-0.3c1.1,0,2.1,0.4,2.9,1.1 c0.8,0.8,1.3,1.7,1.4,2.8c0.3-0.1,0.6-0.2,1-0.2c0.7,0,1.3,0.2,1.7,0.7C21.8,12.6,22.1,13.2,22.1,13.9L22.1,13.9z"/>
+</symbol>
+<symbol id="icon-spotify" viewBox="0 0 24 24">
+<path d="M12,2C6.477,2,2,6.477,2,12c0,5.523,4.477,10,10,10c5.523,0,10-4.477,10-10C22,6.477,17.523,2,12,2 M16.586,16.424 c-0.18,0.295-0.563,0.387-0.857,0.207c-2.348-1.435-5.304-1.76-8.785-0.964c-0.335,0.077-0.67-0.133-0.746-0.469 c-0.077-0.335,0.132-0.67,0.469-0.746c3.809-0.871,7.077-0.496,9.713,1.115C16.673,15.746,16.766,16.13,16.586,16.424 M17.81,13.7 c-0.226,0.367-0.706,0.482-1.072,0.257c-2.687-1.652-6.785-2.131-9.965-1.166C6.36,12.917,5.925,12.684,5.8,12.273 C5.675,11.86,5.908,11.425,6.32,11.3c3.632-1.102,8.147-0.568,11.234,1.328C17.92,12.854,18.035,13.335,17.81,13.7 M17.915,10.865 c-3.223-1.914-8.54-2.09-11.618-1.156C5.804,9.859,5.281,9.58,5.131,9.086C4.982,8.591,5.26,8.069,5.755,7.919 c3.532-1.072,9.404-0.865,13.115,1.338c0.445,0.264,0.59,0.838,0.327,1.282C18.933,10.983,18.359,11.129,17.915,10.865"/>
+</symbol>
+<symbol id="icon-stackoverflow" viewBox="0 0 24 24">
+<path d="m 17.817128,20.228605 v -5.337217 h 1.771431 V 22 H 3.6 v -7.108612 h 1.771401 v 5.337217 z" />
+<path d="m 7.3267845,14.385359 8.6959295,1.817316 0.368168,-1.748385 -8.6959318,-1.817319 z m 1.1503197,-4.140944 8.0517968,3.749872 0.73617,-1.610385 -8.0518344,-3.7728517 z m 2.2315078,-3.9569154 6.832405,5.6822664 1.12738,-1.357316 -6.832576,-5.6822636 z m 4.417,-4.2099019 -1.426448,1.0581864 5.291191,7.1316119 1.426412,-1.0582745 z M 7.1427296,18.434189 h 8.8799844 v -1.7713 H 7.1427296 Z" />
+<path d="m 17.817128,20.228605 v -5.337217 h 1.771431 V 22 H 3.6 v -7.108612 h 1.771401 v 5.337217 z" />
+<path d="m 7.3267845,14.385359 8.6959295,1.817316 0.368168,-1.748385 -8.6959318,-1.817319 z m 1.1503197,-4.140944 8.0517968,3.749872 0.73617,-1.610385 -8.0518344,-3.7728517 z m 2.2315078,-3.9569154 6.832405,5.6822664 1.12738,-1.357316 -6.832576,-5.6822636 z m 4.417,-4.2099019 -1.426448,1.0581864 5.291191,7.1316119 1.426412,-1.0582745 z M 7.1427296,18.434189 h 8.8799844 v -1.7713 H 7.1427296 Z" />
+</symbol>
+<symbol id="icon-strava" viewBox="0 0 24 24">
+<path d="M15.387 17.944l-2.089-4.116h-3.065L15.387 24l5.15-10.172h-3.066m-7.008-5.599l2.836 5.598h4.172L10.463 0l-7 13.828h4.169"/>
+</symbol>
+<symbol id="icon-stumbleupon" viewBox="0 0 24 24">
+<path d="M12,4.294c-2.469,0-4.471,2.002-4.471,4.471v6.353c0,0.585-0.474,1.059-1.059,1.059c-0.585,0-1.059-0.474-1.059-1.059 v-2.824H2v2.941c0,2.469,2.002,4.471,4.471,4.471c2.469,0,4.471-2.002,4.471-4.471V8.765c0-0.585,0.474-1.059,1.059-1.059 s1.059,0.474,1.059,1.059v1.294l1.412,0.647l2-0.647V8.765C16.471,6.296,14.469,4.294,12,4.294z M13.059,12.353v2.882 c0,2.469,2.002,4.471,4.471,4.471S22,17.704,22,15.235v-2.824h-3.412v2.824c0,0.585-0.474,1.059-1.059,1.059 c-0.585,0-1.059-0.474-1.059-1.059v-2.882l-2,0.647L13.059,12.353z"/>
+</symbol>
+<symbol id="icon-threads" viewBox="0 0 24 24">
+<path d="M16.0671 11.1235C15.9632 11.0737 15.8583 11.0261 15.7524 10.9806C15.5671 7.56725 13.702 5.61312 10.5702 5.59312H10.5278C8.6545 5.59312 7.09663 6.39262 6.13775 7.84762L7.86012 9.02913C8.57637 7.94225 9.70062 7.71063 10.5286 7.71063H10.5573C11.5884 7.71725 12.3665 8.01713 12.8701 8.60175C13.2366 9.02738 13.4817 9.61562 13.6031 10.358C12.6889 10.2026 11.7001 10.1547 10.6431 10.2155C7.66562 10.3869 5.75138 12.1235 5.88 14.5365C5.94525 15.7605 6.555 16.8135 7.59688 17.5014C8.47775 18.0829 9.61238 18.3673 10.7915 18.3029C12.3488 18.2175 13.5704 17.6234 14.4226 16.537C15.0699 15.712 15.4792 14.6429 15.66 13.2957C16.4021 13.7436 16.9521 14.333 17.2559 15.0415C17.7724 16.2459 17.8025 18.225 16.1876 19.8385C14.7728 21.252 13.072 21.8635 10.5016 21.8824C7.6505 21.8613 5.49412 20.9469 4.09225 19.1646C2.7795 17.4958 2.101 15.0852 2.07562 12C2.101 8.91475 2.77937 6.50425 4.09225 4.83537C5.49425 3.05312 7.6505 2.13875 10.5016 2.1175C13.3735 2.13875 15.5674 3.0575 17.023 4.84837C17.7368 5.72662 18.2749 6.83087 18.6296 8.11862L20.648 7.58012C20.218 5.99512 19.5414 4.62937 18.6206 3.49662C16.7545 1.20088 14.0252 0.024375 10.5087 0H10.4946C6.98525 0.02425 4.2865 1.20525 2.4735 3.51C0.86025 5.56063 0.0280001 8.41437 0.000125051 11.9915L0 12V12.0084C0.028 15.5855 0.86025 18.4393 2.4735 20.4901C4.2865 22.7948 6.98525 23.9757 10.4946 24H10.5087C13.6287 23.9784 15.828 23.1615 17.6397 21.3514C20.0101 18.9833 19.9387 16.0149 19.1575 14.1926C18.597 12.8859 17.5284 11.8245 16.0671 11.1235ZM10.68 16.1884C9.375 16.2619 8.01925 15.6761 7.9525 14.4215C7.90288 13.4913 8.6145 12.4533 10.7601 12.3296C11.0059 12.3154 11.247 12.3085 11.4839 12.3085C12.2633 12.3085 12.9924 12.3843 13.6552 12.5291C13.408 15.6169 11.9578 16.1183 10.68 16.1884Z" />
+</symbol>
+<symbol id="icon-telegram" viewBox="0 0 24 24">
+<path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm3.08 14.757s-.25.625-.936.325l-2.541-1.949-1.63 1.486s-.127.096-.266.036c0 0-.12-.011-.27-.486-.15-.475-.911-2.972-.911-2.972L6 12.349s-.387-.137-.425-.438c-.037-.3.437-.462.437-.462l10.03-3.934s.824-.362.824.238l-1.786 9.004z"/>
+</symbol>
+<symbol id="icon-tiktok" viewBox="0 0 24 24">
+<path d="M12.22 2H15.64C15.64 2 15.4502 6.39351 20.3898 6.70186V10.0981C20.3898 10.0981 17.7537 10.2636 15.64 8.64957L15.6769 15.6615C15.6769 16.9151 15.3052 18.1406 14.6087 19.1829C13.9123 20.2253 12.9224 21.0377 11.7642 21.5175C10.606 21.9972 9.33162 22.1228 8.10209 21.8782C6.87257 21.6337 5.74316 21.0301 4.85669 20.1437C3.97022 19.2573 3.3665 18.1279 3.12186 16.8984C2.87723 15.6689 3.00267 14.3945 3.48233 13.2363C3.96199 12.0781 4.77432 11.0881 5.8166 10.3916C6.85888 9.69502 8.0843 9.32318 9.33791 9.32307H10.2271V12.7231V12.7954C9.64757 12.6147 9.02578 12.6217 8.45043 12.8152C7.87508 13.0088 7.37556 13.3792 7.02314 13.8734C6.67071 14.3677 6.48338 14.9606 6.48786 15.5677C6.49235 16.1747 6.68842 16.7648 7.04811 17.2538C7.40781 17.7428 7.91274 18.1057 8.49089 18.2908C9.06903 18.4758 9.69086 18.4736 10.2676 18.2843C10.8444 18.0951 11.3467 17.7285 11.7029 17.2369C12.059 16.7454 12.2508 16.1538 12.2509 15.5468L12.22 2Z"/>
+</symbol>
+<symbol id="icon-tumblr" viewBox="0 0 24 24">
+<path d="M16.749,17.396c-0.357,0.17-1.041,0.319-1.551,0.332c-1.539,0.041-1.837-1.081-1.85-1.896V9.847h3.861V6.937h-3.847V2.039 c0,0-2.77,0-2.817,0c-0.046,0-0.127,0.041-0.138,0.144c-0.165,1.499-0.867,4.13-3.783,5.181v2.484h1.945v6.282 c0,2.151,1.587,5.206,5.775,5.135c1.413-0.024,2.982-0.616,3.329-1.126L16.749,17.396z"/>
+</symbol>
+<symbol id="icon-twitch" viewBox="0 0 24 24">
+<path d="M16.499,8.089h-1.636v4.91h1.636V8.089z M12,8.089h-1.637v4.91H12V8.089z M4.228,3.178L3,6.451v13.092h4.499V22h2.456 l2.454-2.456h3.681L21,14.636V3.178H4.228z M19.364,13.816l-2.864,2.865H12l-2.453,2.453V16.68H5.863V4.814h13.501V13.816z"/>
+</symbol>
+<symbol id="icon-twitter" viewBox="0 0 24 24">
+<path d="M22.23,5.924c-0.736,0.326-1.527,0.547-2.357,0.646c0.847-0.508,1.498-1.312,1.804-2.27 c-0.793,0.47-1.671,0.812-2.606,0.996C18.324,4.498,17.257,4,16.077,4c-2.266,0-4.103,1.837-4.103,4.103 c0,0.322,0.036,0.635,0.106,0.935C8.67,8.867,5.647,7.234,3.623,4.751C3.27,5.357,3.067,6.062,3.067,6.814 c0,1.424,0.724,2.679,1.825,3.415c-0.673-0.021-1.305-0.206-1.859-0.513c0,0.017,0,0.034,0,0.052c0,1.988,1.414,3.647,3.292,4.023 c-0.344,0.094-0.707,0.144-1.081,0.144c-0.264,0-0.521-0.026-0.772-0.074c0.522,1.63,2.038,2.816,3.833,2.85 c-1.404,1.1-3.174,1.756-5.096,1.756c-0.331,0-0.658-0.019-0.979-0.057c1.816,1.164,3.973,1.843,6.29,1.843 c7.547,0,11.675-6.252,11.675-11.675c0-0.178-0.004-0.355-0.012-0.531C20.985,7.47,21.68,6.747,22.23,5.924z"/>
+</symbol>
+<symbol id="icon-vimeo" viewBox="0 0 24 24">
+<path d="M22.396,7.164c-0.093,2.026-1.507,4.799-4.245,8.32C15.322,19.161,12.928,21,10.97,21c-1.214,0-2.24-1.119-3.079-3.359 c-0.56-2.053-1.119-4.106-1.68-6.159C5.588,9.243,4.921,8.122,4.206,8.122c-0.156,0-0.701,0.328-1.634,0.98L1.594,7.841 c1.027-0.902,2.04-1.805,3.037-2.708C6.001,3.95,7.03,3.327,7.715,3.264c1.619-0.156,2.616,0.951,2.99,3.321 c0.404,2.557,0.685,4.147,0.841,4.769c0.467,2.121,0.981,3.181,1.542,3.181c0.435,0,1.09-0.688,1.963-2.065 c0.871-1.376,1.338-2.422,1.401-3.142c0.125-1.187-0.343-1.782-1.401-1.782c-0.498,0-1.012,0.115-1.541,0.341 c1.023-3.35,2.977-4.977,5.862-4.884C21.511,3.066,22.52,4.453,22.396,7.164z"/>
+</symbol>
+<symbol id="icon-vk" viewBox="0 0 24 24">
+<path d="M22,7.1c0.2,0.4-0.4,1.5-1.6,3.1c-0.2,0.2-0.4,0.5-0.7,0.9c-0.5,0.7-0.9,1.1-0.9,1.4c-0.1,0.3-0.1,0.6,0.1,0.8 c0.1,0.1,0.4,0.4,0.8,0.9h0l0,0c1,0.9,1.6,1.7,2,2.3c0,0,0,0.1,0.1,0.1c0,0.1,0,0.1,0.1,0.3c0,0.1,0,0.2,0,0.4 c0,0.1-0.1,0.2-0.3,0.3c-0.1,0.1-0.4,0.1-0.6,0.1l-2.7,0c-0.2,0-0.4,0-0.6-0.1c-0.2-0.1-0.4-0.1-0.5-0.2l-0.2-0.1 c-0.2-0.1-0.5-0.4-0.7-0.7s-0.5-0.6-0.7-0.8c-0.2-0.2-0.4-0.4-0.6-0.6C14.8,15,14.6,15,14.4,15c0,0,0,0-0.1,0c0,0-0.1,0.1-0.2,0.2 c-0.1,0.1-0.2,0.2-0.2,0.3c-0.1,0.1-0.1,0.3-0.2,0.5c-0.1,0.2-0.1,0.5-0.1,0.8c0,0.1,0,0.2,0,0.3c0,0.1-0.1,0.2-0.1,0.2l0,0.1 c-0.1,0.1-0.3,0.2-0.6,0.2h-1.2c-0.5,0-1,0-1.5-0.2c-0.5-0.1-1-0.3-1.4-0.6s-0.7-0.5-1.1-0.7s-0.6-0.4-0.7-0.6l-0.3-0.3 c-0.1-0.1-0.2-0.2-0.3-0.3s-0.4-0.5-0.7-0.9s-0.7-1-1.1-1.6c-0.4-0.6-0.8-1.3-1.3-2.2C2.9,9.4,2.5,8.5,2.1,7.5C2,7.4,2,7.3,2,7.2 c0-0.1,0-0.1,0-0.2l0-0.1c0.1-0.1,0.3-0.2,0.6-0.2l2.9,0c0.1,0,0.2,0,0.2,0.1S5.9,6.9,5.9,7L6,7c0.1,0.1,0.2,0.2,0.3,0.3 C6.4,7.7,6.5,8,6.7,8.4C6.9,8.8,7,9,7.1,9.2l0.2,0.3c0.2,0.4,0.4,0.8,0.6,1.1c0.2,0.3,0.4,0.5,0.5,0.7s0.3,0.3,0.4,0.4 c0.1,0.1,0.3,0.1,0.4,0.1c0.1,0,0.2,0,0.3-0.1c0,0,0,0,0.1-0.1c0,0,0.1-0.1,0.1-0.2c0.1-0.1,0.1-0.3,0.1-0.5c0-0.2,0.1-0.5,0.1-0.8 c0-0.4,0-0.8,0-1.3c0-0.3,0-0.5-0.1-0.8c0-0.2-0.1-0.4-0.1-0.5L9.6,7.6C9.4,7.3,9.1,7.2,8.7,7.1C8.6,7.1,8.6,7,8.7,6.9 C8.9,6.7,9,6.6,9.1,6.5c0.4-0.2,1.2-0.3,2.5-0.3c0.6,0,1,0.1,1.4,0.1c0.1,0,0.3,0.1,0.3,0.1c0.1,0.1,0.2,0.1,0.2,0.3 c0,0.1,0.1,0.2,0.1,0.3s0,0.3,0,0.5c0,0.2,0,0.4,0,0.6c0,0.2,0,0.4,0,0.7c0,0.3,0,0.6,0,0.9c0,0.1,0,0.2,0,0.4c0,0.2,0,0.4,0,0.5 c0,0.1,0,0.3,0,0.4s0.1,0.3,0.1,0.4c0.1,0.1,0.1,0.2,0.2,0.3c0.1,0,0.1,0,0.2,0c0.1,0,0.2,0,0.3-0.1c0.1-0.1,0.2-0.2,0.4-0.4 s0.3-0.4,0.5-0.7c0.2-0.3,0.5-0.7,0.7-1.1c0.4-0.7,0.8-1.5,1.1-2.3c0-0.1,0.1-0.1,0.1-0.2c0-0.1,0.1-0.1,0.1-0.1l0,0l0.1,0 c0,0,0,0,0.1,0s0.2,0,0.2,0l3,0c0.3,0,0.5,0,0.7,0S21.9,7,21.9,7L22,7.1z"/>
+</symbol>
+<symbol id="icon-whatsapp" viewBox="0 0 24 24">
+<path d="M2.048,22l1.406-5.136c-0.867-1.503-1.324-3.208-1.323-4.955C2.133,6.446,6.579,2,12.042,2c2.651,0.001,5.14,1.033,7.011,2.906c1.871,1.873,2.901,4.363,2.9,7.011c-0.002,5.464-4.448,9.91-9.91,9.91c0,0,0,0,0,0h-0.004c-1.659-0.001-3.288-0.417-4.736-1.206L2.048,22z M7.545,18.828l0.301,0.179c1.265,0.751,2.714,1.148,4.193,1.148h0.003c4.54,0,8.235-3.695,8.237-8.237c0.001-2.201-0.855-4.271-2.41-5.828c-1.555-1.557-3.623-2.415-5.824-2.416c-4.544,0-8.239,3.695-8.241,8.237c-0.001,1.556,0.435,3.072,1.259,4.384l0.196,0.312l-0.832,3.04L7.545,18.828z M17.035,14.274c-0.062-0.103-0.227-0.165-0.475-0.289c-0.248-0.124-1.465-0.723-1.692-0.806c-0.227-0.083-0.392-0.124-0.557,0.124c-0.165,0.248-0.64,0.806-0.784,0.971c-0.144,0.165-0.289,0.186-0.536,0.062c-0.248-0.124-1.046-0.385-1.991-1.229c-0.736-0.657-1.233-1.468-1.378-1.715c-0.144-0.248-0.015-0.382,0.109-0.505c0.111-0.111,0.248-0.289,0.371-0.434c0.124-0.145,0.165-0.248,0.248-0.413c0.083-0.165,0.041-0.31-0.021-0.434c-0.062-0.124-0.557-1.343-0.763-1.839C9.364,7.284,9.159,7.35,9.007,7.342c-0.144-0.007-0.31-0.009-0.475-0.009c-0.165,0-0.433,0.062-0.66,0.31C7.646,7.891,7.006,8.49,7.006,9.709c0,1.219,0.887,2.396,1.011,2.562c0.124,0.165,1.746,2.666,4.23,3.739c0.591,0.255,1.052,0.408,1.412,0.522c0.593,0.189,1.133,0.162,1.56,0.098c0.476-0.071,1.465-0.599,1.671-1.177C17.096,14.873,17.096,14.378,17.035,14.274z"/>
+</symbol>
+<symbol id="icon-woocommerce" viewBox="0 0 24 24">
+<path d="M19,2H5C3.3,2,2,3.3,2,5v11c0,1.7,1.3,3,3,3h4l6,3l-1-3h5c1.7,0,3-1.3,3-3V5C22,3.3,20.7,2,19,2z M17.4,6.5c-0.4,0.8-0.8,2.1-1,3.9c-0.3,1.8-0.4,3.1-0.3,4.1c0,0.3,0,0.5-0.1,0.7s-0.3,0.4-0.6,0.4s-0.6-0.1-0.9-0.4c-1-1-1.8-2.6-2.4-4.6c-0.7,1.4-1.2,2.4-1.6,3.1c-0.6,1.2-1.2,1.8-1.6,1.9c-0.3,0-0.5-0.2-0.8-0.7C7.6,13.5,7,10.7,6.4,6.7c0-0.3,0-0.5,0.2-0.7C6.7,5.8,7,5.7,7.3,5.6c0.5,0,0.9,0.2,0.9,0.8c0.3,2.3,0.7,4.2,1.1,5.7l2.4-4.5C11.9,7.2,12.1,7,12.5,7c0.5,0,0.8,0.3,0.9,0.9c0.3,1.4,0.6,2.6,1,3.7c0.3-2.7,0.8-4.7,1.4-5.9c0.2-0.3,0.4-0.5,0.7-0.5c0.2,0,0.5,0.1,0.7,0.2c0.2,0.2,0.3,0.4,0.3,0.6S17.5,6.4,17.4,6.5z"/>
+</symbol>
+<symbol id="icon-wordpress" viewBox="0 0 24 24">
+<path d="M12.158,12.786L9.46,20.625c0.806,0.237,1.657,0.366,2.54,0.366c1.047,0,2.051-0.181,2.986-0.51 c-0.024-0.038-0.046-0.079-0.065-0.124L12.158,12.786z M3.009,12c0,3.559,2.068,6.634,5.067,8.092L3.788,8.341 C3.289,9.459,3.009,10.696,3.009,12z M18.069,11.546c0-1.112-0.399-1.881-0.741-2.48c-0.456-0.741-0.883-1.368-0.883-2.109 c0-0.826,0.627-1.596,1.51-1.596c0.04,0,0.078,0.005,0.116,0.007C16.472,3.904,14.34,3.009,12,3.009 c-3.141,0-5.904,1.612-7.512,4.052c0.211,0.007,0.41,0.011,0.579,0.011c0.94,0,2.396-0.114,2.396-0.114 C7.947,6.93,8.004,7.642,7.52,7.699c0,0-0.487,0.057-1.029,0.085l3.274,9.739l1.968-5.901l-1.401-3.838 C9.848,7.756,9.389,7.699,9.389,7.699C8.904,7.67,8.961,6.93,9.446,6.958c0,0,1.484,0.114,2.368,0.114 c0.94,0,2.397-0.114,2.397-0.114c0.485-0.028,0.542,0.684,0.057,0.741c0,0-0.488,0.057-1.029,0.085l3.249,9.665l0.897-2.996 C17.841,13.284,18.069,12.316,18.069,11.546z M19.889,7.686c0.039,0.286,0.06,0.593,0.06,0.924c0,0.912-0.171,1.938-0.684,3.22 l-2.746,7.94c2.673-1.558,4.47-4.454,4.47-7.771C20.991,10.436,20.591,8.967,19.889,7.686z M12,22C6.486,22,2,17.514,2,12 C2,6.486,6.486,2,12,2c5.514,0,10,4.486,10,10C22,17.514,17.514,22,12,22z"/>
+</symbol>
+<symbol id="icon-yelp" viewBox="0 0 24 24">
+<path d="M12.271,16.718v1.417q-.011,3.257-.067,3.4a.707.707,0,0,1-.569.446,4.637,4.637,0,0,1-2.024-.424A4.609,4.609,0,0,1,7.8,20.565a.844.844,0,0,1-.19-.4.692.692,0,0,1,.044-.29,3.181,3.181,0,0,1,.379-.524q.335-.412,2.019-2.409.011,0,.669-.781a.757.757,0,0,1,.44-.274.965.965,0,0,1,.552.039.945.945,0,0,1,.418.324.732.732,0,0,1,.139.468Zm-1.662-2.8a.783.783,0,0,1-.58.781l-1.339.435q-3.067.981-3.257.981a.711.711,0,0,1-.6-.4,2.636,2.636,0,0,1-.19-.836,9.134,9.134,0,0,1,.011-1.857,3.559,3.559,0,0,1,.335-1.389.659.659,0,0,1,.625-.357,22.629,22.629,0,0,1,2.253.859q.781.324,1.283.524l.937.379a.771.771,0,0,1,.4.34A.982.982,0,0,1,10.609,13.917Zm9.213,3.313a4.467,4.467,0,0,1-1.021,1.8,4.559,4.559,0,0,1-1.512,1.417.671.671,0,0,1-.7-.078q-.156-.112-2.052-3.2l-.524-.859a.761.761,0,0,1-.128-.513.957.957,0,0,1,.217-.513.774.774,0,0,1,.926-.29q.011.011,1.327.446,2.264.736,2.7.887a2.082,2.082,0,0,1,.524.229.673.673,0,0,1,.245.68Zm-7.5-7.049q.056,1.137-.6,1.361-.647.19-1.272-.792L6.237,4.08a.7.7,0,0,1,.212-.691,5.788,5.788,0,0,1,2.314-1,5.928,5.928,0,0,1,2.5-.352.681.681,0,0,1,.547.5q.034.2.245,3.407T12.327,10.181Zm7.384,1.2a.679.679,0,0,1-.29.658q-.167.112-3.67.959-.747.167-1.015.257l.011-.022a.769.769,0,0,1-.513-.044.914.914,0,0,1-.413-.357.786.786,0,0,1,0-.971q.011-.011.836-1.137,1.394-1.908,1.673-2.275a2.423,2.423,0,0,1,.379-.435A.7.7,0,0,1,17.435,8a4.482,4.482,0,0,1,1.372,1.489,4.81,4.81,0,0,1,.9,1.868v.034Z"/>
+</symbol>
+<symbol id="icon-x" viewBox="0 0 24 24">
+<path d="M14.1173 9.62177L20.4459 2H18.9463L13.4511 8.61788L9.06215 2H4L10.637 12.0074L4 20H5.49977L11.3028 13.0113L15.9379 20H21L14.1169 9.62177H14.1173ZM12.0632 12.0956L11.3907 11.0991L6.04016 3.16971H8.34371L12.6617 9.56895L13.3341 10.5655L18.947 18.8835H16.6434L12.0632 12.096V12.0956Z"/>
+</symbol>
+<symbol id="icon-xanga" viewBox="0 0 24 24">
+<path d="M9,9h6v6H9V9z M3,9h6V3H3V9z M15,9h6V3h-6V9z M15,21h6v-6h-6V21z M3,21h6v-6H3V21z"/>
+</symbol>
+<symbol id="icon-youtube" viewBox="0 0 24 24">
+<path d="M21.8,8.001c0,0-0.195-1.378-0.795-1.985c-0.76-0.797-1.613-0.801-2.004-0.847c-2.799-0.202-6.997-0.202-6.997-0.202 h-0.009c0,0-4.198,0-6.997,0.202C4.608,5.216,3.756,5.22,2.995,6.016C2.395,6.623,2.2,8.001,2.2,8.001S2,9.62,2,11.238v1.517 c0,1.618,0.2,3.237,0.2,3.237s0.195,1.378,0.795,1.985c0.761,0.797,1.76,0.771,2.205,0.855c1.6,0.153,6.8,0.201,6.8,0.201 s4.203-0.006,7.001-0.209c0.391-0.047,1.243-0.051,2.004-0.847c0.6-0.607,0.795-1.985,0.795-1.985s0.2-1.618,0.2-3.237v-1.517 C22,9.62,21.8,8.001,21.8,8.001z M9.935,14.594l-0.001-5.62l5.404,2.82L9.935,14.594z"/>
+</symbol>
+</defs>
+</svg>
+
+</body>
+</html>
+<!--
+	generated in 1.252 seconds
+	162562 bytes batcached for 300 seconds
+-->

--- a/tests/test_cle_cpc.py
+++ b/tests/test_cle_cpc.py
@@ -1,0 +1,95 @@
+from datetime import datetime
+from os.path import dirname, join
+
+import pytest  # noqa
+from city_scrapers_core.constants import COMMISSION, TENTATIVE
+from city_scrapers_core.utils import file_response
+from freezegun import freeze_time
+
+from city_scrapers.spiders.cle_cpc import CleCpcSpider
+
+test_response = file_response(
+    join(dirname(__file__), "files", "cle_cpc.html"),
+    url="https://clecpc.org/get-involved/calendar/",
+)
+test_detail_response = file_response(
+    join(dirname(__file__), "files", "cle_cpc_detail.html"),
+    url="http://bc.cuyahogacounty.us/en-US/AuditCommitteeMtg-090519.aspx",
+)
+spider = CleCpcSpider()
+
+freezer = freeze_time("2024-01-29")
+freezer.start()
+
+parsed_items = [item for item in spider.parse(test_response)]
+parsed_item = next(spider._parse_detail(test_detail_response), None)
+
+freezer.stop()
+
+
+def test_count():
+    print(len(parsed_items))
+    print(parsed_items)
+    assert len(parsed_items) == 4
+
+
+def test_title():
+    assert parsed_item["title"] == "Police Discipline Work Group"
+
+
+def test_description():
+    assert (
+        parsed_item["description"][0:51]
+        == "Work Group to review the police disciplinary policy"
+    )
+
+
+def test_start():
+    assert parsed_item["start"] == datetime(2024, 2, 1, 18, 30)
+
+
+def test_end():
+    assert parsed_item["end"] == datetime(2024, 2, 1, 20, 30)
+
+
+def test_time_notes():
+    assert parsed_item["time_notes"] == ""
+
+
+def test_id():
+    assert parsed_item["id"] == "cle_cpc/202402011830/x/police_discipline_work_group"
+
+
+def test_status():
+    assert parsed_item["status"] == TENTATIVE
+
+
+def test_location():
+    assert parsed_item["location"] == {
+        "name": "CPC Offices",
+        "address": "3631 Perkins Ave., Cleveland 4th Fl",
+    }
+
+
+def test_source():
+    assert (
+        parsed_item["source"]
+        == "http://bc.cuyahogacounty.us/en-US/AuditCommitteeMtg-090519.aspx"
+    )
+
+
+def test_links():
+    assert parsed_item["links"] == [
+        {
+            "title": "Meeting agendas and minutes",
+            "href": "https://clecpc.org/resources/meeting-agendas-minutes/",
+        }
+    ]
+
+
+def test_classification():
+    assert parsed_item["classification"] == COMMISSION
+
+
+def test_all_day():
+    assert parsed_item["all_day"] is False


### PR DESCRIPTION
## What's this PR do?

Adds a spider for the Cleveland Police Commission (known as `cle_cpc`).

## Why are we doing this? 

Requested by City Bureau's partner site in Cleveland.

## Steps to manually test

After installing the project using `pipenv` (see Readme):

1. Activate the virtual environment:
```
pipenv shell
```
2. Run the spider:
```
scrapy crawl cle_cpc -O test_output.csv
```
3. Monitor the stdout and ensure that the crawl proceeds without raising any errors. Pay attention to the final status report from scrapy.

4. Inspect `test_output.csv` to ensure the data looks valid. I suggest opening a few of the URLs under the source column of test_output.csv and comparing the data for the row with what you see on the page.

## Are there any smells or added technical debt to note? 
**Common detail pages**
The [target website](https://clecpc.org/get-involved/calendar/) is pretty quirky. Meeting titles and meeting detail pages are shared across committees of the same type. For instance, at time of writing, all three "Police Discipline Group" events that are displayed link to the same detail page:

<img width="911" alt="image" src="https://github.com/City-Bureau/city-scrapers-cle/assets/37225902/31195f15-5a61-48d9-85e5-403887054a56">

The [detail page itself](https://clecpc.org/events/police-discipline-work-group/) contains largely generic meeting information and the meeting date refers to the next scheduled meeting.

<img width="1166" alt="image" src="https://github.com/City-Bureau/city-scrapers-cle/assets/37225902/3aaabf5a-38f9-4dbc-9a5a-83dcf254865d">

To account for these quirks, we simple scrape only the first unique committee meeting we come across on the calendar. The downside is that we're scraping fewer upcoming meetings but the upside is that we hopefully are scraping only information that relates to the next upcoming meeting and avoid generating confusing data.

**Common titles**
As a compounding quirk, each committee appears to share a common meeting title across all scheduled meetings on the calendar page. This creates a particularly confusing user experience if a committee adds a special note in its title. Note the two February "BEHAVIORAL HEALTH & CRISIS INTERVENTION WORK GROUP" meetings below where a note is noted regarding a cancelled January meeting that appears to no longer be relevant to the meetings themselves:

<img width="904" alt="image" src="https://github.com/City-Bureau/city-scrapers-cle/assets/37225902/87884d61-68bd-42be-acb0-d2d3010e8cb7">

To handle this, this spider overrides `CityScrapersSpider`'s _get_status method, which would otherwise classify both meetings as cancelled because they contain the word "cancelled". The downside is that we risk treating cancelled meetings as tentative meetings, but this seemed preferable to having scheduled meetings incorrectly classified as cancelled.