### PR TITLE
🕷️ Fix spider: Cleveland Metropolitan School District

### DIFF
--- a/city_scrapers/spiders/cle_metro_school_district.py
+++ b/city_scrapers/spiders/cle_metro_school_district.py
@@ -71,12 +71,14 @@ class CleMetroSchoolDistrictSpider(CityScrapersSpider):
 
     def _parse_location(self, item):
         """Parse or generate location."""
-        loc_item = (
-            item.xpath("./category[@order='1']/agendaitems/item/name/text()")
-            .extract_first()
-            .strip()
-        )
-        loc_str = re.sub(r"^\d{1,2}\.\d{1,2} ?", "", loc_item)
+        loc_item = item.xpath("./category[@order='1']/agendaitems/item/name/text()")
+        if not loc_item:
+            return {
+                "address": "",
+                "name": "TBD",
+            }
+        loc_raw_str = loc_item.extract_first().strip()
+        loc_str = re.sub(r"^\d{1,2}\.\d{1,2} ?", "", loc_raw_str)
         loc_parts = re.split(r", ?(?=\d{2})", loc_str, 1)
         if len(loc_parts) == 2:
             return {


### PR DESCRIPTION
## What's this PR do?

Fixes our Cleveland Metropolitan School District spider (aka. `cle_metro_school_district`), which appears to have broken because the target website added a ROBOTS.txt file. Additionally, our parsing of location information would hit errors on certain items.

## Why are we doing this? 

We want working scrapers, of course 🤖  The changes in this PR include the addition of a `custom_settings` class var to the spider and tweaks to the `_parse_location` method. 

## Steps to manually test

After installing the project using `pipenv` (see Readme):

1. Activate the virtual environment:
```
pipenv shell
```
2. Run the spider:
```
scrapy crawl cle_metro_school_district -O test_output.csv
```
3. Monitor the stdout and ensure that the crawl proceeds without raising any errors. Pay attention to the final status report from scrapy.

4. Inspect `test_output.csv` to ensure the data looks valid. I suggest opening a few of the URLs under the source column of test_output.csv and comparing the data for the row with what you see on the page.

## Are there any smells or added technical debt to note? 
- I don't love that we're ignoring ROBOTS.txt but we've done this elsewhere in city-scraper repos. I believe our rationale is that this is public information. Collecting and sharing this information is in the interest of both the agency and the community it serves.