### PR TITLE
🕷️ Fix spider: Cleveland Design Review Advisory Committees

### DIFF
--- a/city_scrapers/spiders/cle_design_review.py
+++ b/city_scrapers/spiders/cle_design_review.py
@@ -16,8 +16,7 @@ class CleDesignReviewSpider(CityScrapersSpider):
     start_urls = [
         "https://planning.clevelandohio.gov/designreview/schedule.php"  # noqa
     ]
-    description = "Due to Covid meetings are being held on WebEx rather than in person. For more information contact "  # noqa
-    calculated_description = "This is an upcoming meeting - please verify it with staff if you want attend. Due to Covid meetings are being held on WebEx rather than in person. For more information contact "  # noqa
+    description = "Cleveland Planning Commission conducts virtual meetings in a limited capacity using the WebEx Platform. To request access to WebEx meetings, email " # noqa
 
     def parse(self, response):
         """
@@ -130,7 +129,7 @@ class CleDesignReviewSpider(CityScrapersSpider):
                 start = self._parse_calculated_start(day, time_str)
                 meeting = Meeting(
                     title=title,
-                    description=self.calculated_description + email_contact,
+                    description=self.description + email_contact,
                     classification=ADVISORY_COMMITTEE,
                     start=start,
                     end=None,

--- a/city_scrapers/spiders/cle_design_review.py
+++ b/city_scrapers/spiders/cle_design_review.py
@@ -166,6 +166,7 @@ class CleDesignReviewSpider(CityScrapersSpider):
 
     def _parse_start(self, year_str, month_str, day_str, time_str):
         """Parse start datetime as a naive datetime object."""
+        print(year_str, month_str, day_str, time_str)
         date_str = " ".join([year_str, month_str, day_str, time_str])
         return datetime.strptime(date_str, "%Y %B %d %I:%M%p")
 
@@ -241,10 +242,11 @@ class CleDesignReviewSpider(CityScrapersSpider):
         return weekday, chosen_ordinals, is_downtown
 
     def _parse_weekday(self, weekday):
-        """Parses weekday strings as their integer equivalent"""
-        # we cut off the last char of weekday, because it comes through with
-        # an 's' i.e. 'Tuesdays'
-        return time.strptime(weekday[:-1], "%A").tm_wday
+        """Parses weekday strings as their integer equivalent.
+        Handles pluralization."""
+        if weekday.endswith("s"):
+            weekday = weekday[:-1]
+        return time.strptime(weekday, "%A").tm_wday
 
     def _parse_ordinal(self, ordinal_str):
         """Parses ordinals as their integer equivalent beginning from 0"""

--- a/city_scrapers/spiders/cle_design_review.py
+++ b/city_scrapers/spiders/cle_design_review.py
@@ -16,7 +16,7 @@ class CleDesignReviewSpider(CityScrapersSpider):
     start_urls = [
         "https://planning.clevelandohio.gov/designreview/schedule.php"  # noqa
     ]
-    description = "Cleveland Planning Commission conducts virtual meetings in a limited capacity using the WebEx Platform. To request access to WebEx meetings, email " # noqa
+    description = "Cleveland Planning Commission conducts virtual meetings in a limited capacity using the WebEx Platform. To request access to WebEx meetings, email "  # noqa
 
     def parse(self, response):
         """

--- a/tests/test_cle_design_review.py
+++ b/tests/test_cle_design_review.py
@@ -33,7 +33,7 @@ def test_title():
 def test_description():
     assert (
         parsed_items[0]["description"]
-        == "Due to Covid meetings are being held on WebEx rather than in person. For more information contact asantora@clevelandohio.gov"  # noqa
+        == CleDesignReviewSpider.description + "asantora@clevelandohio.gov"  # noqa
     )
 
 
@@ -102,7 +102,7 @@ def test_future_meeting_title():
 def test_future_meeting_description():
     assert (
         parsed_items[-1]["description"]
-        == "This is an upcoming meeting - please verify it with staff if you want attend. Due to Covid meetings are being held on WebEx rather than in person. For more information contact mfields@clevelandohio.gov"  # noqa
+        == CleDesignReviewSpider.description + "mfields@clevelandohio.gov"  # noqa
     )
 
 


### PR DESCRIPTION
## What's this PR do?

Fixes our Cleveland Design Review Advisory Committees spider (aka. `cle_design_review`). Also tweaks the `description` text for meetings.

## Why are we doing this?

We want working scrapers, of course 🤖  This spider was breaking because when it parsed datetime information from the page it expect weekdays (eg. `Thursday`) to always be pluralized. This adjusts the handling so it can handle pluralized or non-pluralized forms.

It also reworks the `description` for each meeting so it's simpler and less dated (no longer are we referencing covid).

## Steps to manually test

After installing the project using `pipenv`:

1. Activate the virtual environment:
```
pipenv shell
```
2. Run the spider:
```
scrapy crawl cle_design_review -O test_output.csv
```
3. Monitor the stdout and ensure that the crawl proceeds without raising any errors. Pay attention to the final status report from scrapy.

4. Inspect `test_output.csv` to ensure the data looks valid. I suggest opening a few of the URLs under the source column of test_output.csv and comparing the data for the row with what you see on the page.

## Are there any smells or added technical debt to note?
