### PR TITLE
[c] Upgrade keep-workflow to version 2

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -82,8 +82,14 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         if: ${{ failure() }}
 
+  keepalive-workflow:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: actions/checkout@v4
       - name: Prevent workflow deactivation
-        uses: gautamkrishnar/keepalive-workflow@v1
+        uses: gautamkrishnar/keepalive-workflow@v2
         with:
-          committer_username: "citybureau-bot"
-          committer_email: "documenters@citybureau.org"
+          auto_write_check: "true"
+          workflow_files: "archive.yml"


### PR DESCRIPTION
## What does this PR do? 
- Upgrade the [gautamkrishnar/keepalive-workflow](https://github.com/gautamkrishnar/keepalive-workflow) to [version 2](https://github.com/gautamkrishnar/keepalive-workflow/tree/v2). In this version, they use Github API to keep the workflow active after 45 days instead of pushing a dummy commit. 
- Separate the keepalive workflow and crawl workflow for better sercurity.
- Implements keepalive mechanism for `cron.yml` and `archive.yml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow configuration to use the latest keepalive workflow version.
	- Simplified workflow parameters for better maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->