### PR TITLE
🛠️ Fix: Tweak playwright config

### DIFF
--- a/city_scrapers/settings/base.py
+++ b/city_scrapers/settings/base.py
@@ -58,11 +58,3 @@ AUTOTHROTTLE_TARGET_CONCURRENCY = float(
 SPIDER_MIDDLEWARES = {}
 
 logging.getLogger("pdfminer").propagate = False
-
-# Playwright settings
-TWISTED_REACTOR = "twisted.internet.asyncioreactor.AsyncioSelectorReactor"
-DOWNLOAD_HANDLERS = {
-    "http": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",
-    "https": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",
-}
-PLAYWRIGHT_BROWSER_TYPE = "firefox"

--- a/city_scrapers/spiders/cuya_northeast_ohio_coordinating.py
+++ b/city_scrapers/spiders/cuya_northeast_ohio_coordinating.py
@@ -15,8 +15,15 @@ class CuyaNortheastOhioCoordinatingSpider(CityScrapersSpider):
         "https://www.noaca.org/board-committees/noaca-board-and-committees/agendas-and-presentations/-toggle-all",  # noqa
         "https://www.noaca.org/board-committees/noaca-board-and-committees/agendas-and-presentations/-toggle-all/-npage-2",  # noqa
     ]
-    # intended to avoid being block by bot detection
     custom_settings = {
+        # Playwright uses to help avoid bot detection
+        "TWISTED_REACTOR": "twisted.internet.asyncioreactor.AsyncioSelectorReactor",
+        "DOWNLOAD_HANDLERS": {
+            "http": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",
+            "https": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",
+        },
+        "PLAYWRIGHT_BROWSER_TYPE": "firefox",
+        # other scrapy settings to help avoid bot detection
         "DOWNLOAD_DELAY": 1,
         "ROBOTSTXT_OBEY": False,
         "USER_AGENT": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:88.0) Gecko/20100101 Firefox/88.0",  # noqa


### PR DESCRIPTION
## What's this PR do?

This PR tweaks #116 by removing the global configuration of playwright and instead applying it only to the spider that needs it (cuya_northeast_ohio_coordinating)

## Why are we doing this?

Enabling playwright middleware globally means that other spiders that don't need it initialize it by default. That makes them each run somewhat slower.

## Steps to manually test

n/a

## Are there any smells or added technical debt to note?

n/a
